### PR TITLE
Move hidden to individual NullRenderContext types

### DIFF
--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -15,7 +15,6 @@ pub use crate::color::*;
 pub use crate::conv::*;
 pub use crate::error::*;
 pub use crate::gradient::*;
-#[doc(hidden)]
 pub use crate::null_renderer::*;
 pub use crate::render_context::*;
 pub use crate::shapes::*;

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -13,18 +13,26 @@ use crate::{
 ///
 /// This is useful largely for doc tests, but is made public in case
 /// it might come in handy.
+#[doc(hidden)]
 pub struct NullRenderContext(NullText);
 
 #[derive(Clone)]
+#[doc(hidden)]
 pub struct NullBrush;
+#[doc(hidden)]
 pub struct NullImage;
 
+#[doc(hidden)]
 pub struct NullText;
 
+#[doc(hidden)]
 pub struct NullFont;
+#[doc(hidden)]
 pub struct NullFontBuilder;
 
+#[doc(hidden)]
 pub struct NullTextLayout;
+#[doc(hidden)]
 pub struct NullTextLayoutBuilder;
 
 impl NullRenderContext {


### PR DESCRIPTION
The blanket attribute on the module wasn't respected by the piet-common re-export.

Fixes #78