### PR TITLE
Reexport piet and kurbo from piet-common

### DIFF
--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -1,29 +1,39 @@
-//! Selection of a common back-end for piet.
+//! A piet backend appropriate for the current platform.
+//!
+//! This crate reexports the [piet crate][piet], alongside an appropriate backend
+//! for the given platform. It also exposes [kurbo][], which defines shape and
+//! curve types useful in drawing.
+//!
+//! The intention of this crate is to provide a single dependency that handles
+//! the common piet use-case. If you have more complicated needs (such as
+//! supporting multiple backends simultaneously) you should use crates such as
+//! [piet][] and [piet-cairo][] directly.
+//!
+//! [piet]: https://crates.io/crates/piet
+//! [kurbo]: https://crates.io/crates/kurbo
+//! [piet-cairo]: https://crates.io/crates/piet-cairo
+
+pub use piet::*;
+
+#[doc(hidden)]
+pub use piet::kurbo;
 
 #[cfg(any(
     feature = "cairo",
     not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
 ))]
-mod cairo_back;
-
-#[cfg(any(
-    feature = "cairo",
-    not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
-))]
-pub use crate::cairo_back::*;
+#[path = "cairo_back.rs"]
+mod backend;
 
 #[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
-mod direct2d_back;
-
-#[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
-pub use crate::direct2d_back::*;
+#[path = "direct2d_back.rs"]
+mod backend;
 
 #[cfg(any(feature = "web", target_arch = "wasm32"))]
-mod back {
+mod backend {
     pub use piet_web::*;
-
     pub type Piet<'a> = WebRenderContext<'a>;
 }
 
-#[cfg(any(feature = "web", target_arch = "wasm32"))]
-pub use crate::back::*;
+#[doc(hidden)]
+pub use backend::*;


### PR DESCRIPTION
The intention of this patch is to make it so that piet-common becomes
the only dependency necessary in order to get up and running with piet.

In addition, this improves documentation and cleans up the code that
selects the backend.

This is follow up on #52, and closes #54; I think this is a good enough solution.

I hope to do a batch of releases shortly after this lands, so that I can start cleaning up druid, using the new `Point` and `Size` types in kurbo.