### PR TITLE
Add clip, transform, save/restore methods

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = "0.1.2"
+kurbo = {path = "/Users/raphl/github/kurbo"}
 piet = { path = "../piet" }
 
 [dependencies.cairo-rs]

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = {path = "/Users/raphl/github/kurbo"}
+kurbo = "0.2.0"
 piet = { path = "../piet" }
 
 [dependencies.cairo-rs]

--- a/piet-cairo/examples/basic-cairo.rs
+++ b/piet-cairo/examples/basic-cairo.rs
@@ -2,7 +2,7 @@
 
 use std::fs::File;
 
-use kurbo::{BezPath, Line};
+use kurbo::{Affine, BezPath, Line, Vec2};
 
 use cairo::{Context, Format, ImageSurface};
 
@@ -13,6 +13,23 @@ const TEXTURE_WIDTH: i32 = 400;
 const TEXTURE_HEIGHT: i32 = 200;
 
 const HIDPI: f64 = 2.0;
+
+// Note: this could be a Shape.
+fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
+    let mut result = BezPath::new();
+    let d_th = std::f64::consts::PI / (n as f64);
+    for i in 0..n {
+        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
+        if i == 0 {
+            result.moveto(outer_pt);
+        } else {
+            result.lineto(outer_pt);
+        }
+        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
+    }
+    result.closepath();
+    result
+}
 
 fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
     rc.clear(0xFF_FF_FF);
@@ -43,6 +60,16 @@ fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
         1.0,
         None,
     );
+
+    rc.save();
+    rc.transform(Affine::rotate(0.1));
+    rc.draw_text(&layout, (80.0, 10.0), &brush);
+    rc.restore();
+
+    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
+    rc.clip(&clip_path, FillRule::NonZero);
+    let layout = rc.new_text_layout(&font, "Clipped text").build();
+    rc.draw_text(&layout, (80.0, 50.0), &brush);
 }
 
 fn main() {

--- a/piet-cairo/examples/basic-cairo.rs
+++ b/piet-cairo/examples/basic-cairo.rs
@@ -79,6 +79,7 @@ fn main() {
     cr.scale(HIDPI, HIDPI);
     let mut piet_context = CairoRenderContext::new(&mut cr);
     draw_pretty_picture(&mut piet_context);
+    piet_context.finish();
     let mut file = File::create("temp-cairo.png").expect("Couldn't create 'file.png'");
     surface
         .write_to_png(&mut file)

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -180,8 +180,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.ctx.restore();
     }
 
-    fn finish(&mut self) {
-    }
+    fn finish(&mut self) {}
 
     fn transform(&mut self, transform: Affine) {
         self.ctx.transform(affine_to_matrix(transform));

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -4,7 +4,7 @@ use cairo::{
     Context, FontFace, FontOptions, FontSlant, FontWeight, LineCap, LineJoin, Matrix, ScaledFont,
 };
 
-use kurbo::{PathEl, QuadBez, Shape, Vec2};
+use kurbo::{Affine, PathEl, QuadBez, Shape, Vec2};
 
 use piet::{FillRule, Font, FontBuilder, RenderContext, RoundInto, TextLayout, TextLayoutBuilder};
 
@@ -119,6 +119,12 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.ctx.fill();
     }
 
+    fn clip(&mut self, shape: &impl Shape, fill_rule: FillRule) {
+        self.set_path(shape);
+        self.ctx.set_fill_rule(convert_fill_rule(fill_rule));
+        self.ctx.clip();
+    }
+
     fn stroke(
         &mut self,
         shape: &impl Shape,
@@ -164,6 +170,21 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         let pos = pos.round_into();
         self.ctx.move_to(pos.x, pos.y);
         self.ctx.show_text(&layout.text);
+    }
+
+    fn save(&mut self) {
+        self.ctx.save();
+    }
+
+    fn restore(&mut self) {
+        self.ctx.restore();
+    }
+
+    fn finish(&mut self) {
+    }
+
+    fn transform(&mut self, transform: Affine) {
+        self.ctx.transform(affine_to_matrix(transform));
     }
 }
 
