### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: rust
 
 rust:
-  - 1.35
+  - 1.35.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,15 @@ os:
 language: rust
 
 rust:
-  - 1.31.1
+  - 1.35
   - stable
   - beta
   - nightly
+
+# There's a build problem on macOS, we hope this will be fixed.
+# See https://github.com/gtk-rs/cairo/issues/263
+env:
+  - PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig
 
 cache: cargo
 before_script:


### PR DESCRIPTION
Increase minimum rust version, as it's needed by wasm-bindgen.

Also set PKG_CONFIG_PATH for cairo, see https://github.com/gtk-rs/cairo/issues/263
