### PR TITLE
[text] fix hanging in hit test point binary search

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -594,9 +594,9 @@ impl TextLayout for CairoTextLayout {
             // since it's not a hit, check if closer to start or finish
             // and move the appropriate search boundary
             if point.x < grapheme_bounds.leading {
-                right = grapheme_bounds.curr_idx as usize; // should this be -1?
+                right = middle;
             } else if point.x > grapheme_bounds.trailing {
-                left = grapheme_bounds.curr_idx as usize; // should this be +1?
+                left = middle;
             }
         }
     }
@@ -1004,7 +1004,7 @@ mod test {
 
     #[test]
     #[cfg(target_os = "linux")]
-    fn test_hit_test_point_complex() {
+    fn test_hit_test_point_complex_0() {
         // Notes on this input:
         // 6 code points
         // 7 utf-16 code units (1/1/1/1/1/2)
@@ -1053,7 +1053,7 @@ mod test {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn test_hit_test_point_complex() {
+    fn test_hit_test_point_complex_0() {
         // Notes on this input:
         // 6 code points
         // 7 utf-16 code units (1/1/1/1/1/2)
@@ -1100,5 +1100,63 @@ mod test {
         assert_eq!(pt.metrics.text_position, 14);
         let pt = layout.hit_test_point(Point::new(43.0, 0.0));
         assert_eq!(pt.metrics.text_position, 14);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_hit_test_point_complex_1() {
+        // this input caused an infinite loop in the binary search when test position
+        // > 21.0 && < 28.0
+        //
+        // This corresponds to the char 'y' in the input.
+        let input = "tßßypi";
+
+        let mut text_layout = CairoText::new();
+        let font = text_layout
+            .new_font_by_name("sans-serif", 12.0)
+            .build()
+            .unwrap();
+        let layout = text_layout.new_text_layout(&font, input).build().unwrap();
+        println!("text pos 0: {:?}", layout.hit_test_text_position(0)); // 0.0
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+        println!("text pos 2: {:?}", layout.hit_test_text_position(2)); // 5.0
+        println!("text pos 3: {:?}", layout.hit_test_text_position(3)); // 13.0
+        println!("text pos 4: {:?}", layout.hit_test_text_position(4)); // 13.0
+        println!("text pos 5: {:?}", layout.hit_test_text_position(5)); // 21.0
+        println!("text pos 6: {:?}", layout.hit_test_text_position(6)); // 28.0
+        println!("text pos 7: {:?}", layout.hit_test_text_position(7)); // 36.0
+        println!("text pos 8: {:?}", layout.hit_test_text_position(8)); // 39.0, end
+
+        let pt = layout.hit_test_point(Point::new(27.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 6);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_hit_test_point_complex_1() {
+        // this input caused an infinite loop in the binary search when test position
+        // > 21.0 && < 28.0
+        //
+        // This corresponds to the char 'y' in the input.
+        let input = "tßßypi";
+
+        let mut text_layout = CairoText::new();
+        let font = text_layout
+            .new_font_by_name("sans-serif", 12.0)
+            .build()
+            .unwrap();
+        let layout = text_layout.new_text_layout(&font, input).build().unwrap();
+        println!("text pos 0: {:?}", layout.hit_test_text_position(0)); // 0.0
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+        println!("text pos 2: {:?}", layout.hit_test_text_position(2)); // 5.0
+        println!("text pos 3: {:?}", layout.hit_test_text_position(3)); // 13.0
+        println!("text pos 4: {:?}", layout.hit_test_text_position(4)); // 13.0
+        println!("text pos 5: {:?}", layout.hit_test_text_position(5)); // 21.0
+        println!("text pos 6: {:?}", layout.hit_test_text_position(6)); // 28.0
+        println!("text pos 7: {:?}", layout.hit_test_text_position(7)); // 36.0
+        println!("text pos 8: {:?}", layout.hit_test_text_position(8)); // 39.0, end
+
+        let pt = layout.hit_test_point(Point::new(27.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 6);
     }
 }

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -596,7 +596,7 @@ impl TextLayout for CairoTextLayout {
             if point.x < grapheme_bounds.leading {
                 right = middle;
             } else if point.x > grapheme_bounds.trailing {
-                left = middle;
+                left = middle + 1;
             } else {
                 unreachable!("hit_test_point conditional is exhaustive");
             }
@@ -914,7 +914,7 @@ mod test {
 
     #[test]
     #[cfg(target_os = "linux")]
-    fn test_hit_test_point_basic() {
+    fn test_hit_test_point_basic_0() {
         let mut text_layout = CairoText::new();
 
         let font = text_layout
@@ -961,7 +961,7 @@ mod test {
 
     #[test]
     #[cfg(target_os = "macos")]
-    fn test_hit_test_point_basic() {
+    fn test_hit_test_point_basic_0() {
         let mut text_layout = CairoText::new();
 
         let font = text_layout
@@ -1002,6 +1002,70 @@ mod test {
         let pt = layout.hit_test_point(Point::new(-1.0, 0.0));
         assert_eq!(pt.metrics.text_position, 0); // first text position
         assert_eq!(pt.is_inside, false);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    // for testing that 'middle' assignment in binary search is correct
+    fn test_hit_test_point_basic_1() {
+        let mut text_layout = CairoText::new();
+
+        // base condition, one grapheme
+        let font = text_layout
+            .new_font_by_name("sans-serif", 12.0)
+            .build()
+            .unwrap();
+        let layout = text_layout.new_text_layout(&font, "t").build().unwrap();
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+
+        // two graphemes (to check that middle moves)
+        let pt = layout.hit_test_point(Point::new(1.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 0);
+
+        let layout = text_layout.new_text_layout(&font, "te").build().unwrap();
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+        println!("text pos 2: {:?}", layout.hit_test_text_position(2)); // 12.0
+
+        let pt = layout.hit_test_point(Point::new(1.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 0);
+        let pt = layout.hit_test_point(Point::new(4.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 1);
+        let pt = layout.hit_test_point(Point::new(6.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 1);
+        let pt = layout.hit_test_point(Point::new(11.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 2);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    // for testing that 'middle' assignment in binary search is correct
+    fn test_hit_test_point_basic_1() {
+        let mut text_layout = CairoText::new();
+
+        // base condition, one grapheme
+        let font = text_layout
+            .new_font_by_name("sans-serif", 12.0)
+            .build()
+            .unwrap();
+        let layout = text_layout.new_text_layout(&font, "t").build().unwrap();
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+
+        // two graphemes (to check that middle moves)
+        let pt = layout.hit_test_point(Point::new(1.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 0);
+
+        let layout = text_layout.new_text_layout(&font, "te").build().unwrap();
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+        println!("text pos 2: {:?}", layout.hit_test_text_position(2)); // 12.0
+
+        let pt = layout.hit_test_point(Point::new(1.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 0);
+        let pt = layout.hit_test_point(Point::new(4.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 1);
+        let pt = layout.hit_test_point(Point::new(6.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 1);
+        let pt = layout.hit_test_point(Point::new(11.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 2);
     }
 
     #[test]

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -597,6 +597,8 @@ impl TextLayout for CairoTextLayout {
                 right = middle;
             } else if point.x > grapheme_bounds.trailing {
                 left = middle;
+            } else {
+                unreachable!("hit_test_point conditional is exhaustive");
             }
         }
     }

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -51,8 +51,11 @@ fn run_tests(ctx: &mut WebRenderContext) {
     test::test_hit_test_text_position_complex_1(ctx);
     console::log_1(&"test hit_test_text_position_complex_1 complete".into());
 
-    test::test_hit_test_point_basic(ctx);
-    console::log_1(&"test hit_test_point_basic complete".into());
+    test::test_hit_test_point_basic_0(ctx);
+    console::log_1(&"test hit_test_point_basic complete_0".into());
+
+    test::test_hit_test_point_basic_1(ctx);
+    console::log_1(&"test hit_test_point_basic complete_1".into());
 
     test::test_hit_test_point_complex_0(ctx);
     console::log_1(&"test hit_test_point_complex_0 complete".into());
@@ -325,7 +328,7 @@ mod test {
     }
 
     // NOTE brittle test
-    pub fn test_hit_test_point_basic(ctx: &mut WebRenderContext) {
+    pub fn test_hit_test_point_basic_0(ctx: &mut WebRenderContext) {
         let text_layout = ctx;
 
         let font = text_layout
@@ -368,6 +371,35 @@ mod test {
         let pt = layout.hit_test_point(Point::new(-1.0, 0.0));
         assert_eq!(pt.metrics.text_position, 0); // first text position
         assert_eq!(pt.is_inside, false);
+    }
+
+    pub fn test_hit_test_point_basic_1(ctx: &mut WebRenderContext) {
+        let text_layout = ctx;
+
+        // base condition, one grapheme
+        let font = text_layout
+            .new_font_by_name("sans-serif", 12.0)
+            .build()
+            .unwrap();
+        let layout = text_layout.new_text_layout(&font, "t").build().unwrap();
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+
+        // two graphemes (to check that middle moves)
+        let pt = layout.hit_test_point(Point::new(1.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 0);
+
+        let layout = text_layout.new_text_layout(&font, "te").build().unwrap();
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+        println!("text pos 2: {:?}", layout.hit_test_text_position(2)); // 12.0
+
+        let pt = layout.hit_test_point(Point::new(1.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 0);
+        let pt = layout.hit_test_point(Point::new(4.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 1);
+        let pt = layout.hit_test_point(Point::new(6.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 1);
+        let pt = layout.hit_test_point(Point::new(11.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 2);
     }
 
     // NOTE brittle test

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -54,8 +54,11 @@ fn run_tests(ctx: &mut WebRenderContext) {
     test::test_hit_test_point_basic(ctx);
     console::log_1(&"test hit_test_point_basic complete".into());
 
-    test::test_hit_test_point_complex(ctx);
-    console::log_1(&"test hit_test_point_complex complete".into());
+    test::test_hit_test_point_complex_0(ctx);
+    console::log_1(&"test hit_test_point_complex_0 complete".into());
+
+    test::test_hit_test_point_complex_1(ctx);
+    console::log_1(&"test hit_test_point_complex_1 complete".into());
 }
 
 mod test {
@@ -368,7 +371,7 @@ mod test {
     }
 
     // NOTE brittle test
-    pub fn test_hit_test_point_complex(ctx: &mut WebRenderContext) {
+    pub fn test_hit_test_point_complex_0(ctx: &mut WebRenderContext) {
         // Notes on this input:
         // 6 code points
         // 7 utf-16 code units (1/1/1/1/1/2)
@@ -413,5 +416,32 @@ mod test {
         assert_eq!(pt.metrics.text_position, 14);
         let pt = layout.hit_test_point(Point::new(40.0, 0.0));
         assert_eq!(pt.metrics.text_position, 14);
+    }
+
+    pub fn test_hit_test_point_complex_1(ctx: &mut WebRenderContext) {
+        // this input caused an infinite loop in the binary search when test position
+        // > 21.0 && < 28.0
+        //
+        // This corresponds to the char 'y' in the input.
+        let input = "tßßypi";
+
+        let text_layout = ctx;
+        let font = text_layout
+            .new_font_by_name("sans-serif", 12.0)
+            .build()
+            .unwrap();
+        let layout = text_layout.new_text_layout(&font, input).build().unwrap();
+        println!("text pos 0: {:?}", layout.hit_test_text_position(0)); // 0.0
+        println!("text pos 1: {:?}", layout.hit_test_text_position(1)); // 5.0
+        println!("text pos 2: {:?}", layout.hit_test_text_position(2)); // 5.0
+        println!("text pos 3: {:?}", layout.hit_test_text_position(3)); // 13.0
+        println!("text pos 4: {:?}", layout.hit_test_text_position(4)); // 13.0
+        println!("text pos 5: {:?}", layout.hit_test_text_position(5)); // 21.0
+        println!("text pos 6: {:?}", layout.hit_test_text_position(6)); // 28.0
+        println!("text pos 7: {:?}", layout.hit_test_text_position(7)); // 36.0
+        println!("text pos 8: {:?}", layout.hit_test_text_position(8)); // 39.0, end
+
+        let pt = layout.hit_test_point(Point::new(27.0, 0.0));
+        assert_eq!(pt.metrics.text_position, 6);
     }
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -609,9 +609,9 @@ impl TextLayout for WebTextLayout {
             // since it's not a hit, check if closer to start or finish
             // and move the appropriate search boundary
             if point.x < grapheme_bounds.leading {
-                right = grapheme_bounds.curr_idx as usize; // should this be -1?
+                right = middle;
             } else if point.x > grapheme_bounds.trailing {
-                left = grapheme_bounds.curr_idx as usize; // should this be +1?
+                left = middle;
             }
         }
     }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -611,7 +611,7 @@ impl TextLayout for WebTextLayout {
             if point.x < grapheme_bounds.leading {
                 right = middle;
             } else if point.x > grapheme_bounds.trailing {
-                left = middle;
+                left = middle + 1;
             } else {
                 unreachable!("hit_test_point conditional is exhaustive");
             }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -612,6 +612,8 @@ impl TextLayout for WebTextLayout {
                 right = middle;
             } else if point.x > grapheme_bounds.trailing {
                 left = middle;
+            } else {
+                unreachable!("hit_test_point conditional is exhaustive");
             }
         }
     }


### PR DESCRIPTION
Hit test point was hanging (infinte loop in binary search). This should fix.

The issue was mixing up grapheme index and text position when updating the binary search slice.

This should hopefully provide a complete fix for the issue.

refer: #104 