### PR TITLE
New crate for selecting default back-end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "piet",
     "piet-cairo",
+    "piet-common",
     "piet-direct2d",
     "piet-test",
     "piet-web",

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-cairo"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Cairo backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -22,6 +22,7 @@ cairo-rs = { version = "0.5.0", default_features = false, optional = true}
 
 [target.'cfg(not(any(target_arch="wasm32", target_os="windows")))'.dependencies]
 piet-cairo = { path = "../piet-cairo" }
+cairo-rs = { version = "0.5.0", default_features = false}
 
 [target.'cfg(target_os="windows")'.dependencies]
 piet-direct2d = { path = "../piet-direct2d" }

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["graphics", "2d"]
 
 [features]
 d2d = ["piet-direct2d"]
-cairo = ["piet-cairo"]
+cairo = ["piet-cairo", "cairo-rs"]
 web = ["piet-web"]
 
 [dependencies]
@@ -18,6 +18,7 @@ piet = { path = "../piet" }
 piet-cairo = { path = "../piet-cairo", optional = true }
 piet-direct2d = { path = "../piet-direct2d", optional = true }
 piet-web = { path = "../piet-web", optional = true }
+cairo-rs = { version = "0.5.0", default_features = false, optional = true}
 
 [target.'cfg(not(any(target_arch="wasm32", target_os="windows")))'.dependencies]
 piet-cairo = { path = "../piet-cairo" }

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-common"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Selection of a single preferred back-end for piet"
 license = "MIT/Apache-2.0"

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "piet-common"
+version = "0.1.0"
+authors = ["Raph Levien <raph.levien@gmail.com>"]
+description = "Selection of a single preferred back-end for piet"
+license = "MIT/Apache-2.0"
+edition = "2018"
+keywords = ["graphics", "2d"]
+
+[features]
+d2d = ["piet-direct2d"]
+cairo = ["piet-cairo"]
+web = ["piet-web"]
+
+[dependencies]
+kurbo = "0.2.0"
+piet = { path = "../piet" }
+piet-cairo = { path = "../piet-cairo", optional = true }
+piet-direct2d = { path = "../piet-direct2d", optional = true }
+piet-web = { path = "../piet-web", optional = true }
+
+[target.'cfg(not(any(target_arch="wasm32", target_os="windows")))'.dependencies]
+piet-cairo = { path = "../piet-cairo" }
+
+[target.'cfg(target_os="windows")'.dependencies]
+piet-direct2d = { path = "../piet-direct2d" }
+direct2d = "0.2.0"
+directwrite = "0.1.4"
+dxgi = "0.1.7"
+direct3d11 = "0.1.7"
+
+[target.'cfg(target_arch="wasm32")'.dependencies]
+piet-web = { path = "../piet-web" }
+
+[dev-dependencies]
+image = "0.20.1"

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -1,3 +1,5 @@
+use kurbo::Line;
+
 use piet::RenderContext;
 use piet_common::Device;
 