@@ -240,6 +261,19 @@ impl<'a> CairoRenderContext<'a> {
 
 fn byte_to_frac(byte: u32) -> f64 {
     ((byte & 255) as f64) * (1.0 / 255.0)
+}
+
+/// Can't implement RoundFrom here because both types belong to other crates.
+fn affine_to_matrix(affine: Affine) -> Matrix {
+    let a = affine.as_coeffs();
+    Matrix {
+        xx: a[0],
+        yx: a[1],
+        xy: a[2],
+        yy: a[3],
+        x0: a[4],
+        y0: a[5],
+    }
 }
 
 fn scale_matrix(scale: f64) -> Matrix {

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = {path = "/Users/raphl/github/kurbo"}
+kurbo = "0.2.0"
 piet = { path = "../piet" }
 
 direct2d = "0.2.0"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = "0.1.2"
+kurbo = {path = "/Users/raphl/github/kurbo"}
 piet = { path = "../piet" }
 
 direct2d = "0.2.0"

--- a/piet-direct2d/examples/basic.rs
+++ b/piet-direct2d/examples/basic.rs
@@ -69,10 +69,10 @@ fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
         None,
     );
 
-    rc.save();
-    rc.transform(Affine::rotate(0.1));
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-    rc.restore();
+    rc.with_save(|rc| {
+        rc.transform(Affine::rotate(0.1));
+        rc.draw_text(&layout, (80.0, 10.0), &brush);
+    });
 
     let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
     rc.clip(&clip_path, FillRule::NonZero);

--- a/piet-direct2d/examples/basic.rs
+++ b/piet-direct2d/examples/basic.rs
@@ -9,7 +9,7 @@ use direct3d11::flags::{BindFlags, CreateDeviceFlags};
 use direct3d11::helpers::ComWrapper;
 use dxgi::flags::Format;
 
-use kurbo::{BezPath, Line};
+use kurbo::{Affine, BezPath, Line, Vec2};
 
 use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
 use piet_direct2d::D2DRenderContext;
@@ -21,6 +21,23 @@ const TEXTURE_WIDTH_S: usize = TEXTURE_WIDTH as usize;
 const TEXTURE_HEIGHT_S: usize = TEXTURE_HEIGHT as usize;
 
 const HIDPI: f32 = 2.0;
+
+// Note: this could be a Shape.
+fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
+    let mut result = BezPath::new();
+    let d_th = std::f64::consts::PI / (n as f64);
+    for i in 0..n {
+        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
+        if i == 0 {
+            result.moveto(outer_pt);
+        } else {
+            result.lineto(outer_pt);
+        }
+        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
+    }
+    result.closepath();
+    result
+}
 
 fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
     rc.clear(0xFF_FF_FF);
@@ -51,6 +68,16 @@ fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
         1.0,
         None,
     );
+
+    rc.save();
+    rc.transform(Affine::rotate(0.1));
+    rc.draw_text(&layout, (80.0, 10.0), &brush);
+    rc.restore();
+
+    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
+    rc.clip(&clip_path, FillRule::NonZero);
+    let layout = rc.new_text_layout(&font, "Clipped text").build();
+    rc.draw_text(&layout, (80.0, 50.0), &brush);
 }
 
 fn main() {
@@ -89,6 +116,7 @@ fn main() {
     context.begin_draw();
     let mut piet_context = D2DRenderContext::new(&d2d, &dwrite, &mut context);
     draw_pretty_picture(&mut piet_context);
+    piet_context.finish();
     context.end_draw().unwrap();
 
     let temp_texture = direct3d11::texture2d::Texture2D::create(&d3d)

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-kurbo = {path = "/Users/raphl/github/kurbo"}
+kurbo = "0.2.0"
 piet = { path = "../piet" }
 
 wasm-bindgen = "0.2.30"

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-kurbo = "0.1.2"
+kurbo = {path = "/Users/raphl/github/kurbo"}
 piet = { path = "../piet" }
 
 wasm-bindgen = "0.2.30"

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 piet = { path = "../../../piet" }
 piet-web = { path = "../.." }
 wasm-bindgen = "0.2.30"
-kurbo = {path = "/Users/raphl/github/kurbo"}
+kurbo = "0.2.0"
 
 [dependencies.web-sys]
 version = "0.3.6"

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 piet = { path = "../../../piet" }
 piet-web = { path = "../.." }
 wasm-bindgen = "0.2.30"
-kurbo = "0.1.2"
+kurbo = {path = "/Users/raphl/github/kurbo"}
 
 [dependencies.web-sys]
 version = "0.3.6"

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -1,6 +1,6 @@
 //! Basic example of rendering on Cairo.
 
-use kurbo::{BezPath, Line};
+use kurbo::{Affine, BezPath, Line, Vec2};
 
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -8,6 +8,23 @@ use web_sys::{window, HtmlCanvasElement};
 
 use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
 use piet_web::WebRenderContext;
+
+// Note: this could be a Shape.
+fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
+    let mut result = BezPath::new();
+    let d_th = std::f64::consts::PI / (n as f64);
+    for i in 0..n {
+        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
+        if i == 0 {
+            result.moveto(outer_pt);
+        } else {
+            result.lineto(outer_pt);
+        }
+        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
+    }
+    result.closepath();
+    result
+}
 
 fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
     rc.clear(0xFF_FF_FF);
@@ -38,6 +55,16 @@ fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
         1.0,
         None,
     );
