### PR TITLE
Use wasm-bindgen instead of stdweb

### DIFF
--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -12,4 +12,8 @@ categories = ["rendering::graphics-api", "wasm"]
 kurbo = "0.1.2"
 piet = { path = "../piet" }
 
-stdweb = "0.4.12"
+wasm-bindgen = "0.2.29"
+
+[dependencies.web-sys]
+version = "0.3.6"
+features = ["CanvasRenderingContext2d", "CanvasWindingRule"]

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -1,6 +1,7 @@
 //! The Web Canvas backend for the Piet 2D graphics abstraction.
 
-use stdweb::web::{CanvasRenderingContext2d, FillRule};
+use wasm_bindgen::JsValue;
+use web_sys::{CanvasRenderingContext2d, CanvasWindingRule};
 
 use kurbo::{PathEl, Shape, Vec2};
 
@@ -25,15 +26,15 @@ pub enum StrokeStyle {
     Default,
 }
 
-fn convert_fill_rule(fill_rule: piet::FillRule) -> FillRule {
+fn convert_fill_rule(fill_rule: piet::FillRule) -> CanvasWindingRule {
     match fill_rule {
-        piet::FillRule::NonZero => FillRule::NonZero,
-        piet::FillRule::EvenOdd => FillRule::EvenOdd,
+        piet::FillRule::NonZero => CanvasWindingRule::Nonzero,
+        piet::FillRule::EvenOdd => CanvasWindingRule::Evenodd,
     }
 }
 
 impl<'a> RenderContext for WebRenderContext<'a> {
-    /// stdweb doesn't have a native Point type, so use kurbo's.
+    /// wasm-bindgen doesn't have a native Point type, so use kurbo's.
     type Point = Vec2;
     type Coord = f64;
     type Brush = Brush;
@@ -47,15 +48,11 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         Brush::Solid(rgba)
     }
 
-    fn fill(
-        &mut self,
-        shape: &impl Shape,
-        brush: &Self::Brush,
-        fill_rule: piet::FillRule,
-    ) {
+    fn fill(&mut self, shape: &impl Shape, brush: &Self::Brush, fill_rule: piet::FillRule) {
         self.set_path(shape);
         self.set_brush(brush, true);
-        self.ctx.fill(convert_fill_rule(fill_rule));
+        self.ctx
+            .fill_with_canvas_winding_rule(convert_fill_rule(fill_rule));
     }
 
     fn stroke(
@@ -94,9 +91,9 @@ impl<'a> WebRenderContext<'a> {
                     )
                 };
                 if is_fill {
-                    self.ctx.set_fill_style_color(&color_str);
+                    self.ctx.set_fill_style(&JsValue::from_str(&color_str));
                 } else {
-                    self.ctx.set_stroke_style_color(&color_str);
+                    self.ctx.set_stroke_style(&JsValue::from_str(&color_str));
                 }
             }
         }


### PR DESCRIPTION
This is still a work in progress, but I wanted to see what you thought...

stdweb is fairly heavy handed. wasm-bindgen and the related web-sys crate provide the bare minimum for integrating Rust in a JavaScript and browser environment. These are the crates that the Rust Wasm working group is focused on. There is an [issue](https://github.com/rustwasm/team/issues/226) calrifying the differences. The stdweb maintainer hints at interest in eventually having stdweb be built on top of wasm-bindgen.  

The changes are fairly minimal, but it should set the project on a path of being as minimal as possible. The downside to this approach is that it makes the example a bit more involved to run since `cargo web` does not currently work with wasm-bindgen.

If you're interested in this approach I will get the example running. 