@@ -7,7 +9,10 @@ fn main() {
     let height = 480;
     let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();
     let mut rc = bitmap.render_context();
-    rc.clear(0x00ff00).unwrap();
+    rc.clear(0xffffff).unwrap();
+    let brush = rc.solid_brush(0x00_00_80_FF).unwrap();
+    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None)
+        .unwrap();
     rc.finish().unwrap();
     let raw_pixels = bitmap.into_raw_pixels().unwrap();
     image::save_buffer(

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -1,6 +1,6 @@
 use kurbo::Line;
 
-use piet::RenderContext;
+use piet::{ImageFormat, RenderContext};
 use piet_common::Device;
 
 fn main() {
@@ -14,7 +14,7 @@ fn main() {
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None)
         .unwrap();
     rc.finish().unwrap();
-    let raw_pixels = bitmap.into_raw_pixels().unwrap();
+    let raw_pixels = bitmap.into_raw_pixels(ImageFormat::RgbaPremul).unwrap();
     image::save_buffer(
         "temp-image.png",
         &raw_pixels,

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -1,0 +1,21 @@
+use piet::RenderContext;
+use piet_common::Device;
+
+fn main() {
+    let device = Device::new().unwrap();
+    let width = 640;
+    let height = 480;
+    let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();
+    let mut rc = bitmap.render_context();
+    rc.clear(0x00ff00).unwrap();
+    rc.finish().unwrap();
+    let raw_pixels = bitmap.into_raw_pixels().unwrap();
+    image::save_buffer(
+        "temp-image.png",
+        &raw_pixels,
+        width as u32,
+        height as u32,
+        image::ColorType::RGBA(8),
+    )
+    .unwrap();
+}

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -1,0 +1,84 @@
+//! Support for piet Cairo back-end.
+
+use std::marker::PhantomData;
+
+use cairo::prelude::SurfaceExt;
+use cairo::{Context, Format, ImageSurface};
+
+pub use piet_cairo::*;
+
+/// The `RenderContext` for the Cairo backend, which is selected.
+pub type Piet<'a> = CairoRenderContext<'a>;
+
+/// A struct that can be used to create bitmap render contexts.
+///
+/// In the case of Cairo, being a software renderer, no state is needed.
+pub struct Device;
+
+/// A struct provides a `RenderContext` and then can have its bitmap extracted.
+pub struct BitmapTarget<'a> {
+    surface: ImageSurface,
+    cr: Context,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl Device {
+    /// Create a new device.
+    pub fn new() -> Result<Device, piet::Error> {
+        Ok(Device)
+    }
+
+    /// Create a new bitmap target.
+    pub fn bitmap_target(
+        &self,
+        width: usize,
+        height: usize,
+        pix_scale: f64,
+    ) -> Result<BitmapTarget, piet::Error> {
+        let surface = ImageSurface::create(Format::ARgb32, width as i32, height as i32).unwrap();
+        let cr = Context::new(&surface);
+        cr.scale(pix_scale, pix_scale);
+        let phantom = Default::default();
+        Ok(BitmapTarget {
+            surface,
+            cr,
+            phantom,
+        })
+    }
+}
+
+impl<'a> BitmapTarget<'a> {
+    /// Get a piet `RenderContext` for the bitmap.
+    ///
+    /// Note: caller is responsible for calling `finish` on the render
+    /// context at the end of rendering.
+    pub fn render_context<'b>(&'b mut self) -> CairoRenderContext<'b> {
+        CairoRenderContext::new(&mut self.cr)
+    }
+
+    /// Get raw RGBA pixels from the bitmap.
+    ///
+    /// These are in premultiplied-alpha format.
+    ///
+    /// Possible TODO: allow different pixel formats and convert.
+    pub fn into_raw_pixels(mut self) -> Result<Vec<u8>, piet::Error> {
+        std::mem::drop(self.cr);
+        self.surface.flush();
+        let stride = self.surface.get_stride() as usize;
+        let width = self.surface.get_width() as usize;
+        let height = self.surface.get_height() as usize;
+        let mut raw_data = vec![0; width * height * 4];
+        let buf = self.surface.get_data().unwrap();
+        for y in 0..height {
+            let src_off = y * stride;
+            let dst_off = y * width * 4;
+            for x in 0..width {
+                raw_data[dst_off + x * 4 + 0] = buf[src_off + x * 4 + 2];
+                raw_data[dst_off + x * 4 + 1] = buf[src_off + x * 4 + 1];
+                raw_data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
+                raw_data[dst_off + x * 4 + 3] = buf[src_off + x * 4 + 3];
+            }
+        }
+        Ok(raw_data)
+    }
+}

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -5,6 +5,8 @@ use std::marker::PhantomData;
 use cairo::prelude::SurfaceExt;
 use cairo::{Context, Format, ImageSurface};
 
+use piet::{ErrorKind, ImageFormat};
+
 pub use piet_cairo::*;
 
 /// The `RenderContext` for the Cairo backend, which is selected.
@@ -57,18 +59,21 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    ///
-    /// These are in premultiplied-alpha format.
-    ///
-    /// Possible TODO: allow different pixel formats and convert.
-    pub fn into_raw_pixels(mut self) -> Result<Vec<u8>, piet::Error> {
+    pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+        // TODO: convert other formats.
+        if fmt != ImageFormat::RgbaPremul {
+            return Err(piet::new_error(ErrorKind::NotSupported));
+        }
         std::mem::drop(self.cr);
         self.surface.flush();
         let stride = self.surface.get_stride() as usize;
         let width = self.surface.get_width() as usize;
         let height = self.surface.get_height() as usize;
         let mut raw_data = vec![0; width * height * 4];
-        let buf = self.surface.get_data().unwrap();
+        let buf = self
+            .surface
+            .get_data()
+            .map_err(|e| Into::<Box<dyn std::error::Error>>::into(e))?;
         for y in 0..height {
             let src_off = y * stride;
             let dst_off = y * width * 4;

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -1,4 +1,4 @@
-//! Select Direct2D back-end for piet.
+//! Support for piet Direct2D back-end.
 
 pub use piet_direct2d::*;
 
@@ -12,7 +12,7 @@ use dxgi::flags::Format;
 /// The `RenderContext` for the Direct2D backend, which is selected.
 pub type Piet<'a> = D2DRenderContext<'a>;
 
-/// A struct that can be used to create bitmap render contexts
+/// A struct that can be used to create bitmap render contexts.
 pub struct Device {
     d2d: direct2d::Factory,
     dwrite: directwrite::Factory,
@@ -65,7 +65,7 @@ impl Device {
         &self,
         width: usize,
         height: usize,
-        pix_scale: f32,
+        pix_scale: f64,
     ) -> Result<BitmapTarget, piet::Error> {
         let mut context = direct2d::DeviceContext::create(&self.device, false).unwrap();
 
@@ -80,7 +80,7 @@ impl Device {
         // Bind the backing texture to a D2D Bitmap
         let target = Bitmap::create(&context)
             .with_dxgi_surface(&tex.as_dxgi())
-            .with_dpi(96.0 * pix_scale, 96.0 * pix_scale)
+            .with_dpi(96.0 * pix_scale as f32, 96.0 * pix_scale as f32)
             .with_options(BitmapOptions::TARGET)
             .build()
             .unwrap();
@@ -106,11 +106,13 @@ impl<'a> BitmapTarget<'a> {
     ///
     /// Note: caller is responsible for calling `finish` on the render
     /// context at the end of rendering.
-    pub fn render_context<'b>(&'b mut self) -> D2DRenderContext<'a> {
+    pub fn render_context<'b>(&'b mut self) -> D2DRenderContext<'b> {
         D2DRenderContext::new(self.d2d, self.dwrite, &mut self.context)
     }
 
     /// Get raw RGBA pixels from the bitmap.
+    ///
+    /// These are in premultiplied-alpha format.
     pub fn into_raw_pixels(mut self) -> Result<Vec<u8>, piet::Error> {
         self.context.end_draw().unwrap();
         let temp_texture = direct3d11::texture2d::Texture2D::create(self.d3d)

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -1,0 +1,143 @@
+//! Select Direct2D back-end for piet.
+
+pub use piet_direct2d::*;
+
+use direct2d::enums::BitmapOptions;
+use direct2d::image::Bitmap;
+use direct2d::RenderTarget;
+use direct3d11::flags::{BindFlags, CreateDeviceFlags};
+use direct3d11::helpers::ComWrapper;
+use dxgi::flags::Format;
+
+/// The `RenderContext` for the Direct2D backend, which is selected.
+pub type Piet<'a> = D2DRenderContext<'a>;
+
+/// A struct that can be used to create bitmap render contexts
+pub struct Device {
+    d2d: direct2d::Factory,
+    dwrite: directwrite::Factory,
+    d3d: direct3d11::Device,
+    d3d_ctx: direct3d11::DeviceContext,
+    device: direct2d::Device,
+}
+
+/// A struct provides a `RenderContext` and then can have its bitmap extracted.
+pub struct BitmapTarget<'a> {
+    width: usize,
+    height: usize,
+    d2d: &'a direct2d::Factory,
+    dwrite: &'a directwrite::Factory,
+    d3d: &'a direct3d11::Device,
+    d3d_ctx: &'a direct3d11::DeviceContext,
+    tex: direct3d11::Texture2D,
+    context: direct2d::DeviceContext,
+}
+
+impl Device {
+    /// Create a new device.
+    ///
+    /// This creates new Direct2D and DirectWrite factories, a Direct3D
+    /// device, and a Direct2D device.
+    pub fn new() -> Result<Device, piet::Error> {
+        let d2d = direct2d::Factory::new().unwrap();
+        let dwrite = directwrite::Factory::new().unwrap();
+
+        // Initialize a D3D Device
+        let (_, d3d, d3d_ctx) = direct3d11::Device::create()
+            .with_flags(CreateDeviceFlags::BGRA_SUPPORT)
+            .build()
+            .unwrap();
+
+        // Create the D2D Device and Context
+        let device = direct2d::Device::create(&d2d, &d3d.as_dxgi()).unwrap();
+
+        Ok(Device {
+            d2d,
+            dwrite,
+            d3d,
+            d3d_ctx,
+            device,
+        })
+    }
+
+    /// Create a new bitmap target.
+    pub fn bitmap_target(
+        &self,
+        width: usize,
+        height: usize,
+        pix_scale: f32,
+    ) -> Result<BitmapTarget, piet::Error> {
+        let mut context = direct2d::DeviceContext::create(&self.device, false).unwrap();
+
+        // Create a texture to render to
+        let tex = direct3d11::Texture2D::create(&self.d3d)
+            .with_size(width as u32, height as u32)
+            .with_format(Format::R8G8B8A8Unorm)
+            .with_bind_flags(BindFlags::RENDER_TARGET | BindFlags::SHADER_RESOURCE)
+            .build()
+            .unwrap();
+
+        // Bind the backing texture to a D2D Bitmap
+        let target = Bitmap::create(&context)
+            .with_dxgi_surface(&tex.as_dxgi())
+            .with_dpi(96.0 * pix_scale, 96.0 * pix_scale)
+            .with_options(BitmapOptions::TARGET)
+            .build()
+            .unwrap();
+
+        context.set_target(&target);
+        context.begin_draw();
+
+        Ok(BitmapTarget {
+            width,
+            height,
+            d2d: &self.d2d,
+            dwrite: &self.dwrite,
+            d3d: &self.d3d,
+            d3d_ctx: &self.d3d_ctx,
+            tex,
+            context,
+        })
+    }
+}
+
+impl<'a> BitmapTarget<'a> {
+    /// Get a piet `RenderContext` for the bitmap.
+    ///
+    /// Note: caller is responsible for calling `finish` on the render
+    /// context at the end of rendering.
+    pub fn render_context<'b>(&'b mut self) -> D2DRenderContext<'a> {
+        D2DRenderContext::new(self.d2d, self.dwrite, &mut self.context)
+    }
+
+    /// Get raw RGBA pixels from the bitmap.
+    pub fn into_raw_pixels(mut self) -> Result<Vec<u8>, piet::Error> {
+        self.context.end_draw().unwrap();
+        let temp_texture = direct3d11::texture2d::Texture2D::create(self.d3d)
+            .with_size(self.width as u32, self.height as u32)
+            .with_format(direct3d11::flags::Format::R8G8B8A8Unorm)
+            .with_bind_flags(direct3d11::flags::BindFlags::NONE)
+            .with_usage(direct3d11::flags::Usage::Staging)
+            .with_cpu_access_flags(direct3d11::flags::CpuAccessFlags::READ)
+            .build()
+            .unwrap();
+
+        // TODO: Have a safe way to accomplish this :D
+        let mut raw_pixels: Vec<u8> = Vec::with_capacity(self.width * self.height * 4);
+        unsafe {
+            let ctx = &*self.d3d_ctx.get_raw();
+            ctx.CopyResource(
+                temp_texture.get_raw() as *mut _,
+                self.tex.get_raw() as *mut _,
+            );
+            ctx.Flush();
+
+            let surface = temp_texture.as_dxgi();
+            let map = surface.map(true, false, false).unwrap();
+            for y in 0..(self.height as u32) {
+                raw_pixels.extend_from_slice(&map.row(y)[..self.width * 4]);
+            }
+        }
+        Ok(raw_pixels)
+    }
+}

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -1,0 +1,33 @@
+//! Selection of a common back-end for piet.
+
+#[cfg(any(
+    feature = "cairo",
+    not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
+))]
+mod back {
+    pub use piet_cairo::*;
+
+    pub type Piet<'a> = CairoRenderContext<'a>;
+}
+
+#[cfg(any(
+    feature = "cairo",
+    not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
+))]
+pub use back::*;
+
+#[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
+mod direct2d_back;
+
+#[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
+pub use direct2d_back::*;
+
+#[cfg(any(feature = "web", target_arch = "wasm32"))]
+mod back {
+    pub use piet_web::*;
+
+    pub type Piet<'a> = WebRenderContext<'a>;
+}
+
+#[cfg(any(feature = "web", target_arch = "wasm32"))]
+pub use back::*;

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -10,13 +10,13 @@ mod cairo_back;
     feature = "cairo",
     not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
 ))]
