### PR TITLE
add console_error_panic_hook to help debug panics in web example.

### DIFF
--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -13,6 +13,7 @@ piet-web = { path = "../.." }
 piet-test = { path = "../../../piet-test" }
 
 wasm-bindgen = "0.2.30"
+console_error_panic_hook = "0.1.6"
 [dependencies.web-sys]
 version = "0.3.10"
 features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement"]

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -9,8 +9,12 @@ use piet_web::WebRenderContext;
 
 use piet_test::draw_test_picture;
 
+extern crate console_error_panic_hook;
+use std::panic;
+
 #[wasm_bindgen]
 pub fn run() {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
     let window = window().unwrap();
     let canvas = window
         .document()


### PR DESCRIPTION
The test page wasn't working for me - I needed to add this crate to diagnose via stack trace. LMK if you need any changes. 