### PR TITLE
Report x advance for cairo text width

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -496,6 +496,6 @@ impl TextLayoutBuilder for CairoTextLayoutBuilder {
 
 impl TextLayout for CairoTextLayout {
     fn width(&self) -> f64 {
-        self.font.text_extents(&self.text).width
+        self.font.text_extents(&self.text).x_advance
     }
 }


### PR DESCRIPTION
For layout purposes, we want the x advance of the text, rather than
the width of the "inked" rectangle, which is what we had before.