### PR TITLE
Expose associated types

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -36,6 +36,7 @@ impl<'a> CairoRenderContext<'a> {
     }
 }
 
+#[derive(Clone)]
 pub enum Brush {
     Solid(u32),
     Linear(cairo::LinearGradient),

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -6,10 +6,46 @@ use cairo::{Context, Format, ImageSurface};
 
 use piet::{ErrorKind, ImageFormat};
 
+#[doc(hidden)]
 pub use piet_cairo::*;
 
 /// The `RenderContext` for the Cairo backend, which is selected.
 pub type Piet<'a> = CairoRenderContext<'a>;
+
+/// The associated brush type for this backend.
+///
+/// This type matches `RenderContext::Brush`
+pub type Brush = piet_cairo::Brush;
+
+/// The associated text factory for this backend.
+///
+/// This type matches `RenderContext::Text`
+pub type PietText<'a> = CairoText;
+
+/// The associated font type for this backend.
+///
+/// This type matches `RenderContext::Text::Font`
+pub type PietFont = CairoFont;
+
+/// The associated font builder for this backend.
+///
+/// This type matches `RenderContext::Text::FontBuilder`
+pub type PietFontBuilder<'a> = CairoFontBuilder;
+
+/// The associated text layout type for this backend.
+///
+/// This type matches `RenderContext::Text::TextLayout`
+pub type PietTextLayout = CairoTextLayout;
+
+/// The associated text layout builder for this backend.
+///
+/// This type matches `RenderContext::Text::TextLayoutBuilder`
+pub type PietTextLayoutBuilder<'a> = CairoTextLayoutBuilder;
+
+/// The associated image type for this backend.
+///
+/// This type matches `RenderContext::Image`
+pub type Image = ImageSurface;
 
 /// A struct that can be used to create bitmap render contexts.
 ///

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -12,10 +12,46 @@ use dxgi::flags::Format;
 
 use piet::{ErrorKind, ImageFormat};
 
+#[doc(hidden)]
 pub use piet_direct2d::*;
 
 /// The `RenderContext` for the Direct2D backend, which is selected.
 pub type Piet<'a> = D2DRenderContext<'a>;
+
+/// The associated brush type for this backend.
+///
+/// This type matches `RenderContext::Brush`
+pub type Brush = GenericBrush;
+
+/// The associated text factory for this backend.
+///
+/// This type matches `RenderContext::Text`
+pub type PietText<'a> = D2DText<'a>;
+
+/// The associated font type for this backend.
+///
+/// This type matches `RenderContext::Text::Font`
+pub type PietFont = D2DFont;
+
+/// The associated font builder for this backend.
+///
+/// This type matches `RenderContext::Text::FontBuilder`
+pub type PietFontBuilder<'a> = D2DFontBuilder<'a>;
+
+/// The associated text layout type for this backend.
+///
+/// This type matches `RenderContext::Text::TextLayout`
+pub type PietTextLayout = D2DTextLayout;
+
+/// The associated text layout builder for this backend.
+///
+/// This type matches `RenderContext::Text::TextLayoutBuilder`
+pub type PietTextLayoutBuilder<'a> = D2DTextLayoutBuilder<'a>;
+
+/// The associated image type for this backend.
+///
+/// This type matches `RenderContext::Image`
+pub type Image = Bitmap;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -9,6 +9,17 @@
 //! supporting multiple backends simultaneously) you should use crates such as
 //! [piet][] and [piet-cairo][] directly.
 //!
+//! The associated types for brushes, text, and images are exported as type
+//! definitions (resolving to concrete types within the backend), so they can
+//! be used directly. The text-related types are prefixed with "Piet" to avoid
+//! conflict with the text traits that would otherwise have the same name.
+//!
+//! Also note that all public types for the specific backend are re-exported,
+//! but have their docs hidden here. These types can be useful for platform
+//! integration, and also potentially to access extensions specific to the
+//! backend. The types documented below can be used portable across all
+//! backends.
+//!
 //! [piet]: https://crates.io/crates/piet
 //! [kurbo]: https://crates.io/crates/kurbo
 //! [piet-cairo]: https://crates.io/crates/piet-cairo
@@ -30,10 +41,7 @@ mod backend;
 mod backend;
 
 #[cfg(any(feature = "web", target_arch = "wasm32"))]
-mod backend {
-    pub use piet_web::*;
-    pub type Piet<'a> = WebRenderContext<'a>;
-}
+#[path = "web_back.rs"]
+mod backend;
 
-#[doc(hidden)]
 pub use backend::*;

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -1,0 +1,40 @@
+//! Support for piet Web back-end.
+
+#[doc(hidden)]
+pub use piet_web::*;
+pub type Piet<'a> = WebRenderContext<'a>;
+
+/// The associated brush type for this backend.
+///
+/// This type matches `RenderContext::Brush`
+pub type Brush = piet_web::Brush;
+
+/// The associated text factory for this backend.
+///
+/// This type matches `RenderContext::Text`
+pub type PietText<'a> = WebRenderContext<'a>;
+
+/// The associated font type for this backend.
+///
+/// This type matches `RenderContext::Text::Font`
+pub type PietFont = WebFont;
+
+/// The associated font builder for this backend.
+///
+/// This type matches `RenderContext::Text::FontBuilder`
+pub type PietFontBuilder<'a> = WebFontBuilder;
+
+/// The associated text layout type for this backend.
+///
+/// This type matches `RenderContext::Text::TextLayout`
+pub type PietTextLayout = WebTextLayout;
+
+/// The associated text layout builder for this backend.
+///
+/// This type matches `RenderContext::Text::TextLayoutBuilder`
+pub type PietTextLayoutBuilder<'a> = WebTextLayoutBuilder;
+
+/// The associated image type for this backend.
+///
+/// This type matches `RenderContext::Image`
+pub type Image = WebImage;

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -18,7 +18,8 @@ use dxgi::Format;
 
 use direct2d::brush::gradient::linear::LinearGradientBrushBuilder;
 use direct2d::brush::gradient::radial::RadialGradientBrushBuilder;
-use direct2d::brush::{Brush, GenericBrush, SolidColorBrush};
+pub use direct2d::brush::GenericBrush;
+use direct2d::brush::{Brush, SolidColorBrush};
 use direct2d::enums::{
     AlphaMode, BitmapInterpolationMode, DrawTextOptions, FigureBegin, FigureEnd, FillMode,
 };

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -34,6 +34,7 @@ impl<'a> WebRenderContext<'a> {
     }
 }
 
+#[derive(Clone)]
 pub enum Brush {
     Solid(u32),
     Gradient(CanvasGradient),


### PR DESCRIPTION
This patch exposes the backend-specific associated types for brushes,
text layout, and images.

It has similar goals as #37, but actually exposes all types as concrete
types, not just as type aliases for associated types. When these types
are hidden (as was the case for `Brush` in the d2d backend) then doing
an impl of a trait on the type causes coherence problems.

Also some updates to the documentation, making sure the new types (as
well as the `Piet` type alias) show up in documentation.