### PR TITLE
Text trait refactoring

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -10,16 +10,15 @@ use cairo::{
 use kurbo::{Affine, PathEl, QuadBez, Rect, Shape, Vec2};
 
 use piet::{
-    new_error, Error, ErrorKind, Factory, FillRule, Font, FontBuilder, ImageFormat,
-    InterpolationMode, LineCap, LineJoin, RenderContext, RoundInto, StrokeStyle, TextLayout,
-    TextLayoutBuilder,
+    new_error, Error, ErrorKind, FillRule, Font, FontBuilder, ImageFormat, InterpolationMode,
+    LineCap, LineJoin, RenderContext, RoundInto, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
 pub struct CairoRenderContext<'a> {
     // Cairo has this as Clone and with &self methods, but we do this to avoid
     // concurrency problems.
     ctx: &'a mut Context,
-    factory: CairoFactory,
+    text: CairoText,
 }
 
 impl<'a> CairoRenderContext<'a> {
@@ -31,7 +30,7 @@ impl<'a> CairoRenderContext<'a> {
     pub fn new(ctx: &mut Context) -> CairoRenderContext {
         CairoRenderContext {
             ctx,
-            factory: CairoFactory,
+            text: CairoText,
         }
     }
 }
@@ -42,7 +41,7 @@ pub enum Brush {
 
 /// Right now, we don't need any state, as the "toy text API" treats the
 /// access to system font information as a global. This will change.
-pub struct CairoFactory;
+pub struct CairoText;
 
 pub struct CairoFont(ScaledFont);
 
@@ -108,7 +107,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     type Coord = f64;
     type Brush = Brush;
 
-    type Factory = CairoFactory;
+    type Text = CairoText;
     type TextLayout = CairoTextLayout;
 
     type Image = ImageSurface;
@@ -161,8 +160,8 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.status()
     }
 
-    fn factory(&mut self) -> &mut Self::Factory {
-        &mut self.factory
+    fn text(&mut self) -> &mut Self::Text {
+        &mut self.text
     }
 
     fn draw_text(
@@ -284,7 +283,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     }
 }
 
-impl Factory for CairoFactory {
+impl Text for CairoText {
     type Coord = f64;
 
     type Font = CairoFont;

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -31,13 +31,13 @@ use directwrite::TextFormat;
 use kurbo::{Affine, PathEl, Rect, Shape};
 
 use piet::{
-    new_error, Error, ErrorKind, Factory, FillRule, Font, FontBuilder, ImageFormat,
-    InterpolationMode, RenderContext, RoundInto, StrokeStyle, TextLayout, TextLayoutBuilder,
+    new_error, Error, ErrorKind, FillRule, Font, FontBuilder, ImageFormat, InterpolationMode,
+    RenderContext, RoundInto, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
 pub struct D2DRenderContext<'a> {
     factory: &'a direct2d::Factory,
-    inner_factory: D2DFactory<'a>,
+    inner_text: D2DText<'a>,
     // This is an owned clone, but after some direct2d refactor, it's likely we'll
     // hold a mutable reference.
     rt: GenericRenderTarget,
@@ -46,7 +46,7 @@ pub struct D2DRenderContext<'a> {
     ctx_stack: Vec<CtxState>,
 }
 
-pub struct D2DFactory<'a> {
+pub struct D2DText<'a> {
     dwrite: &'a directwrite::Factory,
 }
 
@@ -80,10 +80,10 @@ impl<'a> D2DRenderContext<'a> {
         dwrite: &'a directwrite::Factory,
         rt: &'a mut RT,
     ) -> D2DRenderContext<'a> {
-        let inner_factory = D2DFactory { dwrite };
+        let inner_text = D2DText { dwrite };
         D2DRenderContext {
             factory,
-            inner_factory: inner_factory,
+            inner_text: inner_text,
             rt: rt.as_generic(),
             ctx_stack: vec![CtxState::default()],
         }
@@ -187,7 +187,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     type Coord = f32;
     type Brush = GenericBrush;
 
-    type Factory = D2DFactory<'a>;
+    type Text = D2DText<'a>;
 
     type TextLayout = D2DTextLayout;
 
@@ -256,8 +256,8 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         Ok(())
     }
 
-    fn factory(&mut self) -> &mut Self::Factory {
-        &mut self.inner_factory
+    fn text(&mut self) -> &mut Self::Text {
+        &mut self.inner_text
     }
 
     fn draw_text(
@@ -396,7 +396,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     }
 }
 
-impl<'a> Factory for D2DFactory<'a> {
+impl<'a> Text for D2DText<'a> {
     type Coord = f32;
     type FontBuilder = D2DFontBuilder<'a>;
     type Font = D2DFont;

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -3,8 +3,8 @@
 use kurbo::{Affine, BezPath, Line, Vec2};
 
 use piet::{
-    Error, Factory, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext,
-    TextLayout, TextLayoutBuilder,
+    Error, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayout,
+    TextLayoutBuilder,
 };
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
@@ -24,11 +24,8 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let brush = rc.solid_brush(0x00_00_80_C0)?;
     rc.fill(path, &brush, FillRule::NonZero)?;
 
-    let font = rc.factory().new_font_by_name("Segoe UI", 12.0)?.build()?;
-    let layout = rc
-        .factory()
-        .new_text_layout(&font, "Hello piet!")?
-        .build()?;
+    let font = rc.text().new_font_by_name("Segoe UI", 12.0)?.build()?;
+    let layout = rc.text().new_text_layout(&font, "Hello piet!")?.build()?;
     let w: f64 = layout.width().into();
     let brush = rc.solid_brush(0x80_00_00_C0)?;
     rc.draw_text(&layout, (80.0, 10.0), &brush)?;
@@ -50,10 +47,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
     rc.clip(clip_path, FillRule::NonZero)?;
-    let layout = rc
-        .factory()
-        .new_text_layout(&font, "Clipped text")?
-        .build()?;
+    let layout = rc.text().new_text_layout(&font, "Clipped text")?.build()?;
     rc.draw_text(&layout, (80.0, 50.0), &brush)?;
     Ok(())
 }

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -3,8 +3,8 @@
 use kurbo::{Affine, BezPath, Line, Vec2};
 
 use piet::{
-    Error, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext, TextLayout,
-    TextLayoutBuilder,
+    Error, Factory, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext,
+    TextLayout, TextLayoutBuilder,
 };
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
@@ -24,8 +24,11 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let brush = rc.solid_brush(0x00_00_80_C0)?;
     rc.fill(path, &brush, FillRule::NonZero)?;
 
-    let font = rc.new_font_by_name("Segoe UI", 12.0)?.build()?;
-    let layout = rc.new_text_layout(&font, "Hello piet!")?.build()?;
+    let font = rc.factory().new_font_by_name("Segoe UI", 12.0)?.build()?;
+    let layout = rc
+        .factory()
+        .new_text_layout(&font, "Hello piet!")?
+        .build()?;
     let w: f64 = layout.width().into();
     let brush = rc.solid_brush(0x80_00_00_C0)?;
     rc.draw_text(&layout, (80.0, 10.0), &brush)?;
@@ -47,7 +50,10 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let clip_path = star(Vec2::new(90.0, 45.0), 10.0, 30.0, 24);
     rc.clip(clip_path, FillRule::NonZero)?;
-    let layout = rc.new_text_layout(&font, "Clipped text")?.build()?;
+    let layout = rc
+        .factory()
+        .new_text_layout(&font, "Clipped text")?
+        .build()?;
     rc.draw_text(&layout, (80.0, 50.0), &brush)?;
     Ok(())
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -10,8 +10,8 @@ use web_sys::{CanvasRenderingContext2d, CanvasWindingRule, HtmlCanvasElement, Im
 use kurbo::{Affine, PathEl, Rect, Shape, Vec2};
 
 use piet::{
-    Error, Factory, Font, FontBuilder, ImageFormat, InterpolationMode, LineCap, LineJoin,
-    RenderContext, RoundInto, StrokeStyle, TextLayout, TextLayoutBuilder,
+    Error, Font, FontBuilder, ImageFormat, InterpolationMode, LineCap, LineJoin, RenderContext,
+    RoundInto, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
 pub struct WebRenderContext<'a> {
@@ -124,7 +124,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     type Coord = f64;
     type Brush = Brush;
 
-    type Factory = Self;
+    type Text = Self;
     type TextLayout = WebTextLayout;
 
     type Image = WebImage;
@@ -172,7 +172,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         Ok(())
     }
 
-    fn factory(&mut self) -> &mut Self::Factory {
+    fn text(&mut self) -> &mut Self::Text {
         self
     }
 
@@ -291,7 +291,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     }
 }
 
-impl<'a> Factory for WebRenderContext<'a> {
+impl<'a> Text for WebRenderContext<'a> {
     type Coord = f64;
 
     type Font = WebFont;

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -2,7 +2,7 @@
 
 use kurbo::{Affine, Rect, Shape, Vec2};
 
-use crate::{Error, Font, FontBuilder, RoundFrom, RoundInto, TextLayout, TextLayoutBuilder};
+use crate::{Error, Factory, RoundFrom, RoundInto, TextLayout};
 
 /// A fill rule for resolving winding numbers.
 #[derive(Clone, Copy, PartialEq)]
@@ -78,10 +78,8 @@ pub trait RenderContext {
     /// Parameters for the style of stroke operations.
     type StrokeStyle;
 
-    type FontBuilder: FontBuilder<Out = Self::Font>;
-    type Font: Font;
-
-    type TextLayoutBuilder: TextLayoutBuilder<Out = Self::TextLayout>;
+    /// An associated factory for creating text layouts and related resources.
+    type Factory: Factory<TextLayout = Self::TextLayout>;
     type TextLayout: TextLayout;
 
     /// The associated type of an image.
@@ -125,17 +123,7 @@ pub trait RenderContext {
     /// are clipped by the shape.
     fn clip(&mut self, shape: impl Shape, fill_rule: FillRule) -> Result<(), Error>;
 
-    fn new_font_by_name(
-        &mut self,
-        name: &str,
-        size: impl RoundInto<Self::Coord>,
-    ) -> Result<Self::FontBuilder, Error>;
-
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-    ) -> Result<Self::TextLayoutBuilder, Error>;
+    fn factory(&mut self) -> &mut Self::Factory;
 
     /// Draw a text layout.
     ///

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -2,7 +2,7 @@
 
 use kurbo::{Affine, Rect, Shape, Vec2};
 
-use crate::{Error, Factory, FillRule, RoundFrom, RoundInto, StrokeStyle, TextLayout};
+use crate::{Error, FillRule, RoundFrom, RoundInto, StrokeStyle, Text, TextLayout};
 
 /// A requested interpolation mode for drawing images.
 #[derive(Clone, Copy, PartialEq)]
@@ -67,7 +67,7 @@ pub trait RenderContext {
     type Brush;
 
     /// An associated factory for creating text layouts and related resources.
-    type Factory: Factory<TextLayout = Self::TextLayout>;
+    type Text: Text<TextLayout = Self::TextLayout>;
     type TextLayout: TextLayout;
 
     /// The associated type of an image.
@@ -111,7 +111,7 @@ pub trait RenderContext {
     /// are clipped by the shape.
     fn clip(&mut self, shape: impl Shape, fill_rule: FillRule) -> Result<(), Error>;
 
-    fn factory(&mut self) -> &mut Self::Factory;
+    fn text(&mut self) -> &mut Self::Text;
 
     /// Draw a text layout.
     ///

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -1,6 +1,28 @@
 //! Traits for fonts and text handling.
 
-use crate::{Error, RoundFrom};
+use crate::{Error, RoundFrom, RoundInto};
+
+pub trait Factory {
+    type FontBuilder: FontBuilder<Out = Self::Font>;
+    type Font: Font;
+
+    type TextLayoutBuilder: TextLayoutBuilder<Out = Self::TextLayout>;
+    type TextLayout: TextLayout;
+
+    type Coord: Into<f64> + RoundFrom<f64>;
+
+    fn new_font_by_name(
+        &mut self,
+        name: &str,
+        size: impl RoundInto<Self::Coord>,
+    ) -> Result<Self::FontBuilder, Error>;
+
+    fn new_text_layout(
+        &mut self,
+        font: &Self::Font,
+        text: &str,
+    ) -> Result<Self::TextLayoutBuilder, Error>;
+}
 
 pub trait FontBuilder {
     type Out: Font;

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -2,7 +2,7 @@
 
 use crate::{Error, RoundFrom, RoundInto};
 
-pub trait Factory {
+pub trait Text {
     type FontBuilder: FontBuilder<Out = Self::Font>;
     type Font: Font;
 


### PR DESCRIPTION
Make a new Text type (with trait) so text layout doesn't require a RenderContext; this type is essentially a factory for text layouts. There's a `text` method so if you have a RenderContext you can do layouts from that, but it's anticipated there will be other contexts (widget layout) where you want to do text layout but aren't necessarily drawing to a surface.
