### PR TITLE
More ergonomic brushes

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -104,7 +104,7 @@ impl<T> WrapError<T> for Result<T, Status> {
 macro_rules! set_gradient_stops {
     ($dst: expr, $stops: expr) => {
         for stop in $stops {
-            let rgba = stop.color.as_rgba32();
+            let rgba = stop.color.as_rgba_u32();
             $dst.add_color_stop_rgba(
                 stop.pos as f64,
                 byte_to_frac(rgba >> 24),
@@ -135,7 +135,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     }
 
     fn clear(&mut self, color: Color) {
-        let rgba = color.as_rgba32();
+        let rgba = color.as_rgba_u32();
         self.ctx.set_source_rgb(
             byte_to_frac(rgba >> 24),
             byte_to_frac(rgba >> 16),
@@ -145,7 +145,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     }
 
     fn solid_brush(&mut self, color: Color) -> Brush {
-        Brush::Solid(color.as_rgba32())
+        Brush::Solid(color.as_rgba_u32())
     }
 
     fn gradient(&mut self, gradient: FixedGradient) -> Result<Brush, Error> {

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -190,16 +190,24 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.ctx.clip();
     }
 
-    fn stroke(
+    fn stroke(&mut self, shape: impl Shape, brush: &impl IBrush<Self>, width: f64) {
+        let brush = brush.make_brush(self, || shape.bounding_box());
+        self.set_path(shape);
+        self.set_stroke(width, None);
+        self.set_brush(&*brush);
+        self.ctx.stroke();
+    }
+
+    fn stroke_styled(
         &mut self,
         shape: impl Shape,
         brush: &impl IBrush<Self>,
         width: f64,
-        style: Option<&StrokeStyle>,
+        style: &StrokeStyle,
     ) {
         let brush = brush.make_brush(self, || shape.bounding_box());
         self.set_path(shape);
-        self.set_stroke(width, style);
+        self.set_stroke(width, Some(style));
         self.set_brush(&*brush);
         self.ctx.stroke();
     }

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -11,8 +11,8 @@ use cairo::{
 use piet::kurbo::{Affine, PathEl, Point, QuadBez, Rect, Shape};
 
 use piet::{
-    new_error, Color, Error, ErrorKind, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode,
-    LineCap, LineJoin, RawGradient, RenderContext, RoundInto, StrokeStyle, Text, TextLayout,
+    new_error, Color, Error, ErrorKind, FixedGradient, Font, FontBuilder, IBrush, ImageFormat,
+    InterpolationMode, LineCap, LineJoin, RenderContext, RoundInto, StrokeStyle, Text, TextLayout,
     TextLayoutBuilder,
 };
 
@@ -148,16 +148,16 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         Brush::Solid(color.as_rgba32())
     }
 
-    fn gradient(&mut self, gradient: RawGradient) -> Result<Brush, Error> {
+    fn gradient(&mut self, gradient: FixedGradient) -> Result<Brush, Error> {
         match gradient {
-            RawGradient::Linear(linear) => {
+            FixedGradient::Linear(linear) => {
                 let (x0, y0) = (linear.start.x, linear.start.y);
                 let (x1, y1) = (linear.end.x, linear.end.y);
                 let lg = cairo::LinearGradient::new(x0, y0, x1, y1);
                 set_gradient_stops!(&lg, &linear.stops);
                 Ok(Brush::Linear(lg))
             }
-            RawGradient::Radial(radial) => {
+            FixedGradient::Radial(radial) => {
                 let (xc, yc) = (radial.center.x, radial.center.y);
                 let (xo, yo) = (radial.origin_offset.x, radial.origin_offset.y);
                 let r = radial.radius;

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -11,7 +11,7 @@ fn main() {
     let mut rc = bitmap.render_context();
     rc.clear(Color::WHITE);
     let brush = rc.solid_brush(Color::rgb24(0x00_00_80));
-    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None);
+    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
     rc.finish().unwrap();
     let raw_pixels = bitmap.into_raw_pixels(ImageFormat::RgbaPremul).unwrap();
     image::save_buffer(

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -10,7 +10,7 @@ fn main() {
     let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();
     let mut rc = bitmap.render_context();
     rc.clear(Color::WHITE);
-    let brush = rc.solid_brush(Color::rgb24(0x00_00_80));
+    let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
     rc.finish().unwrap();
     let raw_pixels = bitmap.into_raw_pixels(ImageFormat::RgbaPremul).unwrap();

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -91,7 +91,7 @@ pub(crate) fn rect_to_rectf(rect: Rect) -> RectF {
 }
 
 pub(crate) fn color_to_colorf(color: Color) -> ColorF {
-    let rgba = color.as_rgba32();
+    let rgba = color.as_rgba_u32();
     (rgba >> 8, ((rgba & 255) as f32) * (1.0 / 255.0)).into()
 }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -210,7 +210,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     }
 
     fn clear(&mut self, color: Color) {
-        self.rt.clear(color.as_rgba32() >> 8);
+        self.rt.clear(color.as_rgba_u32() >> 8);
     }
 
     fn solid_brush(&mut self, color: Color) -> GenericBrush {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -37,8 +37,8 @@ use directwrite::TextFormat;
 use piet::kurbo::{Affine, PathEl, Point, Rect, Shape};
 
 use piet::{
-    new_error, Color, Error, ErrorKind, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode,
-    RawGradient, RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
+    new_error, Color, Error, ErrorKind, FixedGradient, Font, FontBuilder, IBrush, ImageFormat,
+    InterpolationMode, RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
 pub struct D2DRenderContext<'a> {
@@ -222,9 +222,9 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             .to_generic() // This does an extra COM clone; avoid somehow?
     }
 
-    fn gradient(&mut self, gradient: RawGradient) -> Result<GenericBrush, Error> {
+    fn gradient(&mut self, gradient: FixedGradient) -> Result<GenericBrush, Error> {
         match gradient {
-            RawGradient::Linear(linear) => {
+            FixedGradient::Linear(linear) => {
                 let mut builder = LinearGradientBrushBuilder::new(&self.rt)
                     .with_start(to_point2f(linear.start))
                     .with_end(to_point2f(linear.end));
@@ -235,7 +235,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                 // Same concern about extra COM clone as above.
                 Ok(brush.to_generic())
             }
-            RawGradient::Radial(radial) => {
+            FixedGradient::Radial(radial) => {
                 let radius = radial.radius as f32;
                 let mut builder = RadialGradientBrushBuilder::new(&self.rt)
                     .with_center(to_point2f(radial.center))

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -3,8 +3,8 @@
 use piet::kurbo::{Affine, BezPath, Line, Point, Rect, Vec2};
 
 use piet::{
-    Color, Error, FillRule, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text,
-    TextLayout, TextLayoutBuilder,
+    Color, Error, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayout,
+    TextLayoutBuilder,
 };
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
@@ -22,7 +22,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     path.move_to((10.0, 20.0));
     path.curve_to((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
     let brush = rc.solid_brush(Color::rgba32(0x00_00_80_C0));
-    rc.fill(path, &brush, FillRule::NonZero);
+    rc.fill(path, &brush);
 
     let font = rc.text().new_font_by_name("Segoe UI", 12.0)?.build()?;
     let layout = rc.text().new_text_layout(&font, "Hello piet!")?.build()?;
@@ -47,7 +47,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     );
 
     let clip_path = star(Point::new(90.0, 45.0), 10.0, 30.0, 24);
-    rc.clip(clip_path, FillRule::NonZero);
+    rc.clip(clip_path);
     let layout = rc.text().new_text_layout(&font, "Clipped text")?.build()?;
     rc.draw_text(&layout, (80.0, 50.0), &brush);
     Ok(())

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -10,13 +10,13 @@ use piet::{
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let brush = rc.solid_brush(Color::rgb24(0x00_00_80));
-    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0, None);
+    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
 
     let mut path = BezPath::new();
     path.move_to((50.0, 10.0));
     path.quad_to((60.0, 50.0), (100.0, 90.0));
     let brush = rc.solid_brush(Color::rgb24(0x00_80_00));
-    rc.stroke(path, &brush, 1.0, None);
+    rc.stroke(path, &brush, 1.0);
 
     let mut path = BezPath::new();
     path.move_to((10.0, 20.0));
@@ -30,7 +30,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let brush = rc.solid_brush(Color::rgba32(0x80_00_00_C0));
     rc.draw_text(&layout, (80.0, 10.0), &brush);
 
-    rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &brush, 1.0, None);
+    rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &brush, 1.0);
 
     rc.with_save(|rc| {
         rc.transform(Affine::rotate(0.1));

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -9,25 +9,25 @@ use piet::{
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::WHITE);
-    let brush = rc.solid_brush(Color::rgb24(0x00_00_80));
+    let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
 
     let mut path = BezPath::new();
     path.move_to((50.0, 10.0));
     path.quad_to((60.0, 50.0), (100.0, 90.0));
-    let brush = rc.solid_brush(Color::rgb24(0x00_80_00));
+    let brush = rc.solid_brush(Color::rgb8(0x00, 0x80, 0x00));
     rc.stroke(path, &brush, 1.0);
 
     let mut path = BezPath::new();
     path.move_to((10.0, 20.0));
     path.curve_to((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
-    let brush = rc.solid_brush(Color::rgba32(0x00_00_80_C0));
+    let brush = rc.solid_brush(Color::rgba8(0x00, 0x00, 0x80, 0xC0));
     rc.fill(path, &brush);
 
     let font = rc.text().new_font_by_name("Segoe UI", 12.0)?.build()?;
     let layout = rc.text().new_text_layout(&font, "Hello piet!")?.build()?;
     let w: f64 = layout.width().into();
-    let brush = rc.solid_brush(Color::rgba32(0x80_00_00_C0));
+    let brush = rc.solid_brush(Color::rgba8(0x80, 0x00, 0x00, 0xC0));
     rc.draw_text(&layout, (80.0, 10.0), &brush);
 
     rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &brush, 1.0);

--- a/piet-test/src/picture_1.rs
+++ b/piet-test/src/picture_1.rs
@@ -2,7 +2,7 @@
 
 use piet::kurbo::{BezPath, Line, Point};
 
-use piet::{Color, Error, FillRule, RenderContext};
+use piet::{Color, Error, RenderContext};
 
 // TODO: this will eventually become a `kurbo::Shape`.
 fn circle<V: Into<Point>>(center: V, radius: f64, num_segments: usize) -> BezPath {
@@ -53,7 +53,7 @@ fn draw_cubic_bezier<V: Into<Point>>(
 
     for p in [p0, p1, p2, p3].into_iter() {
         let dot = circle(*p, 1.5, 20);
-        rc.fill(&dot, &handle_brush, FillRule::NonZero);
+        rc.fill(&dot, &handle_brush);
     }
     Ok(())
 }

--- a/piet-test/src/picture_1.rs
+++ b/piet-test/src/picture_1.rs
@@ -44,10 +44,10 @@ fn draw_cubic_bezier<V: Into<Point>>(
     let mut path = BezPath::new();
     path.move_to(p0);
     path.curve_to(p1, p2, p3);
-    let curve_brush = rc.solid_brush(Color::rgb24(0x00_80_00));
+    let curve_brush = rc.solid_brush(Color::rgb8(0x00, 0x80, 0x00));
     rc.stroke(&path, &curve_brush, 3.0);
 
-    let handle_brush = rc.solid_brush(Color::rgb24(0x00_00_80));
+    let handle_brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
     rc.stroke(&Line::new(p0, p1), &handle_brush, 1.0);
     rc.stroke(&Line::new(p2, p3), &handle_brush, 1.0);
 

--- a/piet-test/src/picture_1.rs
+++ b/piet-test/src/picture_1.rs
@@ -45,11 +45,11 @@ fn draw_cubic_bezier<V: Into<Point>>(
     path.move_to(p0);
     path.curve_to(p1, p2, p3);
     let curve_brush = rc.solid_brush(Color::rgb24(0x00_80_00));
-    rc.stroke(&path, &curve_brush, 3.0, None);
+    rc.stroke(&path, &curve_brush, 3.0);
 
     let handle_brush = rc.solid_brush(Color::rgb24(0x00_00_80));
-    rc.stroke(&Line::new(p0, p1), &handle_brush, 1.0, None);
-    rc.stroke(&Line::new(p2, p3), &handle_brush, 1.0, None);
+    rc.stroke(&Line::new(p0, p1), &handle_brush, 1.0);
+    rc.stroke(&Line::new(p2, p3), &handle_brush, 1.0);
 
     for p in [p0, p1, p2, p3].into_iter() {
         let dot = circle(*p, 1.5, 20);

--- a/piet-test/src/picture_3.rs
+++ b/piet-test/src/picture_3.rs
@@ -12,7 +12,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     path.line_to((20.0, 0.0));
     path.line_to((6.0, 10.0));
     let mut y = 5.0;
-    let brush = rc.solid_brush(Color::rgb24(0x00_00_C0));
+    let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0xC0));
     for line_cap in &[LineCap::Butt, LineCap::Round, LineCap::Square] {
         let mut x = 5.0;
         for line_join in &[LineJoin::Bevel, LineJoin::Miter, LineJoin::Round] {

--- a/piet-test/src/picture_3.rs
+++ b/piet-test/src/picture_3.rs
@@ -22,7 +22,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
                 rc.transform(Affine::translate((x, y)));
                 style.set_line_cap(*line_cap);
                 style.set_line_join(*line_join);
-                rc.stroke(&path, &brush, width, Some(&style));
+                rc.stroke_styled(&path, &brush, width, &style);
                 Ok(())
             })?;
             x += 30.0;
@@ -37,7 +37,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         let mut style = StrokeStyle::new();
         dashes.push((i + 1) as f64);
         style.set_dash(dashes.clone(), 0.0);
-        rc.stroke(Line::new((x, y), (x + 50.0, y)), &brush, 2.0, Some(&style));
+        rc.stroke_styled(Line::new((x, y), (x + 50.0, y)), &brush, 2.0, &style);
         y += 10.0;
     }
     Ok(())

--- a/piet-test/src/picture_4.rs
+++ b/piet-test/src/picture_4.rs
@@ -1,9 +1,10 @@
 //! Gradients.
 
-use piet::kurbo::{Rect, Vec2};
+use piet::kurbo::{Point, Rect, Vec2};
 
 use piet::{
-    Color, Error, FillRule, Gradient, GradientStop, LinearGradient, RadialGradient, RenderContext,
+    Color, Error, FillRule, GradientStop, RawGradient, RawLinearGradient, RawRadialGradient,
+    RenderContext,
 };
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
@@ -18,8 +19,8 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
             color: Color::rgb24(0x00_00_00),
         },
     ];
-    let gradient = rc.gradient(Gradient::Radial(RadialGradient {
-        center: Vec2::new(30.0, 30.0),
+    let gradient = rc.gradient(RawGradient::Radial(RawRadialGradient {
+        center: Point::new(30.0, 30.0),
         origin_offset: Vec2::new(10.0, 10.0),
         radius: 30.0,
         stops,
@@ -39,9 +40,9 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
             color: Color::rgb24(0x00_00_00),
         },
     ];
-    let gradient2 = rc.gradient(Gradient::Linear(LinearGradient {
-        start: Vec2::new(0.0, 0.0),
-        end: Vec2::new(60.0, 0.0),
+    let gradient2 = rc.gradient(RawGradient::Linear(RawLinearGradient {
+        start: Point::new(0.0, 0.0),
+        end: Point::new(60.0, 0.0),
         stops: stops2,
     }))?;
     rc.fill(

--- a/piet-test/src/picture_4.rs
+++ b/piet-test/src/picture_4.rs
@@ -3,7 +3,8 @@
 use piet::kurbo::{Point, Rect, Vec2};
 
 use piet::{
-    Color, Error, GradientStop, RawGradient, RawLinearGradient, RawRadialGradient, RenderContext,
+    Color, Error, FixedGradient, FixedLinearGradient, FixedRadialGradient, GradientStop,
+    RenderContext,
 };
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
@@ -18,7 +19,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
             color: Color::rgb24(0x00_00_00),
         },
     ];
-    let gradient = rc.gradient(RawGradient::Radial(RawRadialGradient {
+    let gradient = rc.gradient(FixedGradient::Radial(FixedRadialGradient {
         center: Point::new(30.0, 30.0),
         origin_offset: Vec2::new(10.0, 10.0),
         radius: 30.0,
@@ -35,7 +36,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
             color: Color::rgb24(0x00_00_00),
         },
     ];
-    let gradient2 = rc.gradient(RawGradient::Linear(RawLinearGradient {
+    let gradient2 = rc.gradient(FixedGradient::Linear(FixedLinearGradient {
         start: Point::new(0.0, 0.0),
         end: Point::new(60.0, 0.0),
         stops: stops2,

--- a/piet-test/src/picture_4.rs
+++ b/piet-test/src/picture_4.rs
@@ -3,8 +3,7 @@
 use piet::kurbo::{Point, Rect, Vec2};
 
 use piet::{
-    Color, Error, FillRule, GradientStop, RawGradient, RawLinearGradient, RawRadialGradient,
-    RenderContext,
+    Color, Error, GradientStop, RawGradient, RawLinearGradient, RawRadialGradient, RenderContext,
 };
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
@@ -25,11 +24,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         radius: 30.0,
         stops,
     }))?;
-    rc.fill(
-        Rect::new(0.0, 0.0, 60.0, 60.0),
-        &gradient,
-        FillRule::NonZero,
-    );
+    rc.fill(Rect::new(0.0, 0.0, 60.0, 60.0), &gradient);
     let stops2 = vec![
         GradientStop {
             pos: 0.0,
@@ -45,10 +40,6 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         end: Point::new(60.0, 0.0),
         stops: stops2,
     }))?;
-    rc.fill(
-        Rect::new(0.0, 80.0, 60.0, 100.0),
-        &gradient2,
-        FillRule::NonZero,
-    );
+    rc.fill(Rect::new(0.0, 80.0, 60.0, 100.0), &gradient2);
     Ok(())
 }

--- a/piet-test/src/picture_4.rs
+++ b/piet-test/src/picture_4.rs
@@ -12,11 +12,11 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let stops = vec![
         GradientStop {
             pos: 0.0,
-            color: Color::rgb24(0xff_ff_ff),
+            color: Color::WHITE,
         },
         GradientStop {
             pos: 1.0,
-            color: Color::rgb24(0x00_00_00),
+            color: Color::BLACK,
         },
     ];
     let gradient = rc.gradient(FixedGradient::Radial(FixedRadialGradient {
@@ -29,11 +29,11 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let stops2 = vec![
         GradientStop {
             pos: 0.0,
-            color: Color::rgb24(0xff_ff_ff),
+            color: Color::WHITE,
         },
         GradientStop {
             pos: 1.0,
-            color: Color::rgb24(0x00_00_00),
+            color: Color::BLACK,
         },
     ];
     let gradient2 = rc.gradient(FixedGradient::Linear(FixedLinearGradient {

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -188,16 +188,24 @@ impl<'a> RenderContext for WebRenderContext<'a> {
             .clip_with_canvas_winding_rule(CanvasWindingRule::Nonzero);
     }
 
-    fn stroke(
+    fn stroke(&mut self, shape: impl Shape, brush: &impl IBrush<Self>, width: f64) {
+        let brush = brush.make_brush(self, || shape.bounding_box());
+        self.set_path(shape);
+        self.set_stroke(width, None);
+        self.set_brush(&*brush.deref(), false);
+        self.ctx.stroke();
+    }
+
+    fn stroke_styled(
         &mut self,
         shape: impl Shape,
         brush: &impl IBrush<Self>,
         width: f64,
-        style: Option<&StrokeStyle>,
+        style: &StrokeStyle,
     ) {
         let brush = brush.make_brush(self, || shape.bounding_box());
         self.set_path(shape);
-        self.set_stroke(width, style);
+        self.set_stroke(width, Some(style));
         self.set_brush(&*brush.deref(), false);
         self.ctx.stroke();
     }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -14,8 +14,9 @@ use web_sys::{
 use piet::kurbo::{Affine, PathEl, Point, Rect, Shape};
 
 use piet::{
-    Color, Error, Font, FontBuilder, GradientStop, IBrush, ImageFormat, InterpolationMode, LineCap,
-    LineJoin, RawGradient, RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
+    Color, Error, FixedGradient, Font, FontBuilder, GradientStop, IBrush, ImageFormat,
+    InterpolationMode, LineCap, LineJoin, RenderContext, StrokeStyle, Text, TextLayout,
+    TextLayoutBuilder,
 };
 
 pub struct WebRenderContext<'a> {
@@ -143,16 +144,16 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         Brush::Solid(color.as_rgba32())
     }
 
-    fn gradient(&mut self, gradient: RawGradient) -> Result<Brush, Error> {
+    fn gradient(&mut self, gradient: FixedGradient) -> Result<Brush, Error> {
         match gradient {
-            RawGradient::Linear(linear) => {
+            FixedGradient::Linear(linear) => {
                 let (x0, y0) = (linear.start.x, linear.start.y);
                 let (x1, y1) = (linear.end.x, linear.end.y);
                 let mut lg = self.ctx.create_linear_gradient(x0, y0, x1, y1);
                 set_gradient_stops(&mut lg, &linear.stops);
                 Ok(Brush::Gradient(lg))
             }
-            RawGradient::Radial(radial) => {
+            FixedGradient::Radial(radial) => {
                 let (xc, yc) = (radial.center.x, radial.center.y);
                 let (xo, yo) = (radial.origin_offset.x, radial.origin_offset.y);
                 let r = radial.radius;

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -141,7 +141,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     }
 
     fn solid_brush(&mut self, color: Color) -> Brush {
-        Brush::Solid(color.as_rgba32())
+        Brush::Solid(color.as_rgba_u32())
     }
 
     fn gradient(&mut self, gradient: FixedGradient) -> Result<Brush, Error> {
@@ -366,7 +366,7 @@ fn format_color(rgba: u32) -> String {
 fn set_gradient_stops(dst: &mut CanvasGradient, src: &[GradientStop]) {
     for stop in src {
         // TODO: maybe get error?
-        let rgba = stop.color.as_rgba32();
+        let rgba = stop.color.as_rgba_u32();
         let _ = dst.add_color_stop(stop.pos, &format_color(rgba));
     }
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -106,13 +106,6 @@ impl<T> WrapError<T> for Result<T, JsValue> {
     }
 }
 
-fn convert_fill_rule(fill_rule: piet::FillRule) -> CanvasWindingRule {
-    match fill_rule {
-        piet::FillRule::NonZero => CanvasWindingRule::Nonzero,
-        piet::FillRule::EvenOdd => CanvasWindingRule::Evenodd,
-    }
-}
-
 fn convert_line_cap(line_cap: LineCap) -> &'static str {
     match line_cap {
         LineCap::Butt => "butt",
@@ -173,18 +166,26 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         }
     }
 
-    fn fill(&mut self, shape: impl Shape, brush: &impl IBrush<Self>, fill_rule: piet::FillRule) {
+    fn fill(&mut self, shape: impl Shape, brush: &impl IBrush<Self>) {
         let brush = brush.make_brush(self, || shape.bounding_box());
         self.set_path(shape);
         self.set_brush(&*brush, true);
         self.ctx
-            .fill_with_canvas_winding_rule(convert_fill_rule(fill_rule));
+            .fill_with_canvas_winding_rule(CanvasWindingRule::Nonzero);
     }
 
-    fn clip(&mut self, shape: impl Shape, fill_rule: piet::FillRule) {
+    fn fill_even_odd(&mut self, shape: impl Shape, brush: &impl IBrush<Self>) {
+        let brush = brush.make_brush(self, || shape.bounding_box());
+        self.set_path(shape);
+        self.set_brush(&*brush, true);
+        self.ctx
+            .fill_with_canvas_winding_rule(CanvasWindingRule::Evenodd);
+    }
+
+    fn clip(&mut self, shape: impl Shape) {
         self.set_path(shape);
         self.ctx
-            .clip_with_canvas_winding_rule(convert_fill_rule(fill_rule));
+            .clip_with_canvas_winding_rule(CanvasWindingRule::Nonzero);
     }
 
     fn stroke(

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -19,6 +19,16 @@ impl Debug for Color {
 }
 
 impl Color {
+    /// Create a color from 8 bit per sample RGB values.
+    pub const fn rgb8(r: u8, g: u8, b: u8) -> Color {
+        Color::rgba32(((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | 0xff)
+    }
+
+    /// Create a color from 8 bit per sample RGBA values.
+    pub const fn rgba8(r: u8, g: u8, b: u8, a: u8) -> Color {
+        Color::rgba32(((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | (a as u32))
+    }
+
     /// Create a color from a 32-bit rgba value (alpha as least significant byte).
     pub const fn rgba32(rgba: u32) -> Color {
         Color::Rgba32(rgba)
@@ -140,8 +150,8 @@ impl Color {
     }
 
     /// Opaque white.
-    pub const WHITE: Color = Color::rgba32(0xff_ff_ff_ff);
+    pub const WHITE: Color = Color::rgb8(0xff, 0xff, 0xff);
 
     /// Opaque black.
-    pub const BLACK: Color = Color::rgba32(0x00_00_00_ff);
+    pub const BLACK: Color = Color::rgb8(0, 0, 0);
 }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -1,5 +1,7 @@
 //! A simple representation of color
 
+use std::fmt::{Debug, Formatter};
+
 /// A datatype representing color.
 ///
 /// Currently this is only a 32 bit RGBA value, but it will likely
@@ -8,6 +10,12 @@
 #[derive(Clone)]
 pub enum Color {
     Rgba32(u32),
+}
+
+impl Debug for Color {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "Color(#{:08x})", self.as_rgba32())
+    }
 }
 
 impl Color {
@@ -62,7 +70,7 @@ impl Color {
     /// which is perhaps not ideal (the clipping might change the hue). See
     /// https://github.com/d3/d3-color/issues/33 for discussion.
     #[allow(non_snake_case)]
-    pub fn cielab_hlc<F: Into<f64>>(h: F, l: F, c: F) -> Color {
+    pub fn hlc<F: Into<f64>>(h: F, l: F, c: F) -> Color {
         // The reverse transformation from Lab to XYZ, see
         // https://en.wikipedia.org/wiki/CIELAB_color_space
         fn f_inv(t: f64) -> f64 {
@@ -112,8 +120,8 @@ impl Color {
     /// Create a color from a CIEL\*a\*b\* polar specification and alpha.
     ///
     /// The `a` value represents alpha in the range 0.0 to 1.0.
-    pub fn cielab_hlca<F: Into<f64>>(h: F, l: F, c: F, a: impl Into<f64>) -> Color {
-        Color::cielab_hlc(h, c, l).with_alpha(a)
+    pub fn hlca<F: Into<f64>>(h: F, l: F, c: F, a: impl Into<f64>) -> Color {
+        Color::hlc(h, c, l).with_alpha(a)
     }
 
     /// Change just the alpha value of a color.

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -14,29 +14,26 @@ pub enum Color {
 
 impl Debug for Color {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "Color(#{:08x})", self.as_rgba32())
+        write!(f, "#{:08x}", self.as_rgba_u32())
     }
 }
 
 impl Color {
     /// Create a color from 8 bit per sample RGB values.
     pub const fn rgb8(r: u8, g: u8, b: u8) -> Color {
-        Color::rgba32(((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | 0xff)
+        Color::from_rgba32_u32(((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | 0xff)
     }
 
     /// Create a color from 8 bit per sample RGBA values.
     pub const fn rgba8(r: u8, g: u8, b: u8, a: u8) -> Color {
-        Color::rgba32(((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | (a as u32))
+        Color::from_rgba32_u32(
+            ((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | (a as u32),
+        )
     }
 
     /// Create a color from a 32-bit rgba value (alpha as least significant byte).
-    pub const fn rgba32(rgba: u32) -> Color {
+    pub const fn from_rgba32_u32(rgba: u32) -> Color {
         Color::Rgba32(rgba)
-    }
-
-    /// Create a color from a 24-bit rgb value (red most significant, blue least).
-    pub const fn rgb24(rgb: u32) -> Color {
-        Color::rgba32((rgb << 8) | 0xff)
     }
 
     /// Create a color from four floating point values, each in the range 0.0 to 1.0.
@@ -48,7 +45,7 @@ impl Color {
         let g = (g.into().max(0.0).min(1.0) * 255.0).round() as u32;
         let b = (b.into().max(0.0).min(1.0) * 255.0).round() as u32;
         let a = (a.into().max(0.0).min(1.0) * 255.0).round() as u32;
-        Color::rgba32((r << 24) | (g << 16) | (b << 8) | a)
+        Color::from_rgba32_u32((r << 24) | (g << 16) | (b << 8) | a)
     }
 
     /// Create a color from three floating point values, each in the range 0.0 to 1.0.
@@ -59,7 +56,7 @@ impl Color {
         let r = (r.into().max(0.0).min(1.0) * 255.0).round() as u32;
         let g = (g.into().max(0.0).min(1.0) * 255.0).round() as u32;
         let b = (b.into().max(0.0).min(1.0) * 255.0).round() as u32;
-        Color::rgba32((r << 24) | (g << 16) | (b << 8) | 0xff)
+        Color::from_rgba32_u32((r << 24) | (g << 16) | (b << 8) | 0xff)
     }
 
     /// Create a color from a CIEL\*a\*b\* polar (also known as CIE HCL)
@@ -139,11 +136,11 @@ impl Color {
     /// The `a` value represents alpha in the range 0.0 to 1.0.
     pub fn with_alpha(self, a: impl Into<f64>) -> Color {
         let a = (a.into().max(0.0).min(1.0) * 255.0).round() as u32;
-        Color::rgba32((self.as_rgba32() & !0xff) | a)
+        Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a)
     }
 
     /// Convert a color value to a 32-bit rgba value.
-    pub fn as_rgba32(&self) -> u32 {
+    pub fn as_rgba_u32(&self) -> u32 {
         match *self {
             Color::Rgba32(rgba) => rgba,
         }

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -174,7 +174,7 @@ impl LinearGradient {
     /// # Examples
     ///
     /// ```
-    /// use piet::{Color, FillRule, RenderContext, LinearGradient, UnitPoint};
+    /// use piet::{Color, RenderContext, LinearGradient, UnitPoint};
     /// use piet::kurbo::{Circle, Point};
     ///
     /// # let mut render_ctx = piet::NullRenderContext::new();
@@ -184,7 +184,7 @@ impl LinearGradient {
     ///     UnitPoint::BOTTOM,
     ///     (Color::WHITE, Color::BLACK)
     /// );
-    /// render_ctx.fill(circle, &gradient, FillRule::NonZero);
+    /// render_ctx.fill(circle, &gradient);
     /// ```
     ///
     /// [`UnitPoint`]: struct.UnitPoint.html

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -75,7 +75,7 @@ pub trait GradientStops {
 }
 
 /// A description of a linear gradient in the unit rect, which can be resolved
-/// to a concrete gradient.
+/// to a fixed gradient.
 ///
 /// The start and end points in the gradient are given in [`UnitPoint`] coordinates,
 /// which are then resolved to image-space coordinates for any given concrete `Rect`.
@@ -90,7 +90,7 @@ pub struct LinearGradient {
     stops: Vec<GradientStop>,
 }
 
-/// A representation of a point relative to a rectangle.
+/// A representation of a point relative to a unit rectangle.
 pub struct UnitPoint {
     u: f64,
     v: f64,
@@ -174,8 +174,8 @@ impl UnitPoint {
 
     /// Create a new UnitPoint.
     ///
-    /// The `u` and `v` coordinates describe the point, with 0.0 being
-    /// left and top, and 1.0 being right and bottom, respectively.
+    /// The `u` and `v` coordinates describe the point, with (0.0, 0.0) being
+    /// the top-left, and (1.0, 1.0) being the bottom-right.
     pub const fn new(u: f64, v: f64) -> UnitPoint {
         UnitPoint { u, v }
     }

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -2,7 +2,7 @@
 
 use std::borrow::Cow;
 
-use kurbo::{Point, Rect, Shape, Vec2};
+use kurbo::{Point, Rect, Vec2};
 
 use crate::{IBrush, RenderContext};
 
@@ -198,8 +198,8 @@ impl LinearGradient {
 }
 
 impl<P: RenderContext> IBrush<P> for LinearGradient {
-    fn make_brush<'a>(&'a self, piet: &mut P, shape: &impl Shape) -> Cow<'a, P::Brush> {
-        let rect = shape.bounding_box();
+    fn make_brush<'a>(&'a self, piet: &mut P, bbox: impl FnOnce() -> Rect) -> Cow<'a, P::Brush> {
+        let rect = bbox();
         let gradient = RawGradient::Linear(RawLinearGradient {
             start: self.start.resolve(rect),
             end: self.end.resolve(rect),

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -1,25 +1,29 @@
 //! Gradient specifications.
 
-use kurbo::Vec2;
+use std::borrow::Cow;
+
+use kurbo::{Point, Rect, Shape, Vec2};
+
+use crate::{IBrush, RenderContext};
 
 use crate::Color;
 
 /// Specification of a gradient.
 #[derive(Clone)]
-pub enum Gradient {
+pub enum RawGradient {
     /// A linear gradient.
-    Linear(LinearGradient),
+    Linear(RawLinearGradient),
     /// A radial gradient.
-    Radial(RadialGradient),
+    Radial(RawRadialGradient),
 }
 
 /// Specification of a linear gradient.
 #[derive(Clone)]
-pub struct LinearGradient {
+pub struct RawLinearGradient {
     /// The start point (corresponding to pos 0.0).
-    pub start: Vec2,
+    pub start: Point,
     /// The end point (corresponding to pos 1.0).
-    pub end: Vec2,
+    pub end: Point,
     /// The stops.
     ///
     /// There must be at least two for the gradient to be valid.
@@ -28,9 +32,9 @@ pub struct LinearGradient {
 
 /// Specification of a radial gradient.
 #[derive(Clone)]
-pub struct RadialGradient {
+pub struct RawRadialGradient {
     /// The center.
-    pub center: Vec2,
+    pub center: Point,
     /// The offset of the origin relative to the center.
     pub origin_offset: Vec2,
     /// The radius.
@@ -38,7 +42,7 @@ pub struct RadialGradient {
     /// The circle with this radius from the center corresponds to pos 1.0.
     // TODO: investigate elliptical radius
     pub radius: f64,
-    /// The stops (see similar field in [`LinearGradient`](#struct.LinearGradient.html)).
+    /// The stops (see similar field in [`LinearGradient`](struct.LinearGradient.html)).
     pub stops: Vec<GradientStop>,
 }
 
@@ -49,4 +53,159 @@ pub struct GradientStop {
     pub pos: f32,
     /// The color at that stop.
     pub color: Color,
+}
+
+/// A flexible, ergonomic way to describe gradient stops.
+pub trait GradientStops {
+    fn to_vec(self) -> Vec<GradientStop>;
+}
+
+/// A "gradient description" that depends on the geometry being drawn.
+pub struct LinearGradient {
+    start: UnitPoint,
+    end: UnitPoint,
+    stops: Vec<GradientStop>,
+}
+
+/// A representation of a point relative to a rectangle.
+pub struct UnitPoint {
+    u: f64,
+    v: f64,
+}
+
+impl GradientStops for Vec<GradientStop> {
+    fn to_vec(self) -> Vec<GradientStop> {
+        self
+    }
+}
+
+impl<'a> GradientStops for &'a [GradientStop] {
+    fn to_vec(self) -> Vec<GradientStop> {
+        self.to_owned()
+    }
+}
+
+// Generate equally-spaced stops.
+impl<'a> GradientStops for &'a [Color] {
+    fn to_vec(self) -> Vec<GradientStop> {
+        if self.is_empty() {
+            Vec::new()
+        } else {
+            let denom = (self.len() - 1).max(1) as f32;
+            self.iter()
+                .enumerate()
+                .map(|(i, c)| GradientStop {
+                    pos: (i as f32) / denom,
+                    color: c.to_owned(),
+                })
+                .collect()
+        }
+    }
+}
+
+impl<'a> GradientStops for (Color, Color) {
+    fn to_vec(self) -> Vec<GradientStop> {
+        let stops: &[Color] = &[self.0, self.1];
+        GradientStops::to_vec(stops)
+    }
+}
+
+impl<'a> GradientStops for (Color, Color, Color) {
+    fn to_vec(self) -> Vec<GradientStop> {
+        let stops: &[Color] = &[self.0, self.1, self.2];
+        GradientStops::to_vec(stops)
+    }
+}
+
+impl<'a> GradientStops for (Color, Color, Color, Color) {
+    fn to_vec(self) -> Vec<GradientStop> {
+        let stops: &[Color] = &[self.0, self.1, self.2, self.3];
+        GradientStops::to_vec(stops)
+    }
+}
+
+impl<'a> GradientStops for (Color, Color, Color, Color, Color) {
+    fn to_vec(self) -> Vec<GradientStop> {
+        let stops: &[Color] = &[self.0, self.1, self.2, self.3, self.4];
+        GradientStops::to_vec(stops)
+    }
+}
+
+impl<'a> GradientStops for (Color, Color, Color, Color, Color, Color) {
+    fn to_vec(self) -> Vec<GradientStop> {
+        let stops: &[Color] = &[self.0, self.1, self.2, self.3, self.4, self.5];
+        GradientStops::to_vec(stops)
+    }
+}
+
+impl UnitPoint {
+    pub const TOP_LEFT: UnitPoint = UnitPoint::new(0.0, 0.0);
+    pub const TOP: UnitPoint = UnitPoint::new(0.5, 0.0);
+    pub const TOP_RIGHT: UnitPoint = UnitPoint::new(1.0, 0.0);
+    pub const LEFT: UnitPoint = UnitPoint::new(0.0, 0.5);
+    pub const CENTER: UnitPoint = UnitPoint::new(0.5, 0.5);
+    pub const RIGHT: UnitPoint = UnitPoint::new(1.0, 0.5);
+    pub const BOTTOM_LEFT: UnitPoint = UnitPoint::new(0.0, 1.0);
+    pub const BOTTOM: UnitPoint = UnitPoint::new(0.5, 1.0);
+    pub const BOTTOM_RIGHT: UnitPoint = UnitPoint::new(1.0, 1.0);
+
+    /// Create a new UnitPoint.
+    ///
+    /// The `u` and `v` coordinates describe the point, with 0.0 being
+    /// left and top, and 1.0 being right and bottom, respectively.
+    pub const fn new(u: f64, v: f64) -> UnitPoint {
+        UnitPoint { u, v }
+    }
+    /// Given a rectangle, resolve the point within the rectangle.
+    pub fn resolve(&self, rect: Rect) -> Point {
+        Point::new(
+            rect.x0 + self.u * (rect.x1 - rect.x0),
+            rect.y0 + self.v * (rect.y1 - rect.y0),
+        )
+    }
+}
+
+impl LinearGradient {
+    /// Create a new linear gradient.
+    ///
+    /// The `start` and `end` coordinates are [`UnitPoint`] coordinates, relative
+    /// to the geometry of the shape being drawn.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use piet::{Color, FillRule, RenderContext, LinearGradient, UnitPoint};
+    /// use piet::kurbo::{Circle, Point};
+    ///
+    /// # let mut render_ctx = piet::NullRenderContext::new();
+    /// let circle = Circle::new(Point::new(100.0, 100.0), 50.0);
+    /// let gradient = LinearGradient::new(
+    ///     UnitPoint::TOP,
+    ///     UnitPoint::BOTTOM,
+    ///     (Color::WHITE, Color::BLACK)
+    /// );
+    /// render_ctx.fill(circle, &gradient, FillRule::NonZero);
+    /// ```
+    ///
+    /// [`UnitPoint`]: struct.UnitPoint.html
+    pub fn new(start: UnitPoint, end: UnitPoint, stops: impl GradientStops) -> LinearGradient {
+        LinearGradient {
+            start,
+            end,
+            stops: stops.to_vec(),
+        }
+    }
+}
+
+impl<P: RenderContext> IBrush<P> for LinearGradient {
+    fn make_brush<'a>(&'a self, piet: &mut P, shape: &impl Shape) -> Cow<'a, P::Brush> {
+        let rect = shape.bounding_box();
+        let gradient = RawGradient::Linear(RawLinearGradient {
+            start: self.start.resolve(rect),
+            end: self.end.resolve(rect),
+            stops: self.stops.clone(),
+        });
+        // Perhaps the make_brush method should be fallible instead of panicking.
+        Cow::Owned(piet.gradient(gradient).expect("error creating gradient"))
+    }
 }

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -6,6 +6,7 @@ mod color;
 mod conv;
 mod error;
 mod gradient;
+mod null_renderer;
 mod render_context;
 mod shapes;
 mod text;
@@ -14,6 +15,8 @@ pub use crate::color::*;
 pub use crate::conv::*;
 pub use crate::error::*;
 pub use crate::gradient::*;
+#[doc(hidden)]
+pub use crate::null_renderer::*;
 pub use crate::render_context::*;
 pub use crate::shapes::*;
 pub use crate::text::*;

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -1,0 +1,161 @@
+//! A render context that does nothing.
+
+use std::borrow::Cow;
+
+use kurbo::{Affine, Point, Rect, Shape};
+
+use crate::{
+    Color, Error, FillRule, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode, RawGradient,
+    RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
+};
+
+/// A render context that doesn't render.
+///
+/// This is useful largely for doc tests, but is made public in case
+/// it might come in handy.
+pub struct NullRenderContext(NullText);
+
+#[derive(Clone)]
+pub struct NullBrush;
+pub struct NullImage;
+
+pub struct NullText;
+
+pub struct NullFont;
+pub struct NullFontBuilder;
+
+pub struct NullTextLayout;
+pub struct NullTextLayoutBuilder;
+
+impl NullRenderContext {
+    pub fn new() -> NullRenderContext {
+        NullRenderContext(NullText)
+    }
+}
+
+impl RenderContext for NullRenderContext {
+    type Brush = NullBrush;
+    type Image = NullImage;
+    type Text = NullText;
+    type TextLayout = NullTextLayout;
+
+    fn status(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn solid_brush(&mut self, _color: Color) -> Self::Brush {
+        NullBrush
+    }
+
+    fn gradient(&mut self, _gradient: RawGradient) -> Result<Self::Brush, Error> {
+        Ok(NullBrush)
+    }
+
+    fn clear(&mut self, _color: Color) {}
+
+    fn stroke(
+        &mut self,
+        _shape: impl Shape,
+        _brush: &impl IBrush<Self>,
+        _width: f64,
+        _style: Option<&StrokeStyle>,
+    ) {
+    }
+
+    fn fill(&mut self, _shape: impl Shape, _brush: &impl IBrush<Self>, _fill_rule: FillRule) {}
+
+    fn clip(&mut self, _shape: impl Shape, _fill_rule: FillRule) {}
+
+    fn text(&mut self) -> &mut Self::Text {
+        &mut self.0
+    }
+
+    fn draw_text(
+        &mut self,
+        _layout: &Self::TextLayout,
+        _pos: impl Into<Point>,
+        _brush: &Self::Brush,
+    ) {
+    }
+
+    fn save(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    fn restore(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    fn finish(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    fn transform(&mut self, _transform: Affine) {}
+
+    fn make_image(
+        &mut self,
+        _width: usize,
+        _height: usize,
+        _buf: &[u8],
+        _format: ImageFormat,
+    ) -> Result<Self::Image, Error> {
+        Ok(NullImage)
+    }
+    fn draw_image(
+        &mut self,
+        _image: &Self::Image,
+        _rect: impl Into<Rect>,
+        _interp: InterpolationMode,
+    ) {
+    }
+}
+
+impl Text for NullText {
+    type Font = NullFont;
+    type FontBuilder = NullFontBuilder;
+    type TextLayout = NullTextLayout;
+    type TextLayoutBuilder = NullTextLayoutBuilder;
+
+    fn new_font_by_name(&mut self, _name: &str, _size: f64) -> Result<Self::FontBuilder, Error> {
+        Ok(NullFontBuilder)
+    }
+
+    fn new_text_layout(
+        &mut self,
+        _font: &Self::Font,
+        _text: &str,
+    ) -> Result<Self::TextLayoutBuilder, Error> {
+        Ok(NullTextLayoutBuilder)
+    }
+}
+
+impl Font for NullFont {}
+
+impl FontBuilder for NullFontBuilder {
+    type Out = NullFont;
+
+    fn build(self) -> Result<Self::Out, Error> {
+        Ok(NullFont)
+    }
+}
+
+impl TextLayoutBuilder for NullTextLayoutBuilder {
+    type Out = NullTextLayout;
+
+    fn build(self) -> Result<Self::Out, Error> {
+        Ok(NullTextLayout)
+    }
+}
+
+impl TextLayout for NullTextLayout {
+    fn width(&self) -> f64 {
+        42.0
+    }
+}
+
+impl IBrush<NullRenderContext> for NullBrush {
+    fn make_brush<'b>(
+        &'b self,
+        _piet: &mut NullRenderContext,
+        _shape: &impl Shape,
+    ) -> std::borrow::Cow<'b, NullBrush> {
+        Cow::Borrowed(self)
+    }
+}

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use kurbo::{Affine, Point, Rect, Shape};
 
 use crate::{
-    Color, Error, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode, RawGradient,
+    Color, Error, FixedGradient, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode,
     RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
@@ -47,7 +47,7 @@ impl RenderContext for NullRenderContext {
         NullBrush
     }
 
-    fn gradient(&mut self, _gradient: RawGradient) -> Result<Self::Brush, Error> {
+    fn gradient(&mut self, _gradient: FixedGradient) -> Result<Self::Brush, Error> {
         Ok(NullBrush)
     }
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -53,12 +53,14 @@ impl RenderContext for NullRenderContext {
 
     fn clear(&mut self, _color: Color) {}
 
-    fn stroke(
+    fn stroke(&mut self, _shape: impl Shape, _brush: &impl IBrush<Self>, _width: f64) {}
+
+    fn stroke_styled(
         &mut self,
         _shape: impl Shape,
         _brush: &impl IBrush<Self>,
         _width: f64,
-        _style: Option<&StrokeStyle>,
+        _style: &StrokeStyle,
     ) {
     }
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use kurbo::{Affine, Point, Rect, Shape};
 
 use crate::{
-    Color, Error, FillRule, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode, RawGradient,
+    Color, Error, Font, FontBuilder, IBrush, ImageFormat, InterpolationMode, RawGradient,
     RenderContext, StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
@@ -62,9 +62,11 @@ impl RenderContext for NullRenderContext {
     ) {
     }
 
-    fn fill(&mut self, _shape: impl Shape, _brush: &impl IBrush<Self>, _fill_rule: FillRule) {}
+    fn fill(&mut self, _shape: impl Shape, _brush: &impl IBrush<Self>) {}
 
-    fn clip(&mut self, _shape: impl Shape, _fill_rule: FillRule) {}
+    fn fill_even_odd(&mut self, _shape: impl Shape, _brush: &impl IBrush<Self>) {}
+
+    fn clip(&mut self, _shape: impl Shape) {}
 
     fn text(&mut self) -> &mut Self::Text {
         &mut self.0

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -74,7 +74,7 @@ impl RenderContext for NullRenderContext {
         &mut self,
         _layout: &Self::TextLayout,
         _pos: impl Into<Point>,
-        _brush: &Self::Brush,
+        _brush: &impl IBrush<Self>,
     ) {
     }
 
@@ -154,7 +154,7 @@ impl IBrush<NullRenderContext> for NullBrush {
     fn make_brush<'b>(
         &'b self,
         _piet: &mut NullRenderContext,
-        _shape: &impl Shape,
+        _bbox: impl FnOnce() -> Rect,
     ) -> std::borrow::Cow<'b, NullBrush> {
         Cow::Borrowed(self)
     }

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use kurbo::{Affine, Point, Rect, Shape};
 
-use crate::{Color, Error, FillRule, RawGradient, StrokeStyle, Text, TextLayout};
+use crate::{Color, Error, RawGradient, StrokeStyle, Text, TextLayout};
 
 /// A requested interpolation mode for drawing images.
 #[derive(Clone, Copy, PartialEq)]
@@ -99,17 +99,17 @@ where
         style: Option<&StrokeStyle>,
     );
 
-    /// Fill a shape.
+    /// Fill a shape, using non-zero fill rule.
+    fn fill(&mut self, shape: impl Shape, brush: &impl IBrush<Self>);
 
-    // TODO: switch last two argument order to be more similar to clip? Maybe we
-    // should have a convention, geometry first.
-    fn fill(&mut self, shape: impl Shape, brush: &impl IBrush<Self>, fill_rule: FillRule);
+    /// Fill a shape, using even-odd fill rule
+    fn fill_even_odd(&mut self, shape: impl Shape, brush: &impl IBrush<Self>);
 
     /// Clip to a shape.
     ///
     /// All subsequent drawing operations up to the next [`restore`](#method.restore)
     /// are clipped by the shape.
-    fn clip(&mut self, shape: impl Shape, fill_rule: FillRule);
+    fn clip(&mut self, shape: impl Shape);
 
     fn text(&mut self) -> &mut Self::Text;
 

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 
 use kurbo::{Affine, Point, Rect, Shape};
 
-use crate::{Color, Error, RawGradient, StrokeStyle, Text, TextLayout};
+use crate::{Color, Error, FixedGradient, StrokeStyle, Text, TextLayout};
 
 /// A requested interpolation mode for drawing images.
 #[derive(Clone, Copy, PartialEq)]
@@ -83,7 +83,7 @@ where
     fn solid_brush(&mut self, color: Color) -> Self::Brush;
 
     /// Create a new gradient brush.
-    fn gradient(&mut self, gradient: RawGradient) -> Result<Self::Brush, Error>;
+    fn gradient(&mut self, gradient: FixedGradient) -> Result<Self::Brush, Error>;
 
     /// Clear the canvas with the given color.
     ///

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -91,12 +91,15 @@ where
     fn clear(&mut self, color: Color);
 
     /// Stroke a shape.
-    fn stroke(
+    fn stroke(&mut self, shape: impl Shape, brush: &impl IBrush<Self>, width: f64);
+
+    /// Stroke a shape, with styled strokes.
+    fn stroke_styled(
         &mut self,
         shape: impl Shape,
         brush: &impl IBrush<Self>,
         width: f64,
-        style: Option<&StrokeStyle>,
+        style: &StrokeStyle,
     );
 
     /// Fill a shape, using non-zero fill rule.

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -117,7 +117,12 @@ where
     ///
     /// The `pos` parameter specifies the baseline of the left starting place of
     /// the text. Note: this is true even if the text is right-to-left.
-    fn draw_text(&mut self, layout: &Self::TextLayout, pos: impl Into<Point>, brush: &Self::Brush);
+    fn draw_text(
+        &mut self,
+        layout: &Self::TextLayout,
+        pos: impl Into<Point>,
+        brush: &impl IBrush<Self>,
+    );
 
     /// Save the context state.
     ///
@@ -181,11 +186,11 @@ pub trait IBrush<P: RenderContext>
 where
     P: ?Sized,
 {
-    fn make_brush<'a>(&'a self, piet: &mut P, shape: &impl Shape) -> Cow<'a, P::Brush>;
+    fn make_brush<'a>(&'a self, piet: &mut P, bbox: impl FnOnce() -> Rect) -> Cow<'a, P::Brush>;
 }
 
 impl<P: RenderContext> IBrush<P> for Color {
-    fn make_brush<'a>(&'a self, piet: &mut P, _shape: &impl Shape) -> Cow<'a, P::Brush> {
+    fn make_brush<'a>(&'a self, piet: &mut P, _bbox: impl FnOnce() -> Rect) -> Cow<'a, P::Brush> {
         Cow::Owned(piet.solid_brush(self.to_owned()))
     }
 }

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -1,14 +1,5 @@
 //! Options for drawing paths.
 
-/// A fill rule for resolving winding numbers.
-#[derive(Clone, Copy, PartialEq)]
-pub enum FillRule {
-    /// Fill everything with a non-zero winding number.
-    NonZero,
-    /// Fill everything with an odd winding number.
-    EvenOdd,
-}
-
 /// Options for drawing stroked lines.
 #[derive(Clone, PartialEq, Debug)]
 pub struct StrokeStyle {


### PR DESCRIPTION
Allow Color as brush argument to stroke and fill. Provide a new, more
ergonomic Gradient that uses UnitPoint, and let that be the argument to
stroke and fill as well.

Rolls in a few Color ergonomic improvements (#71).

Also adds a new `NullRenderContext` which is useful for doctests.

Fixes #72