### PR TITLE
Implement cairo stroke styles

### DIFF
--- a/piet-cairo/examples/basic-cairo.rs
+++ b/piet-cairo/examples/basic-cairo.rs
@@ -41,5 +41,7 @@ fn main() {
     let mut piet_context = CairoRenderContext::new(&mut cr);
     draw_pretty_picture(&mut piet_context);
     let mut file = File::create("temp-cairo.png").expect("Couldn't create 'file.png'");
-    surface.write_to_png(&mut file).expect("Error writing image file");
+    surface
+        .write_to_png(&mut file)
+        .expect("Error writing image file");
 }

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -1,6 +1,6 @@
 //! The Cairo backend for the Piet 2D graphics abstraction.
 
-use cairo::Context;
+use cairo::{Context, LineCap, LineJoin};
 
 use kurbo::{PathEl, QuadBez, Vec2};
 
@@ -22,9 +22,42 @@ pub enum Brush {
     Solid(u32),
 }
 
-pub enum StrokeStyle {
-    // TODO: actual stroke style options
-    Default,
+pub struct StrokeStyle {
+    line_join: Option<LineJoin>,
+    line_cap: Option<LineCap>,
+    dash: Option<(Vec<f64>, f64)>,
+    miter_limit: Option<f64>,
+}
+
+impl StrokeStyle {
+    pub fn new() -> StrokeStyle {
+        StrokeStyle {
+            line_join: None,
+            line_cap: None,
+            dash: None,
+            miter_limit: None,
+        }
+    }
+
+    pub fn line_join(mut self, line_join: LineJoin) -> Self {
+        self.line_join = Some(line_join);
+        self
+    }
+
+    pub fn line_cap(mut self, line_cap: LineCap) -> Self {
+        self.line_cap = Some(line_cap);
+        self
+    }
+
+    pub fn dash(mut self, dashes: Vec<f64>, offset: f64) -> Self {
+        self.dash = Some((dashes, offset));
+        self
+    }
+
+    pub fn miter_limit(mut self, miter_limit: f64) -> Self {
+        self.miter_limit = Some(miter_limit);
+        self
+    }
 }
 
 impl<'a> RenderContext for CairoRenderContext<'a> {
@@ -35,7 +68,11 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     type StrokeStyle = StrokeStyle;
 
     fn clear(&mut self, rgb: u32) {
-        self.ctx.set_source_rgb(byte_to_frac(rgb >> 16), byte_to_frac(rgb >> 8), byte_to_frac(rgb));
+        self.ctx.set_source_rgb(
+            byte_to_frac(rgb >> 16),
+            byte_to_frac(rgb >> 8),
+            byte_to_frac(rgb),
+        );
         self.ctx.paint();
     }
 
@@ -51,6 +88,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         width: C,
         style: Option<&Self::StrokeStyle>,
     ) {
+        self.ctx.save();
         self.ctx.new_path();
         let p0 = p0.round_into();
         let p1 = p1.round_into();
@@ -59,6 +97,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.set_stroke(width.round_into(), style);
         self.set_brush(brush);
         self.ctx.stroke();
+        self.ctx.restore();
     }
 
     fn fill_path<I: IntoIterator<Item = PathEl>>(&mut self, iter: I, brush: &Self::Brush) {
@@ -88,9 +127,12 @@ impl<'a> CairoRenderContext<'a> {
     /// This is part of the impedance matching.
     fn set_brush(&mut self, brush: &Brush) {
         match *brush {
-            Brush::Solid(rgba) =>
-                self.ctx.set_source_rgba(byte_to_frac(rgba >> 24), byte_to_frac(rgba >> 16),
-                    byte_to_frac(rgba >> 8), byte_to_frac(rgba))
+            Brush::Solid(rgba) => self.ctx.set_source_rgba(
+                byte_to_frac(rgba >> 24),
+                byte_to_frac(rgba >> 16),
+                byte_to_frac(rgba >> 8),
+                byte_to_frac(rgba),
+            ),
         }
     }
 
@@ -98,9 +140,17 @@ impl<'a> CairoRenderContext<'a> {
     fn set_stroke(&mut self, width: f64, style: Option<&StrokeStyle>) {
         self.ctx.set_line_width(width);
         if let Some(style) = style {
-            match style {
-                // TODO: actual stroke style parameters
-                StrokeStyle::Default => (),
+            if let Some(line_join) = style.line_join {
+                self.ctx.set_line_join(line_join);
+            }
+            if let Some(line_cap) = style.line_cap {
+                self.ctx.set_line_cap(line_cap);
+            }
+            if let Some((dashes, offset)) = &style.dash {
+                self.ctx.set_dash(&dashes, *offset);
+            }
+            if let Some(miter_limit) = style.miter_limit {
+                self.ctx.set_miter_limit(miter_limit);
             }
         }
     }
@@ -123,7 +173,8 @@ impl<'a> CairoRenderContext<'a> {
                 PathEl::Quadto(p1, p2) => {
                     let q = QuadBez::new(last, p1, p2);
                     let c = q.raise();
-                    self.ctx.curve_to(c.p1.x, c.p1.y, c.p2.x, c.p2.y, p2.x, p2.y);
+                    self.ctx
+                        .curve_to(c.p1.x, c.p1.y, c.p2.x, c.p2.y, p2.x, p2.y);
                     last = p2;
                 }
                 PathEl::Curveto(p1, p2, p3) => {


### PR DESCRIPTION
These aren't really usable yet as there is no way to get a `StrokeStyle` from the piet `RenderContext` generically yet.

I also had to add a context save/restore so that stroke styles for one path do not affect the styles of another.