### PR TITLE
Refine Shape ownership; refactor test pictures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "piet",
     "piet-cairo",
     "piet-direct2d",
+    "piet-test",
     "piet-web",
     "piet-web/examples/basic"
 ]

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -17,6 +17,9 @@ version = "0.5.0"
 # We don't need glib
 default-features = false
 
+[dev-dependencies]
+piet-test = { path = "../piet-test" }
+
 [dev-dependencies.cairo-rs]
 version = "0.5.0"
 features = ["png"]

--- a/piet-cairo/examples/basic-cairo.rs
+++ b/piet-cairo/examples/basic-cairo.rs
@@ -2,83 +2,29 @@
 
 use std::fs::File;
 
-use kurbo::{Affine, BezPath, Line, Vec2};
-
 use cairo::{Context, Format, ImageSurface};
 
-use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
+use piet::RenderContext;
 use piet_cairo::CairoRenderContext;
+
+use piet_test::draw_test_picture;
 
 const TEXTURE_WIDTH: i32 = 400;
 const TEXTURE_HEIGHT: i32 = 200;
 
 const HIDPI: f64 = 2.0;
 
-// Note: this could be a Shape.
-fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
-    let mut result = BezPath::new();
-    let d_th = std::f64::consts::PI / (n as f64);
-    for i in 0..n {
-        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
-        if i == 0 {
-            result.moveto(outer_pt);
-        } else {
-            result.lineto(outer_pt);
-        }
-        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
-    }
-    result.closepath();
-    result
-}
-
-fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
-    rc.clear(0xFF_FF_FF);
-    let brush = rc.solid_brush(0x00_00_80_FF);
-    rc.stroke(&Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None);
-
-    let mut path = BezPath::new();
-    path.moveto((50.0, 10.0));
-    path.quadto((60.0, 50.0), (100.0, 90.0));
-    let brush = rc.solid_brush(0x00_80_00_FF);
-    rc.stroke(&path, &brush, 1.0, None);
-
-    let mut path = BezPath::new();
-    path.moveto((10.0, 20.0));
-    path.curveto((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
-    let brush = rc.solid_brush(0x00_00_80_C0);
-    rc.fill(&path, &brush, FillRule::NonZero);
-
-    let font = rc.new_font_by_name("Segoe UI", 12.0).build();
-    let layout = rc.new_text_layout(&font, "Hello piet-cairo!").build();
-    let w: f64 = layout.width().into();
-    let brush = rc.solid_brush(0x80_00_00_C0);
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-
-    rc.stroke(
-        &Line::new((80.0, 12.0), (80.0 + w, 12.0)),
-        &brush,
-        1.0,
-        None,
-    );
-
-    rc.save();
-    rc.transform(Affine::rotate(0.1));
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-    rc.restore();
-
-    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
-    rc.clip(&clip_path, FillRule::NonZero);
-    let layout = rc.new_text_layout(&font, "Clipped text").build();
-    rc.draw_text(&layout, (80.0, 50.0), &brush);
-}
 
 fn main() {
+    // TODO: make selectable
+    let test_picture_number = 0;
+
     let surface = ImageSurface::create(Format::ARgb32, TEXTURE_WIDTH, TEXTURE_HEIGHT)
         .expect("Can't create surface");
     let mut cr = Context::new(&surface);
     cr.scale(HIDPI, HIDPI);
     let mut piet_context = CairoRenderContext::new(&mut cr);
-    draw_pretty_picture(&mut piet_context);
+    draw_test_picture(&mut piet_context, test_picture_number);
     piet_context.finish();
     let mut file = File::create("temp-cairo.png").expect("Couldn't create 'file.png'");
     surface

--- a/piet-cairo/examples/basic-cairo.rs
+++ b/piet-cairo/examples/basic-cairo.rs
@@ -14,7 +14,6 @@ const TEXTURE_HEIGHT: i32 = 200;
 
 const HIDPI: f64 = 2.0;
 
-
 fn main() {
     // TODO: make selectable
     let test_picture_number = 0;

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -112,14 +112,14 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         Brush::Solid(rgba)
     }
 
-    fn fill(&mut self, shape: &impl Shape, brush: &Self::Brush, fill_rule: FillRule) {
+    fn fill(&mut self, shape: impl Shape, brush: &Self::Brush, fill_rule: FillRule) {
         self.set_path(shape);
         self.set_brush(brush);
         self.ctx.set_fill_rule(convert_fill_rule(fill_rule));
         self.ctx.fill();
     }
 
-    fn clip(&mut self, shape: &impl Shape, fill_rule: FillRule) {
+    fn clip(&mut self, shape: impl Shape, fill_rule: FillRule) {
         self.set_path(shape);
         self.ctx.set_fill_rule(convert_fill_rule(fill_rule));
         self.ctx.clip();
@@ -127,7 +127,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
 
     fn stroke(
         &mut self,
-        shape: &impl Shape,
+        shape: impl Shape,
         brush: &Self::Brush,
         width: impl RoundInto<Self::Coord>,
         style: Option<&Self::StrokeStyle>,
@@ -226,7 +226,7 @@ impl<'a> CairoRenderContext<'a> {
         }
     }
 
-    fn set_path(&mut self, shape: &impl Shape) {
+    fn set_path(&mut self, shape: impl Shape) {
         // This shouldn't be necessary, we always leave the context in no-path
         // state. But just in case, and it should be harmless.
         self.ctx.new_path();

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -19,3 +19,4 @@ directwrite = "0.1.4"
 direct3d11 = "0.1.7"
 dxgi = "0.1.7"
 image = "0.20.1"
+piet-test = { path = "../piet-test" }

--- a/piet-direct2d/examples/basic.rs
+++ b/piet-direct2d/examples/basic.rs
@@ -9,10 +9,10 @@ use direct3d11::flags::{BindFlags, CreateDeviceFlags};
 use direct3d11::helpers::ComWrapper;
 use dxgi::flags::Format;
 
-use kurbo::{Affine, BezPath, Line, Vec2};
-
-use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
+use piet::RenderContext;
 use piet_direct2d::D2DRenderContext;
+
+use piet_test::draw_test_picture;
 
 const TEXTURE_WIDTH: u32 = 400;
 const TEXTURE_HEIGHT: u32 = 200;
@@ -22,65 +22,10 @@ const TEXTURE_HEIGHT_S: usize = TEXTURE_HEIGHT as usize;
 
 const HIDPI: f32 = 2.0;
 
-// Note: this could be a Shape.
-fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
-    let mut result = BezPath::new();
-    let d_th = std::f64::consts::PI / (n as f64);
-    for i in 0..n {
-        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
-        if i == 0 {
-            result.moveto(outer_pt);
-        } else {
-            result.lineto(outer_pt);
-        }
-        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
-    }
-    result.closepath();
-    result
-}
-
-fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
-    rc.clear(0xFF_FF_FF);
-    let brush = rc.solid_brush(0x00_00_80_FF);
-    rc.stroke(&Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None);
-
-    let mut path = BezPath::new();
-    path.moveto((50.0, 10.0));
-    path.quadto((60.0, 50.0), (100.0, 90.0));
-    let brush = rc.solid_brush(0x00_80_00_FF);
-    rc.stroke(&path, &brush, 1.0, None);
-
-    let mut path = BezPath::new();
-    path.moveto((10.0, 20.0));
-    path.curveto((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
-    let brush = rc.solid_brush(0x00_00_80_C0);
-    rc.fill(&path, &brush, FillRule::NonZero);
-
-    let font = rc.new_font_by_name("Segoe UI", 12.0).build();
-    let layout = rc.new_text_layout(&font, "Hello piet!").build();
-    let w: f64 = layout.width().into();
-    let brush = rc.solid_brush(0x80_00_00_C0);
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-
-    rc.stroke(
-        &Line::new((80.0, 12.0), (80.0 + w, 12.0)),
-        &brush,
-        1.0,
-        None,
-    );
-
-    rc.save();
-    rc.transform(Affine::rotate(0.1));
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-    rc.restore();
-
-    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
-    rc.clip(&clip_path, FillRule::NonZero);
-    let layout = rc.new_text_layout(&font, "Clipped text").build();
-    rc.draw_text(&layout, (80.0, 50.0), &brush);
-}
-
 fn main() {
+    // TODO: make selectable
+    let test_picture_number = 0;
+
     // Create the D2D factory
     let d2d = direct2d::factory::Factory::new().unwrap();
     let dwrite = directwrite::factory::Factory::new().unwrap();
@@ -115,7 +60,7 @@ fn main() {
     context.set_dpi(96.0 * HIDPI, 96.0 * HIDPI);
     context.begin_draw();
     let mut piet_context = D2DRenderContext::new(&d2d, &dwrite, &mut context);
-    draw_pretty_picture(&mut piet_context);
+    draw_test_picture(&mut piet_context, test_picture_number);
     piet_context.finish();
     context.end_draw().unwrap();
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -160,7 +160,7 @@ fn to_point2f<P: RoundInto<Point2>>(p: P) -> Point2F {
 fn path_from_shape(
     d2d: &direct2d::Factory,
     is_filled: bool,
-    shape: &impl Shape,
+    shape: impl Shape,
     fill_rule: FillRule,
 ) -> Path {
     let mut path = Path::create(d2d).unwrap();
@@ -245,7 +245,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             .to_generic() // This does an extra COM clone; avoid somehow?
     }
 
-    fn fill(&mut self, shape: &impl Shape, brush: &Self::Brush, fill_rule: FillRule) {
+    fn fill(&mut self, shape: impl Shape, brush: &Self::Brush, fill_rule: FillRule) {
         // TODO: various special-case shapes, for efficiency
         let path = path_from_shape(self.factory, true, shape, fill_rule);
         self.rt.fill_geometry(&path, brush);
@@ -253,7 +253,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
 
     fn stroke(
         &mut self,
-        shape: &impl Shape,
+        shape: impl Shape,
         brush: &Self::Brush,
         width: impl RoundInto<Self::Coord>,
         style: Option<&Self::StrokeStyle>,
@@ -264,7 +264,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             .draw_geometry(&path, brush, width.round_into(), style);
     }
 
-    fn clip(&mut self, shape: &impl Shape, fill_rule: FillRule) {
+    fn clip(&mut self, shape: impl Shape, fill_rule: FillRule) {
         // TODO: set size based on bbox of shape.
         if let Ok(layer) = Layer::create(&mut self.rt, None) {
             let path = path_from_shape(self.factory, true, shape, fill_rule);

--- a/piet-test/Cargo.toml
+++ b/piet-test/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "piet-test"
+version = "0.1.0"
+authors = ["Raph Levien <raph.levien@gmail.com>"]
+description = "Utilities for testing the piet 2D graphics abstraction."
+license = "MIT/Apache-2.0"
+edition = "2018"
+keywords = ["graphics", "2d"]
+
+[dependencies]
+kurbo = "0.2.0"
+piet = { path = "../piet" }

--- a/piet-test/src/lib.rs
+++ b/piet-test/src/lib.rs
@@ -46,12 +46,7 @@ fn draw_picture_0(rc: &mut impl RenderContext) {
     let brush = rc.solid_brush(0x80_00_00_C0);
     rc.draw_text(&layout, (80.0, 10.0), &brush);
 
-    rc.stroke(
-        Line::new((80.0, 12.0), (80.0 + w, 12.0)),
-        &brush,
-        1.0,
-        None,
-    );
+    rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &brush, 1.0, None);
 
     rc.save();
     rc.transform(Affine::rotate(0.1));
@@ -70,6 +65,9 @@ fn draw_picture_0(rc: &mut impl RenderContext) {
 pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) {
     match number {
         0 => draw_picture_0(rc),
-        _ => eprintln!("Don't have test picture {} yet. Why don't you make it?", number),
+        _ => eprintln!(
+            "Don't have test picture {} yet. Why don't you make it?",
+            number
+        ),
     }
 }

--- a/piet-test/src/lib.rs
+++ b/piet-test/src/lib.rs
@@ -1,0 +1,75 @@
+//! Test code for piet.
+
+// Right now, this is just code to generate sample images.
+
+use kurbo::{Affine, BezPath, Line, Vec2};
+
+use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
+
+// Note: this could be a Shape.
+fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
+    let mut result = BezPath::new();
+    let d_th = std::f64::consts::PI / (n as f64);
+    for i in 0..n {
+        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
+        if i == 0 {
+            result.moveto(outer_pt);
+        } else {
+            result.lineto(outer_pt);
+        }
+        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
+    }
+    result.closepath();
+    result
+}
+
+fn draw_picture_0(rc: &mut impl RenderContext) {
+    rc.clear(0xFF_FF_FF);
+    let brush = rc.solid_brush(0x00_00_80_FF);
+    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None);
+
+    let mut path = BezPath::new();
+    path.moveto((50.0, 10.0));
+    path.quadto((60.0, 50.0), (100.0, 90.0));
+    let brush = rc.solid_brush(0x00_80_00_FF);
+    rc.stroke(path, &brush, 1.0, None);
+
+    let mut path = BezPath::new();
+    path.moveto((10.0, 20.0));
+    path.curveto((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
+    let brush = rc.solid_brush(0x00_00_80_C0);
+    rc.fill(path, &brush, FillRule::NonZero);
+
+    let font = rc.new_font_by_name("Segoe UI", 12.0).build();
+    let layout = rc.new_text_layout(&font, "Hello piet!").build();
+    let w: f64 = layout.width().into();
+    let brush = rc.solid_brush(0x80_00_00_C0);
+    rc.draw_text(&layout, (80.0, 10.0), &brush);
+
+    rc.stroke(
+        Line::new((80.0, 12.0), (80.0 + w, 12.0)),
+        &brush,
+        1.0,
+        None,
+    );
+
+    rc.save();
+    rc.transform(Affine::rotate(0.1));
+    rc.draw_text(&layout, (80.0, 10.0), &brush);
+    rc.restore();
+
+    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
+    rc.clip(clip_path, FillRule::NonZero);
+    let layout = rc.new_text_layout(&font, "Clipped text").build();
+    rc.draw_text(&layout, (80.0, 50.0), &brush);
+}
+
+/// Draw a test picture, by number.
+///
+/// Hopefully there will be a suite of test pictures. For now, there is just the one.
+pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) {
+    match number {
+        0 => draw_picture_0(rc),
+        _ => eprintln!("Don't have test picture {} yet. Why don't you make it?", number),
+    }
+}

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 piet = { path = "../../../piet" }
 piet-web = { path = "../.." }
+piet-test = { path = "../../../piet-test" }
 wasm-bindgen = "0.2.30"
 kurbo = "0.2.0"
 

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -1,71 +1,13 @@
 //! Basic example of rendering on Cairo.
 
-use kurbo::{Affine, BezPath, Line, Vec2};
-
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlCanvasElement};
 
-use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
+use piet::RenderContext;
 use piet_web::WebRenderContext;
 
-// Note: this could be a Shape.
-fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
-    let mut result = BezPath::new();
-    let d_th = std::f64::consts::PI / (n as f64);
-    for i in 0..n {
-        let outer_pt = center + outer * Vec2::from_angle(d_th * ((i * 2) as f64));
-        if i == 0 {
-            result.moveto(outer_pt);
-        } else {
-            result.lineto(outer_pt);
-        }
-        result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
-    }
-    result.closepath();
-    result
-}
-
-fn draw_pretty_picture<R: RenderContext>(rc: &mut R) {
-    rc.clear(0xFF_FF_FF);
-    let brush = rc.solid_brush(0x00_00_80_FF);
-    rc.stroke(&Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None);
-
-    let mut path = BezPath::new();
-    path.moveto((50.0, 10.0));
-    path.quadto((60.0, 50.0), (100.0, 90.0));
-    let brush = rc.solid_brush(0x00_80_00_FF);
-    rc.stroke(&path, &brush, 1.0, None);
-
-    let mut path = BezPath::new();
-    path.moveto((10.0, 20.0));
-    path.curveto((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
-    let brush = rc.solid_brush(0x00_00_80_C0);
-    rc.fill(&path, &brush, FillRule::NonZero);
-
-    let font = rc.new_font_by_name("Segoe UI", 12.0).build();
-    let layout = rc.new_text_layout(&font, "Hello piet-web!").build();
-    let w: f64 = layout.width().into();
-    let brush = rc.solid_brush(0x80_00_00_C0);
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-
-    rc.stroke(
-        &Line::new((80.0, 12.0), (80.0 + w, 12.0)),
-        &brush,
-        1.0,
-        None,
-    );
-
-    rc.save();
-    rc.transform(Affine::rotate(0.1));
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
-    rc.restore();
-
-    let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
-    rc.clip(&clip_path, FillRule::NonZero);
-    let layout = rc.new_text_layout(&font, "Clipped text").build();
-    rc.draw_text(&layout, (80.0, 50.0), &brush);
-}
+use piet_test::draw_test_picture;
 
 #[wasm_bindgen]
 pub fn run() {
@@ -90,6 +32,6 @@ pub fn run() {
     let _ = context.scale(dpr, dpr);
 
     let mut piet_context = WebRenderContext::new(&mut context);
-    draw_pretty_picture(&mut piet_context);
+    draw_test_picture(&mut piet_context, 0);
     piet_context.finish();
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -86,14 +86,14 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         Brush::Solid(rgba)
     }
 
-    fn fill(&mut self, shape: &impl Shape, brush: &Self::Brush, fill_rule: piet::FillRule) {
+    fn fill(&mut self, shape: impl Shape, brush: &Self::Brush, fill_rule: piet::FillRule) {
         self.set_path(shape);
         self.set_brush(brush, true);
         self.ctx
             .fill_with_canvas_winding_rule(convert_fill_rule(fill_rule));
     }
 
-    fn clip(&mut self, shape: &impl Shape, fill_rule: piet::FillRule) {
+    fn clip(&mut self, shape: impl Shape, fill_rule: piet::FillRule) {
         self.set_path(shape);
         self.ctx
             .clip_with_canvas_winding_rule(convert_fill_rule(fill_rule));
@@ -101,7 +101,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
 
     fn stroke(
         &mut self,
-        shape: &impl Shape,
+        shape: impl Shape,
         brush: &Self::Brush,
         width: impl RoundInto<Self::Coord>,
         style: Option<&Self::StrokeStyle>,
@@ -206,7 +206,7 @@ impl<'a> WebRenderContext<'a> {
         }
     }
 
-    fn set_path(&mut self, shape: &impl Shape) {
+    fn set_path(&mut self, shape: impl Shape) {
         // This shouldn't be necessary, we always leave the context in no-path
         // state. But just in case, and it should be harmless.
         self.ctx.begin_path();

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -66,7 +66,7 @@ pub trait RenderContext {
     /// Stroke a shape.
     fn stroke(
         &mut self,
-        shape: &impl Shape,
+        shape: impl Shape,
         brush: &Self::Brush,
         width: impl RoundInto<Self::Coord>,
         style: Option<&Self::StrokeStyle>,
@@ -76,13 +76,13 @@ pub trait RenderContext {
 
     // TODO: switch last two argument order to be more similar to clip? Maybe we
     // should have a convention, geometry first.
-    fn fill(&mut self, shape: &impl Shape, brush: &Self::Brush, fill_rule: FillRule);
+    fn fill(&mut self, shape: impl Shape, brush: &Self::Brush, fill_rule: FillRule);
 
     /// Clip to a shape.
     ///
     /// All subsequent drawing operations up to the next [`restore`](#method.restore)
     /// are clipped by the shape.
-    fn clip(&mut self, shape: &impl Shape, fill_rule: FillRule);
+    fn clip(&mut self, shape: impl Shape, fill_rule: FillRule);
 
     fn new_font_by_name(
         &mut self,


### PR DESCRIPTION
Allow both owned and borrowed Shape parameters, following changes in kurbo.

Reduce duplication of test picture code by putting it in a separate crate. Over time, it is expected that crate will grow test and benchmark functionality, in addition to just being a repository of pictures.

Partially addresses #17
