### PR TITLE
Remove `Result` when creating Font and TextLayout builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+.cargo
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -362,25 +362,21 @@ impl Text for CairoText {
     type TextLayout = CairoTextLayout;
     type TextLayoutBuilder = CairoTextLayoutBuilder;
 
-    fn new_font_by_name(&mut self, name: &str, size: f64) -> Result<Self::FontBuilder, Error> {
-        Ok(CairoFontBuilder {
+    fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder {
+        CairoFontBuilder {
             family: name.to_owned(),
             size: size.round_into(),
             weight: FontWeight::Normal,
             slant: FontSlant::Normal,
-        })
+        }
     }
 
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-    ) -> Result<Self::TextLayoutBuilder, Error> {
+    fn new_text_layout(&mut self, font: &Self::Font, text: &str) -> Self::TextLayoutBuilder {
         let text_layout = CairoTextLayout {
             font: font.0.clone(),
             text: text.to_owned(),
         };
-        Ok(CairoTextLayoutBuilder(text_layout))
+        CairoTextLayoutBuilder(text_layout)
     }
 }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg(windows)]
 //! The Direct2D backend for the Piet 2D graphics abstraction.
 
 mod conv;
@@ -492,27 +493,23 @@ impl<'a> Text for D2DText<'a> {
     type TextLayoutBuilder = D2DTextLayoutBuilder<'a>;
     type TextLayout = D2DTextLayout;
 
-    fn new_font_by_name(&mut self, name: &str, size: f64) -> Result<Self::FontBuilder, Error> {
+    fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder {
         // Note: the name is cloned here, rather than applied using `with_family` for
         // lifetime reasons. Maybe there's a better approach.
-        Ok(D2DFontBuilder {
+        D2DFontBuilder {
             builder: TextFormat::create(self.dwrite).with_size(size as f32),
             name: name.to_owned(),
-        })
+        }
     }
 
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-    ) -> Result<Self::TextLayoutBuilder, Error> {
+    fn new_text_layout(&mut self, font: &Self::Font, text: &str) -> Self::TextLayoutBuilder {
         // Same consideration as above, we clone the font and text for lifetime
         // reasons.
-        Ok(D2DTextLayoutBuilder {
+        D2DTextLayoutBuilder {
             builder: text_layout::TextLayout::create(self.dwrite),
             format: font.0.clone(),
             text: text.to_owned(),
-        })
+        }
     }
 }
 

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -24,8 +24,8 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let brush = rc.solid_brush(Color::rgba8(0x00, 0x00, 0x80, 0xC0));
     rc.fill(path, &brush);
 
-    let font = rc.text().new_font_by_name("Segoe UI", 12.0)?.build()?;
-    let layout = rc.text().new_text_layout(&font, "Hello piet!")?.build()?;
+    let font = rc.text().new_font_by_name("Segoe UI", 12.0).build()?;
+    let layout = rc.text().new_text_layout(&font, "Hello piet!").build()?;
     let w: f64 = layout.width().into();
     let brush = rc.solid_brush(Color::rgba8(0x80, 0x00, 0x00, 0xC0));
     rc.draw_text(&layout, (80.0, 10.0), &brush);
@@ -48,7 +48,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let clip_path = star(Point::new(90.0, 45.0), 10.0, 30.0, 24);
     rc.clip(clip_path);
-    let layout = rc.text().new_text_layout(&font, "Clipped text")?.build()?;
+    let layout = rc.text().new_text_layout(&font, "Clipped text").build()?;
     rc.draw_text(&layout, (80.0, 50.0), &brush);
     Ok(())
 }

--- a/piet-test/src/picture_5.rs
+++ b/piet-test/src/picture_5.rs
@@ -8,9 +8,9 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::BLACK);
 
     // do something texty
-    let font = rc.text().new_font_by_name("Segoe UI", 12.0)?.build()?;
+    let font = rc.text().new_font_by_name("Segoe UI", 12.0).build()?;
 
-    let layout = rc.text().new_text_layout(&font, "piet text!")?.build()?;
+    let layout = rc.text().new_text_layout(&font, "piet text!").build()?;
 
     let width = layout.width();
 

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -376,28 +376,24 @@ impl<'a> Text for WebRenderContext<'a> {
     type TextLayout = WebTextLayout;
     type TextLayoutBuilder = WebTextLayoutBuilder;
 
-    fn new_font_by_name(&mut self, name: &str, size: f64) -> Result<Self::FontBuilder, Error> {
+    fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder {
         let font = WebFont {
             family: name.to_owned(),
             size,
             weight: 400,
             style: FontStyle::Normal,
         };
-        Ok(WebFontBuilder(font))
+        WebFontBuilder(font)
     }
 
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-    ) -> Result<Self::TextLayoutBuilder, Error> {
-        Ok(WebTextLayoutBuilder {
+    fn new_text_layout(&mut self, font: &Self::Font, text: &str) -> Self::TextLayoutBuilder {
+        WebTextLayoutBuilder {
             // TODO: it's very likely possible to do this without cloning ctx, but
             // I couldn't figure out the lifetime errors from a `&'a` reference.
             ctx: self.ctx.clone(),
             font: font.clone(),
             text: text.to_owned(),
-        })
+        }
     }
 }
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -125,16 +125,12 @@ impl Text for NullText {
     type TextLayout = NullTextLayout;
     type TextLayoutBuilder = NullTextLayoutBuilder;
 
-    fn new_font_by_name(&mut self, _name: &str, _size: f64) -> Result<Self::FontBuilder, Error> {
-        Ok(NullFontBuilder)
+    fn new_font_by_name(&mut self, _name: &str, _size: f64) -> Self::FontBuilder {
+        NullFontBuilder
     }
 
-    fn new_text_layout(
-        &mut self,
-        _font: &Self::Font,
-        _text: &str,
-    ) -> Result<Self::TextLayoutBuilder, Error> {
-        Ok(NullTextLayoutBuilder)
+    fn new_text_layout(&mut self, _font: &Self::Font, _text: &str) -> Self::TextLayoutBuilder {
+        NullTextLayoutBuilder
     }
 }
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -9,13 +9,9 @@ pub trait Text {
     type TextLayoutBuilder: TextLayoutBuilder<Out = Self::TextLayout>;
     type TextLayout: TextLayout;
 
-    fn new_font_by_name(&mut self, name: &str, size: f64) -> Result<Self::FontBuilder, Error>;
+    fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder;
 
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-    ) -> Result<Self::TextLayoutBuilder, Error>;
+    fn new_text_layout(&mut self, font: &Self::Font, text: &str) -> Self::TextLayoutBuilder;
 }
 
 pub trait FontBuilder {


### PR DESCRIPTION
Creating Font and TextLayout builders should not fail, so to avoid
unnecessary unwrapping for users, this commit removes the Result from
the `new_font_by_name` and `new_text_layout` methods in the `Text`
trait.

This is a user API breaking change.

Also updated implementers of `Text` (all existing backends):
- null_renderer
- direct2d
- cairo
- web

Also updated user of `Text`, `piet-crate`.

As an ergonomic change for devs, this commit also:
- adds `#![cfg(windows)]` to the `direct-2d` backend so that it does
not attempt to compile on linux.
- adds `.cargo` to .gitignore; it's used for cross compilation config

Closes #76 