### PR TITLE
Add Color::hlc constructor

### DIFF
--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -44,7 +44,8 @@ impl Color {
         Color::rgba32((r << 24) | (g << 16) | (b << 8) | 0xff)
     }
 
-    /// Create a color from an HLC (aka CIEHLC) specification.
+    /// Create a color from a CIEL\*a\*b\* polar (also known as CIE HCL)
+    /// specification.
     ///
     /// The `h` parameter is an angle in degrees, with 0 roughly magenta, 90
     /// roughly yellow, 180 roughly cyan, and 270 roughly blue. The `l`
@@ -61,7 +62,7 @@ impl Color {
     /// which is perhaps not ideal (the clipping might change the hue). See
     /// https://github.com/d3/d3-color/issues/33 for discussion.
     #[allow(non_snake_case)]
-    pub fn hlc<F: Into<f64>>(h: F, l: F, c: F) -> Color {
+    pub fn cielab_hlc<F: Into<f64>>(h: F, l: F, c: F) -> Color {
         // The reverse transformation from Lab to XYZ, see
         // https://en.wikipedia.org/wiki/CIELAB_color_space
         fn f_inv(t: f64) -> f64 {
@@ -108,11 +109,11 @@ impl Color {
         Color::rgb(gamma(r_lin), gamma(g_lin), gamma(b_lin))
     }
 
-    /// Create a color from an HLC specification and alpha.
+    /// Create a color from a CIEL\*a\*b\* polar specification and alpha.
     ///
     /// The `a` value represents alpha in the range 0.0 to 1.0.
-    pub fn hlca<F: Into<f64>>(h: F, l: F, c: F, a: impl Into<f64>) -> Color {
-        Color::hlc(h, c, l).with_alpha(a)
+    pub fn cielab_hlca<F: Into<f64>>(h: F, l: F, c: F, a: impl Into<f64>) -> Color {
+        Color::cielab_hlc(h, c, l).with_alpha(a)
     }
 
     /// Change just the alpha value of a color.

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -46,9 +46,20 @@ impl Color {
 
     /// Create a color from an HLC (aka CIEHLC) specification.
     ///
+    /// The `h` parameter is an angle in degrees, with 0 roughly magenta, 90
+    /// roughly yellow, 180 roughly cyan, and 270 roughly blue. The `l`
+    /// parameter is perceptual luminance, with 0 black and 100 white.
+    /// The `c` parameter is a chrominance concentration, with 0 grayscale
+    /// and a nominal maximum of 127 (in the future, higher values might
+    /// be useful, for high gamut contexts).
+    ///
     /// Currently this is just converted into sRGB, but in the future as we
     /// support high-gamut colorspaces, it can be used to specify more colors
     /// or existing colors with a higher accuracy.
+    ///
+    /// Currently out-of-gamut values are clipped to the nearest sRGB color,
+    /// which is perhaps not ideal (the clipping might change the hue). See
+    /// https://github.com/d3/d3-color/issues/33 for discussion.
     #[allow(non_snake_case)]
     pub fn hlc<F: Into<f64>>(h: F, l: F, c: F) -> Color {
         // The reverse transformation from Lab to XYZ, see

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -44,6 +44,62 @@ impl Color {
         Color::rgba32((r << 24) | (g << 16) | (b << 8) | 0xff)
     }
 
+    /// Create a color from an HLC (aka CIEHLC) specification.
+    ///
+    /// Currently this is just converted into sRGB, but in the future as we
+    /// support high-gamut colorspaces, it can be used to specify more colors
+    /// or existing colors with a higher accuracy.
+    #[allow(non_snake_case)]
+    pub fn hlc<F: Into<f64>>(h: F, l: F, c: F) -> Color {
+        // The reverse transformation from Lab to XYZ, see
+        // https://en.wikipedia.org/wiki/CIELAB_color_space
+        fn f_inv(t: f64) -> f64 {
+            let d = 6. / 29.;
+            if t > d {
+                t.powi(3)
+            } else {
+                3. * d * d * (t - 4. / 29.)
+            }
+        }
+        let th = h.into() * (std::f64::consts::PI / 180.);
+        let c = c.into();
+        let a = c * th.cos();
+        let b = c * th.sin();
+        let L = l.into();
+        let ll = (L + 16.) * (1. / 116.);
+        // Produce XYZ values scaled to D65 white reference
+        let X = 0.9505 * f_inv(ll + a * (1. / 500.));
+        let Y = f_inv(ll);
+        let Z = 1.0890 * f_inv(ll - b * (1. / 200.));
+        // See https://en.wikipedia.org/wiki/SRGB
+        let r_lin = 3.2406 * X - 1.5372 * Y - 0.4986 * Z;
+        let g_lin = -0.9689 * X + 1.8758 * Y + 0.0415 * Z;
+        let b_lin = 0.0557 * X - 0.2040 * Y + 1.0570 * Z;
+        fn gamma(u: f64) -> f64 {
+            if u <= 0.0031308 {
+                12.92 * u
+            } else {
+                1.055 * u.powf(1. / 2.4) - 0.055
+            }
+        }
+        Color::rgb(gamma(r_lin), gamma(g_lin), gamma(b_lin))
+    }
+
+    /// Create a color from an HLC specification and alpha.
+    ///
+    /// The `a` value represents alpha in the range 0.0 to 1.0.
+    pub fn hlca<F: Into<f64>>(h: F, l: F, c: F, a: impl Into<f64>) -> Color {
+        Color::hlc(h, c, l).with_alpha(a)
+    }
+
+    /// Change just the alpha value of a color.
+    ///
+    /// The `a` value represents alpha in the range 0.0 to 1.0.
+    pub fn with_alpha(self, a: impl Into<f64>) -> Color {
+        let a = (a.into().max(0.0).min(1.0) * 255.0).round() as u32;
+        Color::rgba32((self.as_rgba32() & !0xff) | a)
+    }
+
     /// Convert a color value to a 32-bit rgba value.
     pub fn as_rgba32(&self) -> u32 {
         match *self {


### PR DESCRIPTION
Provide a method to construct colors based on the CIE HLC color space,
which is both colorimetrically sound and useful for communication; it
is the space advocated by freiefarbe.de.

Currently the implementation just creates an 8-bit per channel sRGB
value, but as we adopt high-gamut spaces we can make a better color
from the same inputs, so hopefully clients won't have to change.