### PR TITLE
Add images

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -1,12 +1,16 @@
 //! The Cairo backend for the Piet 2D graphics abstraction.
 
 use cairo::{
-    Context, FontFace, FontOptions, FontSlant, FontWeight, LineCap, LineJoin, Matrix, ScaledFont,
+    Context, Filter, FontFace, FontOptions, FontSlant, FontWeight, Format, ImageSurface, LineCap,
+    LineJoin, Matrix, Pattern, PatternTrait, ScaledFont, SurfacePattern,
 };
 
-use kurbo::{Affine, PathEl, QuadBez, Shape, Vec2};
+use kurbo::{Affine, PathEl, QuadBez, Rect, Shape, Vec2};
 
-use piet::{FillRule, Font, FontBuilder, RenderContext, RoundInto, TextLayout, TextLayoutBuilder};
+use piet::{
+    FillRule, Font, FontBuilder, InterpolationMode, RenderContext, RoundInto, TextLayout,
+    TextLayoutBuilder,
+};
 
 pub struct CairoRenderContext<'a> {
     // Cairo has this as Clone and with &self methods, but we do this to avoid
@@ -99,6 +103,8 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     type TextLayout = CairoTextLayout;
     type TextLayoutBuilder = CairoTextLayoutBuilder;
 
+    type Image = ImageSurface;
+
     fn clear(&mut self, rgb: u32) {
         self.ctx.set_source_rgb(
             byte_to_frac(rgb >> 16),
@@ -184,6 +190,55 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
 
     fn transform(&mut self, transform: Affine) {
         self.ctx.transform(affine_to_matrix(transform));
+    }
+
+    fn make_rgba_image(&mut self, width: usize, height: usize, buf: &[u8]) -> Self::Image {
+        let mut image = ImageSurface::create(Format::ARgb32, width as i32, height as i32).unwrap();
+        // Confident no borrow errors because we just created it.
+        let bytes_per_pixel = 4; // RGBA
+        let bytes_per_row = width * bytes_per_pixel;
+        let stride = image.get_stride() as usize;
+        {
+            let mut data = image.get_data().unwrap();
+            for y in 0..height {
+                let src_off = y * bytes_per_row;
+                let dst_off = y * stride;
+                // It's annoying that Cairo exposes only ARGB. Ah well. Let's hope that
+                // LLVM generates pretty good code for this.
+                for x in 0..width {
+                    data[dst_off + x * 4 + 0] = buf[src_off + x * 4 + 2];
+                    data[dst_off + x * 4 + 1] = buf[src_off + x * 4 + 1];
+                    data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
+                    data[dst_off + x * 4 + 3] = buf[src_off + x * 4 + 3];
+                }
+            }
+        }
+        image
+    }
+
+    fn draw_image(
+        &mut self,
+        image: &Self::Image,
+        rect: impl Into<Rect>,
+        interp: InterpolationMode,
+    ) {
+        self.ctx.save();
+        let surface_pattern = SurfacePattern::create(image);
+        let filter = match interp {
+            InterpolationMode::NearestNeighbor => Filter::Nearest,
+            InterpolationMode::Bilinear => Filter::Bilinear,
+        };
+        surface_pattern.set_filter(filter);
+        let rect = rect.into();
+        self.ctx.translate(rect.x0, rect.y0);
+        self.ctx.scale(
+            rect.width() / (image.get_width() as f64),
+            rect.height() / (image.get_height() as f64),
+        );
+        self.ctx
+            .set_source(&Pattern::SurfacePattern(surface_pattern));
+        self.ctx.paint();
+        self.ctx.restore();
     }
 }
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -259,23 +259,22 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         rect: impl Into<Rect>,
         interp: InterpolationMode,
     ) {
-        self.ctx.save();
-        let surface_pattern = SurfacePattern::create(image);
-        let filter = match interp {
-            InterpolationMode::NearestNeighbor => Filter::Nearest,
-            InterpolationMode::Bilinear => Filter::Bilinear,
-        };
-        surface_pattern.set_filter(filter);
-        let rect = rect.into();
-        self.ctx.translate(rect.x0, rect.y0);
-        self.ctx.scale(
-            rect.width() / (image.get_width() as f64),
-            rect.height() / (image.get_height() as f64),
-        );
-        self.ctx
-            .set_source(&Pattern::SurfacePattern(surface_pattern));
-        self.ctx.paint();
-        self.ctx.restore();
+        self.with_save(|rc| {
+            let surface_pattern = SurfacePattern::create(image);
+            let filter = match interp {
+                InterpolationMode::NearestNeighbor => Filter::Nearest,
+                InterpolationMode::Bilinear => Filter::Bilinear,
+            };
+            surface_pattern.set_filter(filter);
+            let rect = rect.into();
+            rc.ctx.translate(rect.x0, rect.y0);
+            rc.ctx.scale(
+                rect.width() / (image.get_width() as f64),
+                rect.height() / (image.get_height() as f64),
+            );
+            rc.ctx.set_source(&Pattern::SurfacePattern(surface_pattern));
+            rc.ctx.paint();
+        })
     }
 }
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -8,8 +8,8 @@ use cairo::{
 use kurbo::{Affine, PathEl, QuadBez, Rect, Shape, Vec2};
 
 use piet::{
-    FillRule, Font, FontBuilder, InterpolationMode, RenderContext, RoundInto, TextLayout,
-    TextLayoutBuilder,
+    FillRule, Font, FontBuilder, ImageFormat, InterpolationMode, RenderContext, RoundInto,
+    TextLayout, TextLayoutBuilder,
 };
 
 pub struct CairoRenderContext<'a> {
@@ -192,10 +192,21 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.ctx.transform(affine_to_matrix(transform));
     }
 
