### PR TITLE
Reexport kurbo from piet crate

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = "0.2.1"
 piet = { version = "0.0.2", path = "../piet" }
 
 [dependencies.cairo-rs]

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -7,7 +7,7 @@ use cairo::{
     ImageSurface, Matrix, Pattern, PatternTrait, ScaledFont, Status, SurfacePattern,
 };
 
-use kurbo::{Affine, PathEl, QuadBez, Rect, Shape, Vec2};
+use piet::kurbo::{Affine, PathEl, QuadBez, Rect, Shape, Vec2};
 
 use piet::{
     new_error, Error, ErrorKind, FillRule, Font, FontBuilder, Gradient, GradientStop, ImageFormat,

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -13,7 +13,6 @@ cairo = ["piet-cairo", "cairo-rs"]
 web = ["piet-web"]
 
 [dependencies]
-kurbo = "0.2.1"
 piet = { version = "0.0.2", path = "../piet" }
 piet-cairo = { version = "0.0.2", path = "../piet-cairo", optional = true }
 piet-direct2d = { version = "0.0.2", path = "../piet-direct2d", optional = true }

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -1,4 +1,4 @@
-use kurbo::Line;
+use piet::kurbo::Line;
 
 use piet::{ImageFormat, RenderContext};
 use piet_common::Device;

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -9,7 +9,6 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-kurbo = "0.2.1"
 piet = { version = "0.0.2", path = "../piet" }
 
 direct2d = "0.2.0"

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -2,7 +2,7 @@
 
 use direct2d::math::{ColorF, Matrix3x2F, Point2F, RectF};
 
-use kurbo::{Affine, Rect, Vec2};
+use piet::kurbo::{Affine, Rect, Vec2};
 
 use piet::{Error, GradientStop, LineCap, LineJoin, RoundFrom, RoundInto, StrokeStyle};
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -33,7 +33,7 @@ use directwrite::text_format::TextFormatBuilder;
 use directwrite::text_layout;
 use directwrite::TextFormat;
 
-use kurbo::{Affine, PathEl, Rect, Shape};
+use piet::kurbo::{Affine, PathEl, Rect, Shape};
 
 use piet::{
     new_error, Error, ErrorKind, FillRule, Font, FontBuilder, Gradient, ImageFormat,

--- a/piet-test/Cargo.toml
+++ b/piet-test/Cargo.toml
@@ -8,5 +8,4 @@ edition = "2018"
 keywords = ["graphics", "2d"]
 
 [dependencies]
-kurbo = "0.2.1"
 piet = { version = "0.0.2", path = "../piet" }

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -1,6 +1,6 @@
 //! A wide assortment of graphics meant to show off many different uses of piet
 
-use kurbo::{Affine, BezPath, Line, Vec2};
+use piet::kurbo::{Affine, BezPath, Line, Vec2};
 
 use piet::{
     Error, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayout,

--- a/piet-test/src/picture_1.rs
+++ b/piet-test/src/picture_1.rs
@@ -1,6 +1,6 @@
 //! Rendering a cubic Bézier curve with its control points and handles
 
-use kurbo::{BezPath, Line, Vec2};
+use piet::kurbo::{BezPath, Line, Vec2};
 
 use piet::{Error, FillRule, RenderContext};
 

--- a/piet-test/src/picture_3.rs
+++ b/piet-test/src/picture_3.rs
@@ -1,6 +1,6 @@
 //! Rendering stroke styles.
 
-use kurbo::{Affine, BezPath, Line};
+use piet::kurbo::{Affine, BezPath, Line};
 
 use piet::{Error, LineCap, LineJoin, RenderContext, StrokeStyle};
 

--- a/piet-test/src/picture_4.rs
+++ b/piet-test/src/picture_4.rs
@@ -1,6 +1,6 @@
 //! Gradients.
 
-use kurbo::{Rect, Vec2};
+use piet::kurbo::{Rect, Vec2};
 
 use piet::{
     Error, FillRule, Gradient, GradientStop, LinearGradient, RadialGradient, RenderContext,

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-kurbo = "0.2.1"
 piet = { version = "0.0.2", path = "../piet" }
 
 wasm-bindgen = "0.2.30"

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["cdylib"]
 piet = { path = "../../../piet" }
 piet-web = { path = "../.." }
 piet-test = { path = "../../../piet-test" }
-kurbo = "0.2.1"
 
 wasm-bindgen = "0.2.30"
 [dependencies.web-sys]

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -10,7 +10,7 @@ use web_sys::{
     Window,
 };
 
-use kurbo::{Affine, PathEl, Rect, Shape, Vec2};
+use piet::kurbo::{Affine, PathEl, Rect, Shape, Vec2};
 
 use piet::{
     Error, Font, FontBuilder, Gradient, GradientStop, ImageFormat, InterpolationMode, LineCap,

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -1,5 +1,7 @@
 //! A 2D graphics abstraction.
 
+pub use kurbo;
+
 mod conv;
 mod error;
 mod gradient;


### PR DESCRIPTION
This ensures that all of the piet family crates are depending on
a single version of kurbo, which is listed as a dependency in
exactly one `Cargo.toml`.


This was causing me a major headache when I wanted to test out some local changes I'd made to kurbo.

If there are any problems with this approach I'm curious to hear what they are, I couldn't think of anything.