### PR TITLE
Only install rustfmt on stable runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ rust:
 
 cache: cargo
 before_script:
-  - rustup component add rustfmt
+  - if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then rustup component add rustfmt; fi
 script:
   - if [[ "$TRAVIS_RUST_VERSION" = stable ]]; then eval "cargo fmt --all -- --check"; fi
   - TO_RUN="--all --exclude piet-direct2d"


### PR DESCRIPTION
This fixes travis errors, as it's gone missing on nightly.