-    fn make_rgba_image(&mut self, width: usize, height: usize, buf: &[u8]) -> Self::Image {
-        let mut image = ImageSurface::create(Format::ARgb32, width as i32, height as i32).unwrap();
+    fn make_image(
+        &mut self,
+        width: usize,
+        height: usize,
+        buf: &[u8],
+        format: ImageFormat,
+    ) -> Self::Image {
+        let cairo_fmt = match format {
+            ImageFormat::Rgb => Format::Rgb24,
+            ImageFormat::RgbaSeparate | ImageFormat::RgbaPremul => Format::ARgb32,
+            _ => panic!(),
+        };
+        let mut image = ImageSurface::create(cairo_fmt, width as i32, height as i32).unwrap();
         // Confident no borrow errors because we just created it.
-        let bytes_per_pixel = 4; // RGBA
+        let bytes_per_pixel = format.bytes_per_pixel();
         let bytes_per_row = width * bytes_per_pixel;
         let stride = image.get_stride() as usize;
         {
@@ -203,13 +214,39 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
             for y in 0..height {
                 let src_off = y * bytes_per_row;
                 let dst_off = y * stride;
-                // It's annoying that Cairo exposes only ARGB. Ah well. Let's hope that
-                // LLVM generates pretty good code for this.
-                for x in 0..width {
-                    data[dst_off + x * 4 + 0] = buf[src_off + x * 4 + 2];
-                    data[dst_off + x * 4 + 1] = buf[src_off + x * 4 + 1];
-                    data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
-                    data[dst_off + x * 4 + 3] = buf[src_off + x * 4 + 3];
+                match format {
+                    ImageFormat::Rgb => {
+                        for x in 0..width {
+                            data[dst_off + x * 4 + 0] = buf[src_off + x * 3 + 2];
+                            data[dst_off + x * 4 + 1] = buf[src_off + x * 3 + 1];
+                            data[dst_off + x * 4 + 2] = buf[src_off + x * 3 + 0];
+                        }
+                    }
+                    ImageFormat::RgbaPremul => {
+                        // It's annoying that Cairo exposes only ARGB. Ah well. Let's
+                        // hope that LLVM generates pretty good code for this.
+                        // TODO: consider adding BgraPremul format.
+                        for x in 0..width {
+                            data[dst_off + x * 4 + 0] = buf[src_off + x * 4 + 2];
+                            data[dst_off + x * 4 + 1] = buf[src_off + x * 4 + 1];
+                            data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
+                            data[dst_off + x * 4 + 3] = buf[src_off + x * 4 + 3];
+                        }
+                    }
+                    ImageFormat::RgbaSeparate => {
+                        fn premul(x: u8, a: u8) -> u8 {
+                            let y = (x as u16) * (a as u16);
+                            ((y + (y >> 8) + 0x80) >> 8) as u8
+                        }
+                        for x in 0..width {
+                            let a = buf[src_off + x * 4 + 3];
+                            data[dst_off + x * 4 + 0] = premul(buf[src_off + x * 4 + 2], a);
+                            data[dst_off + x * 4 + 1] = premul(buf[src_off + x * 4 + 1], a);
+                            data[dst_off + x * 4 + 2] = premul(buf[src_off + x * 4 + 0], a);
+                            data[dst_off + x * 4 + 3] = a;
+                        }
+                    }
+                    _ => panic!(),
                 }
             }
         }

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -14,9 +14,10 @@ piet = { path = "../piet" }
 
 direct2d = "0.2.0"
 directwrite = "0.1.4"
+dxgi = "0.1.7"
+winapi = "0.3.6"
 
 [dev-dependencies]
 direct3d11 = "0.1.7"
-dxgi = "0.1.7"
 image = "0.20.1"
 piet-test = { path = "../piet-test" }

--- a/piet-test/src/lib.rs
+++ b/piet-test/src/lib.rs
@@ -5,17 +5,21 @@
 use piet::RenderContext;
 mod picture_0;
 mod picture_1;
+mod picture_2;
 
 use crate::picture_0::draw as draw_picture_0;
 use crate::picture_1::draw as draw_picture_1;
+use crate::picture_2::draw as draw_picture_2;
 
 /// Draw a test picture, by number.
 ///
-/// Hopefully there will be a suite of test pictures. For now, there is just the one.
+/// There are a few test pictures here now, and hopefully it will grow into
+/// a full suite, suitable for both benchmarking and correctness testing.
 pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) {
     match number {
         0 => draw_picture_0(rc),
         1 => draw_picture_1(rc),
+        2 => draw_picture_2(rc),
         _ => eprintln!(
             "Don't have test picture {} yet. Why don't you make it?",
             number

--- a/piet-test/src/lib.rs
+++ b/piet-test/src/lib.rs
@@ -4,7 +4,9 @@
 
 use kurbo::{Affine, BezPath, Line, Vec2};
 
-use piet::{FillRule, FontBuilder, RenderContext, TextLayout, TextLayoutBuilder};
+use piet::{
+    FillRule, FontBuilder, InterpolationMode, RenderContext, TextLayout, TextLayoutBuilder,
+};
 
 // Note: this could be a Shape.
 fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
@@ -20,6 +22,20 @@ fn star(center: Vec2, inner: f64, outer: f64, n: usize) -> BezPath {
         result.lineto(center + inner * Vec2::from_angle(d_th * ((i * 2 + 1) as f64)));
     }
     result.closepath();
+    result
+}
+
+fn make_image_data(width: usize, height: usize) -> Vec<u8> {
+    let mut result = vec![0; width * height * 4];
+    for y in 0..height {
+        for x in 0..width {
+            let ix = (y * width + x) * 4;
+            result[ix + 0] = x as u8;
+            result[ix + 1] = y as u8;
+            result[ix + 2] = !(x as u8);
+            result[ix + 3] = 255;
+        }
+    }
     result
 }
 
@@ -52,6 +68,14 @@ fn draw_picture_0(rc: &mut impl RenderContext) {
     rc.transform(Affine::rotate(0.1));
     rc.draw_text(&layout, (80.0, 10.0), &brush);
     rc.restore();
+
+    let image_data = make_image_data(256, 256);
+    let image = rc.make_rgba_image(256, 256, &image_data);
+    rc.draw_image(
+        &image,
+        ((150.0, 50.0), (180.0, 80.0)),
+        InterpolationMode::Bilinear,
+    );
 
     let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
     rc.clip(clip_path, FillRule::NonZero);

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -3,7 +3,8 @@
 use kurbo::{Affine, BezPath, Line, Vec2};
 
 use piet::{
-    FillRule, FontBuilder, InterpolationMode, RenderContext, TextLayout, TextLayoutBuilder,
+    FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext, TextLayout,
+    TextLayoutBuilder,
 };
 
 pub fn draw(rc: &mut impl RenderContext) {
@@ -37,7 +38,7 @@ pub fn draw(rc: &mut impl RenderContext) {
     });
 
     let image_data = make_image_data(256, 256);
-    let image = rc.make_rgba_image(256, 256, &image_data);
+    let image = rc.make_image(256, 256, &image_data, ImageFormat::RgbaSeparate);
     rc.draw_image(
         &image,
         ((150.0, 50.0), (180.0, 80.0)),
@@ -75,7 +76,7 @@ fn make_image_data(width: usize, height: usize) -> Vec<u8> {
             result[ix + 0] = x as u8;
             result[ix + 1] = y as u8;
             result[ix + 2] = !(x as u8);
-            result[ix + 3] = 255;
+            result[ix + 3] = 127;
         }
     }
     result

--- a/piet-test/src/picture_2.rs
+++ b/piet-test/src/picture_2.rs
@@ -1,0 +1,66 @@
+//! A bunch of image test cases.
+
+use piet::{ImageFormat, InterpolationMode, RenderContext};
+
+pub fn draw(rc: &mut impl RenderContext) {
+    rc.clear(0xFF_FF_FF);
+
+    let mut y = 5.0;
+    for &mode in &[
+        InterpolationMode::NearestNeighbor,
+        InterpolationMode::Bilinear,
+    ] {
+        let mut x = 5.0;
+        for &format in &[
+            ImageFormat::RgbaSeparate,
+            ImageFormat::RgbaPremul,
+            ImageFormat::Rgb,
+        ] {
+            let image_data = make_image_data(16, 16, format);
+            let image = rc.make_image(16, 16, &image_data, format);
+            rc.draw_image(&image, ((x, y), (x + 40.0, y + 40.0)), mode);
+            x += 50.0;
+        }
+        y += 50.0;
+    }
+}
+
+fn make_image_data(width: usize, height: usize, format: ImageFormat) -> Vec<u8> {
+    let bytes_per_pixel = format.bytes_per_pixel();
+    let mut result = vec![0; width * height * bytes_per_pixel];
+    for y in 0..height {
+        for x in 0..width {
+            let ix = (y * width + x) * bytes_per_pixel;
+            let r = (x * 255 / (width - 1)) as u8;
+            let g = (y * 255 / (height - 1)) as u8;
+            let b = !r;
+            let r2 = ((x as f64) - 8.0).powi(2) + ((y as f64) - 8.0).powi(2);
+            let a = (255.0 * (-0.01 * r2).exp()) as u8;
+            match format {
+                ImageFormat::RgbaSeparate => {
+                    result[ix + 0] = r;
+                    result[ix + 1] = g;
+                    result[ix + 2] = b;
+                    result[ix + 3] = a;
+                }
+                ImageFormat::RgbaPremul => {
+                    fn premul(x: u8, a: u8) -> u8 {
+                        let y = (x as u16) * (a as u16);
+                        ((y + (y >> 8) + 0x80) >> 8) as u8
+                    }
+                    result[ix + 0] = premul(r, a);
+                    result[ix + 1] = premul(g, a);
+                    result[ix + 2] = premul(b, a);
+                    result[ix + 3] = a;
+                }
+                ImageFormat::Rgb => {
+                    result[ix + 0] = r;
+                    result[ix + 1] = g;
+                    result[ix + 2] = b;
+                }
+                _ => (),
+            }
+        }
+    }
+    result
+}

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -19,5 +19,5 @@ wasm-bindgen = "0.2.30"
 
 [dependencies.web-sys]
 version = "0.3.6"
-features = ["CanvasRenderingContext2d", "CanvasWindingRule", "ImageBitmap", "ImageData",
-    "TextMetrics"]
+features = ["CanvasRenderingContext2d", "CanvasWindingRule", "Document", "Element",
+    "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -19,4 +19,5 @@ wasm-bindgen = "0.2.30"
 
 [dependencies.web-sys]
 version = "0.3.6"
-features = ["CanvasRenderingContext2d", "CanvasWindingRule", "TextMetrics"]
+features = ["CanvasRenderingContext2d", "CanvasWindingRule", "ImageBitmap", "ImageData",
+    "TextMetrics"]

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -11,8 +11,8 @@ use piet_test::draw_test_picture;
 
 #[wasm_bindgen]
 pub fn run() {
-    let canvas = window()
-        .unwrap()
+    let window = window().unwrap();
+    let canvas = window
         .document()
         .unwrap()
         .get_element_by_id("canvas")
@@ -26,12 +26,12 @@ pub fn run() {
         .dyn_into::<web_sys::CanvasRenderingContext2d>()
         .unwrap();
 
-    let dpr = window().unwrap().device_pixel_ratio();
+    let dpr = window.device_pixel_ratio();
     canvas.set_width((canvas.offset_width() as f64 * dpr) as u32);
     canvas.set_height((canvas.offset_height() as f64 * dpr) as u32);
     let _ = context.scale(dpr, dpr);
 
-    let mut piet_context = WebRenderContext::new(&mut context);
+    let mut piet_context = WebRenderContext::new(&mut context, &window);
     draw_test_picture(&mut piet_context, 0);
     piet_context.finish();
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use wasm_bindgen::JsValue;
-use web_sys::{CanvasRenderingContext2d, CanvasWindingRule};
+use web_sys::{CanvasRenderingContext2d, CanvasWindingRule, Window};
 
 use kurbo::{Affine, PathEl, Rect, Shape, Vec2};
 
@@ -13,11 +13,13 @@ use piet::{
 
 pub struct WebRenderContext<'a> {
     ctx: &'a mut CanvasRenderingContext2d,
+    /// Used for creating image bitmaps and possibly other resources.
+    window: &'a Window,
 }
 
 impl<'a> WebRenderContext<'a> {
-    pub fn new(ctx: &mut CanvasRenderingContext2d) -> WebRenderContext {
-        WebRenderContext { ctx }
+    pub fn new(ctx: &'a mut CanvasRenderingContext2d, window: &'a Window) -> WebRenderContext<'a> {
+        WebRenderContext { ctx, window }
     }
 }
 

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -5,9 +5,11 @@ use std::borrow::Cow;
 use wasm_bindgen::JsValue;
 use web_sys::{CanvasRenderingContext2d, CanvasWindingRule};
 
-use kurbo::{Affine, PathEl, Shape, Vec2};
+use kurbo::{Affine, PathEl, Rect, Shape, Vec2};
 
-use piet::{Font, FontBuilder, RenderContext, RoundInto, TextLayout, TextLayoutBuilder};
+use piet::{
+    Font, FontBuilder, InterpolationMode, RenderContext, RoundInto, TextLayout, TextLayoutBuilder,
+};
 
 pub struct WebRenderContext<'a> {
     ctx: &'a mut CanvasRenderingContext2d,
@@ -77,6 +79,8 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     type FontBuilder = WebFontBuilder;
     type TextLayout = WebTextLayout;
     type TextLayoutBuilder = WebTextLayoutBuilder;
+
+    type Image = ();
 
     fn clear(&mut self, _rgb: u32) {
         // TODO: we might need to know the size of the canvas to do this.
@@ -162,6 +166,16 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     fn transform(&mut self, transform: Affine) {
         let a = transform.as_coeffs();
         let _ = self.ctx.transform(a[0], a[1], a[2], a[3], a[4], a[5]);
+    }
+
+    fn make_rgba_image(&mut self, _width: usize, _height: usize, _buf: &[u8]) -> Self::Image {}
+
+    fn draw_image(
+        &mut self,
+        _image: &Self::Image,
+        _rect: impl Into<Rect>,
+        _interp: InterpolationMode,
+    ) {
     }
 }
 

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -1,6 +1,6 @@
 //! The main render context trait.
 
-use kurbo::{Affine, Shape, Vec2};
+use kurbo::{Affine, Rect, Shape, Vec2};
 
 use crate::{Font, FontBuilder, RoundFrom, RoundInto, TextLayout, TextLayoutBuilder};
 
@@ -11,6 +11,15 @@ pub enum FillRule {
     NonZero,
     /// Fill everything with an odd winding number.
     EvenOdd,
+}
+
+/// A requested interpolation mode for drawing images.
+#[derive(Clone, Copy, PartialEq)]
+pub enum InterpolationMode {
+    /// Don't interpolate, use nearest neighbor.
+    NearestNeighbor,
+    /// Use bilinear interpolation.
+    Bilinear,
 }
 
 /// The main trait for rendering graphics.
@@ -50,6 +59,9 @@ pub trait RenderContext {
 
     type TextLayoutBuilder: TextLayoutBuilder<Out = Self::TextLayout>;
     type TextLayout: TextLayout;
+
+    /// The associated type of an image.
+    type Image;
 
     /// Create a new brush resource.
     ///
@@ -130,4 +142,15 @@ pub trait RenderContext {
     /// Apply an affine transformation. The transformation remains in effect
     /// until a [`restore`](#method.restore) operation.
     fn transform(&mut self, transform: Affine);
+
+    /// Create a new image from RGBA data.
+    ///
+    /// The alpha is interpreted as premultiplied.
+    fn make_rgba_image(&mut self, width: usize, height: usize, buf: &[u8]) -> Self::Image;
+
+    /// Draw an image.
+    ///
+    /// The image is scaled to the provided `rect`. It will be squashed if
+    /// aspect ratios don't match.
+    fn draw_image(&mut self, image: &Self::Image, rect: impl Into<Rect>, interp: InterpolationMode);
 }

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -22,6 +22,30 @@ pub enum InterpolationMode {
     Bilinear,
 }
 
+/// The pixel format for bitmap images.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ImageFormat {
+    /// 3 bytes per pixel, in RGB order.
+    Rgb,
+    /// 4 bytes per pixel, in RGBA order, with separate alpha.
+    RgbaSeparate,
+    /// 4 bytes per pixel, in RGBA order, with premultiplied alpha.
+    RgbaPremul,
+    /// More formats may be added later.
+    #[doc(hidden)]
+    _NonExhaustive,
+}
+
+impl ImageFormat {
+    pub fn bytes_per_pixel(&self) -> usize {
+        match *self {
+            ImageFormat::Rgb => 3,
+            ImageFormat::RgbaPremul | ImageFormat::RgbaSeparate => 4,
+            _ => panic!(),
+        }
+    }
+}
+
 /// The main trait for rendering graphics.
 ///
 /// This trait provides an API for drawing 2D graphics. In basic usage, it
@@ -156,10 +180,14 @@ pub trait RenderContext {
     /// until a [`restore`](#method.restore) operation.
     fn transform(&mut self, transform: Affine);
 
-    /// Create a new image from RGBA data.
-    ///
-    /// The alpha is interpreted as premultiplied.
-    fn make_rgba_image(&mut self, width: usize, height: usize, buf: &[u8]) -> Self::Image;
+    /// Create a new image from a pixel buffer.
+    fn make_image(
+        &mut self,
+        width: usize,
+        height: usize,
+        buf: &[u8],
+        format: ImageFormat,
+    ) -> Self::Image;
 
     /// Draw an image.
     ///


### PR DESCRIPTION
This patch adds image capability, including support in all back-ends. Three image formats are intially supported; RGB 24 bits per pixel, and RGBA with both premultiplied and separate alpha. We will likely want to revisit this set, as some combinations of format and back-end may reduce the amount of conversion needed. In addition, there should be some mechanism (whether compile time or run time) to signal to drawing code which formats are most efficient. For example, premultiplied alpha is the most efficient on Cairo and Direct2D back ends, but separate alpha is dramatically more efficient on Web, as unpremultiplying requires 3 divides per pixel, and SIMD is not (at present) available.

The web implementation uses a scratch HTML Canvas to hold the image. That's most compatible when the source is an RGBA buffer and for general transform/clip, but direct ImageData could be more efficient for unity scale and clip to hard rectangle, and ImageBitmap could be useful for letting the browser do the decoding (though ImageBitmap has poorer compatibility and is async).

Images have many error conditions, so the need for #20 was strongly felt. That will happen soon.