+
+    rc.save();
+    rc.transform(Affine::rotate(0.1));
+    rc.draw_text(&layout, (80.0, 10.0), &brush);
+    rc.restore();
+
+    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
+    rc.clip(&clip_path, FillRule::NonZero);
+    let layout = rc.new_text_layout(&font, "Clipped text").build();
+    rc.draw_text(&layout, (80.0, 50.0), &brush);
 }
 
 #[wasm_bindgen]

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -91,4 +91,5 @@ pub fn run() {
 
     let mut piet_context = WebRenderContext::new(&mut context);
     draw_pretty_picture(&mut piet_context);
+    piet_context.finish();
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use wasm_bindgen::JsValue;
 use web_sys::{CanvasRenderingContext2d, CanvasWindingRule};
 
-use kurbo::{PathEl, Shape, Vec2};
+use kurbo::{Affine, PathEl, Shape, Vec2};
 
 use piet::{Font, FontBuilder, RenderContext, RoundInto, TextLayout, TextLayoutBuilder};
 

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -93,6 +93,12 @@ impl<'a> RenderContext for WebRenderContext<'a> {
             .fill_with_canvas_winding_rule(convert_fill_rule(fill_rule));
     }
 
+    fn clip(&mut self, shape: &impl Shape, fill_rule: piet::FillRule) {
+        self.set_path(shape);
+        self.ctx
+            .clip_with_canvas_winding_rule(convert_fill_rule(fill_rule));
+    }
+
     fn stroke(
         &mut self,
         shape: &impl Shape,
@@ -141,6 +147,21 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         let pos = pos.round_into();
         // TODO: should we be tracking errors, or just ignoring them?
         let _ = self.ctx.fill_text(&layout.text, pos.x, pos.y);
+    }
+
+    fn save(&mut self) {
+        self.ctx.save();
+    }
+
+    fn restore(&mut self) {
+        self.ctx.restore();
+    }
+
+    fn finish(&mut self) {}
+
+    fn transform(&mut self, transform: Affine) {
+        let a = transform.as_coeffs();
+        let _ = self.ctx.transform(a[0], a[1], a[2], a[3], a[4], a[5]);
     }
 }
 

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -9,4 +9,4 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = "0.1.2"
+kurbo = {path = "/Users/raphl/github/kurbo"}

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -9,4 +9,4 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = {path = "/Users/raphl/github/kurbo"}
+kurbo = "0.2.0"

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -108,6 +108,9 @@ pub trait RenderContext {
     /// Pushes the current context state onto a stack, to be popped by
     /// [`restore`](#method.restore).
     ///
+    /// Prefer [`with_save`](#method.with_save) if possible, as that statically
+    /// enforces balance of save/restore pairs.
+    ///
     /// The context state currently consists of a clip region and an affine
     /// transform, but is expected to grow in the near future.
     fn save(&mut self);
@@ -117,6 +120,16 @@ pub trait RenderContext {
     /// Pop a context state that was pushed by [`save`](#method.save). See
     /// that method for details.
     fn restore(&mut self);
+
+    /// Do graphics operations with the context state saved and then restored.
+    ///
+    /// Equivalent to [`save`](#method.save), calling `f`, then
+    /// [`restore`](#method.restore). See those methods for more details.
+    fn with_save(&mut self, f: impl FnOnce(&mut Self)) {
+        self.save();
+        f(self);
+        self.restore();
+    }
 
     /// Finish any pending operations.
     ///

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -82,7 +82,7 @@ pub trait RenderContext {
     ///
     /// All subsequent drawing operations up to the next [`restore`](#method.restore)
     /// are clipped by the shape.
-    fn clip(&mut self, shape: &impl Shape, fill_rule: FillRule) {}
+    fn clip(&mut self, shape: &impl Shape, fill_rule: FillRule);
 
     fn new_font_by_name(
         &mut self,
@@ -110,24 +110,24 @@ pub trait RenderContext {
     ///
     /// The context state currently consists of a clip region and an affine
     /// transform, but is expected to grow in the near future.
-    fn save(&mut self) {}
+    fn save(&mut self);
 
     /// Restore the context state.
     ///
     /// Pop a context state that was pushed by [`save`](#method.save). See
     /// that method for details.
-    fn restore(&mut self) {}
+    fn restore(&mut self);
 
     /// Finish any pending operations.
     ///
     /// This will generally be called by a shell after all user drawing
     /// operations but before presenting. Not all back-ends will handle this
     /// the same way.
-    fn finish(&mut self) {}
+    fn finish(&mut self);
 
     /// Apply a transform.
     ///
     /// Apply an affine transformation. The transformation remains in effect
     /// until a [`restore`](#method.restore) operation.
-    fn transform(&mut self, transform: Affine) {}
+    fn transform(&mut self, transform: Affine);
 }


### PR DESCRIPTION
This patch adds several fundamental methods to RenderContext and implementations to the three back-ends: clip, save/restore, and transform.