### PR TITLE
piet-common: Add type aliases for the associated types

### DIFF
--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -3,13 +3,13 @@
 pub type Point = <Piet<'static> as piet::RenderContext>::Point;
 pub type Coord = <Piet<'static> as piet::RenderContext>::Coord;
 pub type Brush = <Piet<'static> as piet::RenderContext>::Brush;
-pub type Text = <Piet<'static> as piet::RenderContext>::Text;
+pub type Text<'a> = <Piet<'a> as piet::RenderContext>::Text;
 pub type TextLayout = <Piet<'static> as piet::RenderContext>::TextLayout;
 pub type Image = <Piet<'static> as piet::RenderContext>::Image;
 
-pub type FontBuilder = <Text as piet::Text>::FontBuilder;
-pub type Font = <Text as piet::Text>::Font;
-pub type TextLayoutBuilder = <Text as piet::Text>::TextLayoutBuilder;
+pub type FontBuilder<'a> = <Text<'a> as piet::Text>::FontBuilder;
+pub type Font = <Text<'static> as piet::Text>::Font;
+pub type TextLayoutBuilder<'a> = <Text<'a> as piet::Text>::TextLayoutBuilder;
 
 #[cfg(any(
     feature = "cairo",

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -1,5 +1,16 @@
 //! Selection of a common back-end for piet.
 
+pub type Point = <Piet<'static> as piet::RenderContext>::Point;
+pub type Coord = <Piet<'static> as piet::RenderContext>::Coord;
+pub type Brush = <Piet<'static> as piet::RenderContext>::Brush;
+pub type Text = <Piet<'static> as piet::RenderContext>::Text;
+pub type TextLayout = <Piet<'static> as piet::RenderContext>::TextLayout;
+pub type Image = <Piet<'static> as piet::RenderContext>::Image;
+
+pub type FontBuilder = <Text as piet::Text>::FontBuilder;
+pub type Font = <Text as piet::Text>::Font;
+pub type TextLayoutBuilder = <Text as piet::Text>::TextLayoutBuilder;
+
 #[cfg(any(
     feature = "cairo",
     not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))


### PR DESCRIPTION
… which are otherwise verbose to name. This hopefully makes code like https://github.com/xi-editor/druid/pull/11#discussion_r251832951 easier to write.

The use of `'static` is somewhat dubious, but I think that picking *an* arbitrary lifetime might be necessary (unless the type aliases themselves gain a lifetime parameter) because, on principle, the associated types in `impl<'a> RenderContext for SomeType<'a>` *could* use `'a`. But they don’t, for backends that `piet-common` supports, so picking *any* lifetime sounds ok.

Another question is: should there be a `TextCoord` type alias? CC https://github.com/linebender/piet/issues/36