### PR TITLE
Don't apply transform to d2 clip mask

### DIFF
--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -301,12 +301,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         // TODO: we get a use-after-free crash if we don't do this. Almost certainly
         // this will be fixed in direct2d 0.3, so remove workaround when upgrading.
         let _clone = path.clone();
-        let transform = affine_to_matrix3x2f(self.current_transform());
-        self.rt
-            .push_layer(&layer)
-            .with_mask(path)
-            .with_mask_transform(transform)
-            .push();
+        self.rt.push_layer(&layer).with_mask(path).push();
         self.ctx_stack.last_mut().unwrap().n_layers_pop += 1;
     }
 


### PR DESCRIPTION
I thought you explictly had to add a transform to a clip mask, but
it turns out it applies the current transform. So the old code was
actually doing the transform twice.