### PR TITLE
Add a `new` method to d2d text

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -312,6 +312,16 @@ fn set_gradient_stops(dst: &mut impl cairo::Gradient, src: &[GradientStop]) {
     }
 }
 
+impl CairoText {
+    /// Create a new factory that satisfies the piet `Text` trait.
+    ///
+    /// No state is needed for now because the current implementation is just
+    /// toy text, but that will change when proper text is implemented.
+    pub fn new() -> CairoText {
+        CairoText
+    }
+}
+
 impl Text for CairoText {
     type Font = CairoFont;
     type FontBuilder = CairoFontBuilder;

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -443,6 +443,14 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     }
 }
 
+impl<'a> D2DText<'a> {
+    /// Create a new factory that satisfies the piet `Text` trait given
+    /// the (platform-specific) dwrite factory.
+    pub fn new(dwrite: &'a directwrite::Factory) -> D2DText<'a> {
+        D2DText { dwrite }
+    }
+}
+
 impl<'a> Text for D2DText<'a> {
     type FontBuilder = D2DFontBuilder<'a>;
     type Font = D2DFont;


### PR DESCRIPTION
This will be necessary to plumb a text layout context.

WIP, a similar change should be made for cairo and web impls.