### PR TITLE
Fix closed paths on stroke (d2d)

### DIFF
--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -1,6 +1,6 @@
 //! A wide assortment of graphics meant to show off many different uses of piet
 
-use piet::kurbo::{Affine, BezPath, Line, Point, Rect, Vec2};
+use piet::kurbo::{Affine, BezPath, Line, Point, Rect, RoundedRect, Vec2};
 
 use piet::{
     Color, Error, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextLayout,
@@ -23,6 +23,8 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     path.curve_to((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
     let brush = rc.solid_brush(Color::rgba8(0x00, 0x00, 0x80, 0xC0));
     rc.fill(path, &brush);
+
+    rc.stroke(RoundedRect::new(145.0, 45.0, 185.0, 85.0, 5.0), &brush, 1.0);
 
     let font = rc.text().new_font_by_name("Segoe UI", 12.0).build()?;
     let layout = rc.text().new_text_layout(&font, "Hello piet!").build()?;


### PR DESCRIPTION
Do a slightly more inefficient conversion to bezier paths so we can
tell in advance whether a subpath needs to be closed. This is a bit of
a workaround, as there are plans to improve the direct2d bindings so
we can set the is_closed at the end of the subpath, enabling a single
pass of iteration (tracked in #65).