### PR TITLE
[text] remove unused is_text

### DIFF
--- a/piet-cairo/src/grapheme.rs
+++ b/piet-cairo/src/grapheme.rs
@@ -47,7 +47,6 @@ pub(crate) fn point_x_in_grapheme(
         }
 
         res.is_inside = true;
-        res.metrics.is_text = true;
         Some(res)
     } else {
         None
@@ -108,7 +107,6 @@ mod test {
         let expected_curr = Some(HitTestPoint {
             metrics: HitTestMetrics {
                 text_position: 2,
-                is_text: true,
                 ..Default::default()
             },
             is_inside: true,
@@ -117,7 +115,6 @@ mod test {
         let expected_next = Some(HitTestPoint {
             metrics: HitTestMetrics {
                 text_position: 4,
-                is_text: true,
                 ..Default::default()
             },
             is_inside: true,

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -618,7 +618,6 @@ impl TextLayout for CairoTextLayout {
                 },
                 metrics: HitTestMetrics {
                     text_position: text_len,
-                    is_text: true,
                 },
             });
         }
@@ -637,7 +636,6 @@ impl TextLayout for CairoTextLayout {
                 point: Point { x: point_x, y: 0.0 },
                 metrics: HitTestMetrics {
                     text_position: text_position,
-                    is_text: true,
                 },
             })
         } else {
@@ -649,7 +647,6 @@ impl TextLayout for CairoTextLayout {
                 },
                 metrics: HitTestMetrics {
                     text_position: text_len,
-                    is_text: true,
                 },
             })
         }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -602,10 +602,7 @@ impl TextLayout for D2DTextLayout {
             count_until_utf16(&self.text, text_position_16).unwrap_or(self.text.len());
 
         HitTestPoint {
-            metrics: HitTestMetrics {
-                text_position,
-                is_text: htp.metrics.is_text(),
-            },
+            metrics: HitTestMetrics { text_position },
             is_inside: htp.is_inside,
         }
     }
@@ -639,7 +636,6 @@ impl TextLayout for D2DTextLayout {
                     },
                     metrics: HitTestMetrics {
                         text_position: text_position, // no need to use directwrite return value
-                        is_text: http.metrics.is_text(),
                     },
                 }
             })

--- a/piet-web/src/grapheme.rs
+++ b/piet-web/src/grapheme.rs
@@ -52,7 +52,6 @@ pub(crate) fn point_x_in_grapheme(
         }
 
         res.is_inside = true;
-        res.metrics.is_text = true;
         Some(res)
     } else {
         None

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -632,7 +632,6 @@ impl TextLayout for WebTextLayout {
                 point: Point { x, y: 0.0 },
                 metrics: HitTestMetrics {
                     text_position: text_len,
-                    is_text: true,
                 },
             });
         }
@@ -655,7 +654,6 @@ impl TextLayout for WebTextLayout {
                 point: Point { x, y: 0.0 },
                 metrics: HitTestMetrics {
                     text_position: text_position,
-                    is_text: true,
                 },
             })
         } else {
@@ -667,7 +665,6 @@ impl TextLayout for WebTextLayout {
                 },
                 metrics: HitTestMetrics {
                     text_position: text_len,
-                    is_text: true,
                 },
             })
         }

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -79,7 +79,6 @@ pub struct HitTestTextPosition {
 /// and [`hit_test_point`](../piet/trait.TextLayout.html#tymethod.hit_test_point).
 pub struct HitTestMetrics {
     pub text_position: usize,
-    pub is_text: bool,
     // TODO:
     // consider adding other metrics as needed, such as those provided in
     // [DWRITE_HIT_TEST_METRICS](https://docs.microsoft.com/en-us/windows/win32/api/dwrite/ns-dwrite-dwrite_hit_test_metrics).


### PR DESCRIPTION
`is_text` is not useful in piet's text api at the moment. It was a holdover from the initial port from directwrite.

If we need it later, we can add it back. For now it's just confusing.