### PR TITLE
Add text example to piet-test

### DIFF
--- a/piet-test/src/lib.rs
+++ b/piet-test/src/lib.rs
@@ -8,12 +8,14 @@ mod picture_1;
 mod picture_2;
 mod picture_3;
 mod picture_4;
+mod picture_5;
 
 use crate::picture_0::draw as draw_picture_0;
 use crate::picture_1::draw as draw_picture_1;
 use crate::picture_2::draw as draw_picture_2;
 use crate::picture_3::draw as draw_picture_3;
 use crate::picture_4::draw as draw_picture_4;
+use crate::picture_5::draw as draw_picture_5;
 
 /// Draw a test picture, by number.
 ///
@@ -26,6 +28,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         2 => draw_picture_2(rc),
         3 => draw_picture_3(rc),
         4 => draw_picture_4(rc),
+        5 => draw_picture_5(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",

--- a/piet-test/src/picture_5.rs
+++ b/piet-test/src/picture_5.rs
@@ -1,0 +1,25 @@
+//! Basic example of just text
+
+use piet::kurbo::Line;
+use piet::{Color, Error, FontBuilder, RenderContext, Text, TextLayout, TextLayoutBuilder};
+
+pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
+    // Black background
+    rc.clear(Color::BLACK);
+
+    // do something texty
+    let font = rc.text().new_font_by_name("Segoe UI", 12.0)?.build()?;
+
+    let layout = rc.text().new_text_layout(&font, "piet text!")?.build()?;
+
+    let width = layout.width();
+
+    let brush = rc.solid_brush(Color::rgba8(0x00, 0x80, 0x80, 0xF0));
+
+    rc.draw_text(&layout, (100.0, 50.0), &brush);
+
+    // underline text
+    rc.stroke(Line::new((100.0, 52.0), (100.0 + width, 52.0)), &brush, 1.0);
+
+    Ok(())
+}


### PR DESCRIPTION
Basic example that's text-only. In preparation for testing api changes
and new features.