-pub use cairo_back::*;
+pub use crate::cairo_back::*;
 
 #[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
 mod direct2d_back;
 
 #[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
-pub use direct2d_back::*;
+pub use crate::direct2d_back::*;
 
 #[cfg(any(feature = "web", target_arch = "wasm32"))]
 mod back {
@@ -26,4 +26,4 @@ mod back {
 }
 
 #[cfg(any(feature = "web", target_arch = "wasm32"))]
-pub use back::*;
+pub use crate::back::*;

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -4,17 +4,13 @@
     feature = "cairo",
     not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
 ))]
-mod back {
-    pub use piet_cairo::*;
-
-    pub type Piet<'a> = CairoRenderContext<'a>;
-}
+mod cairo_back;
 
 #[cfg(any(
     feature = "cairo",
     not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
 ))]
-pub use back::*;
+pub use cairo_back::*;
 
 #[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
 mod direct2d_back;

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-direct2d"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Direct2D backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -75,11 +75,16 @@ struct CtxState {
 }
 
 impl<'b, 'a: 'b> D2DRenderContext<'a> {
+    /// Create a new Piet RenderContext for the Direct2D RenderTarget.
+    ///
+    /// Note: the signature of this function has more restrictive lifetimes than
+    /// the implementation requires, because we actually clone the RT, but this
+    /// will likely change.
     pub fn new<RT: RenderTarget>(
         factory: &'a direct2d::Factory,
         dwrite: &'a directwrite::Factory,
         rt: &'b mut RT,
-    ) -> D2DRenderContext<'a> {
+    ) -> D2DRenderContext<'b> {
         let inner_text = D2DText { dwrite };
         D2DRenderContext {
             factory,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -74,11 +74,11 @@ struct CtxState {
     n_layers_pop: usize,
 }
 
-impl<'a> D2DRenderContext<'a> {
+impl<'b, 'a: 'b> D2DRenderContext<'a> {
     pub fn new<RT: RenderTarget>(
         factory: &'a direct2d::Factory,
         dwrite: &'a directwrite::Factory,
-        rt: &'a mut RT,
+        rt: &'b mut RT,
     ) -> D2DRenderContext<'a> {
         let inner_text = D2DText { dwrite };
         D2DRenderContext {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -1,7 +1,7 @@
 //! The Direct2D backend for the Piet 2D graphics abstraction.
 
 mod conv;
-mod error;
+pub mod error;
 
 use crate::conv::{affine_to_matrix3x2f, convert_stroke_style, rect_to_rectf, to_point2f, Point2};
 use crate::error::WrapError;

--- a/piet-test/Cargo.toml
+++ b/piet-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-test"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Utilities for testing the piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "An abstraction for 2D graphics."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This patch creates a new piet-common crate that selects a default piet back-end, and also provides much of the boilerplate for setting it up so that a raw bitmap can be extracted.

The common crate currently works for direct2d and cairo back-ends. I might try to get a web back-end into this PR, or do it as a follow-on.

This PR also sets versions to 0.0.1 in preparation for the first crates.io release.