### PR TITLE
Do addition and subtraction in binary search

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -594,9 +594,9 @@ impl TextLayout for CairoTextLayout {
             // since it's not a hit, check if closer to start or finish
             // and move the appropriate search boundary
             if point.x < grapheme_bounds.leading {
-                right = grapheme_bounds.curr_idx as usize; // should this be -1?
+                right -= 1;
             } else if point.x > grapheme_bounds.trailing {
-                left = grapheme_bounds.curr_idx as usize; // should this be +1?
+                left += 1;
             }
         }
     }


### PR DESCRIPTION
Currently we have a couple of problems with non-ASCII characters in Druid's textbox (as pointed out in [druid#256](https://github.com/xi-editor/druid/pull/256) that trace back to this loop: this can get stuck in an infinite loop, and this can overflow when subtracting.

By changing these branches to += 1 / -=1 (as proposed in the comments) I'm not seeing those problems anymore, but I'm not 100 percent sure we're out of the woods.