### PR TITLE
Raw d2d

### DIFF
--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -4,7 +4,7 @@ use piet::{Color, ImageFormat, RenderContext};
 use piet_common::Device;
 
 fn main() {
-    let device = Device::new().unwrap();
+    let mut device = Device::new().unwrap();
     let width = 640;
     let height = 480;
     let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -67,7 +67,7 @@ impl Device {
 
     /// Create a new bitmap target.
     pub fn bitmap_target(
-        &self,
+        &mut self,
         width: usize,
         height: usize,
         pix_scale: f64,

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -2,14 +2,20 @@
 
 use std::fmt;
 
-use direct2d::enums::BitmapOptions;
-use direct2d::image::Bitmap;
-use direct2d::render_target::RenderTag;
-use direct2d::RenderTarget;
-use direct3d11::flags::{BindFlags, CreateDeviceFlags};
-use direct3d11::helpers::ComWrapper;
-use dxgi::flags::Format;
+// --- old block of imports
+//use direct2d::enums::BitmapOptions;
+//use direct2d::image::Bitmap;
+//use direct2d::render_target::RenderTag;
+//use direct2d::RenderTarget;
+//use direct3d11::flags::{BindFlags, CreateDeviceFlags};
+//use direct3d11::helpers::ComWrapper;
+//use dxgi::flags::Format;
 
+// --- new block of imports
+// d3d11 interface, enough for drawing d2d
+use piet_direct2d::d3d::{D3D11Device, D3D11DeviceContext, D3D11Texture2D, DXGI_MAP_READ, TextureMode};
+
+// -- end change in import block
 use piet::{ErrorKind, ImageFormat};
 
 #[doc(hidden)]
@@ -55,85 +61,27 @@ pub type Image = Bitmap;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {
-    d2d: direct2d::Factory,
-    dwrite: directwrite::Factory,
-    d3d: direct3d11::Device,
-    d3d_ctx: direct3d11::DeviceContext,
-    device: direct2d::Device,
+    d2d: D2DFactory,
+    dwrite: DwriteFactory,
+    d3d: D3D11Device,
+    d3d_ctx: D3D11DeviceContext,
+    device: D2DDevice,
 }
 
 /// A struct provides a `RenderContext` and then can have its bitmap extracted.
 pub struct BitmapTarget<'a> {
     width: usize,
     height: usize,
-    d2d: &'a direct2d::Factory,
-    dwrite: &'a directwrite::Factory,
-    d3d: &'a direct3d11::Device,
-    d3d_ctx: &'a direct3d11::DeviceContext,
-    tex: direct3d11::Texture2D,
-    context: direct2d::DeviceContext,
+    d2d: &'a D2DFactory,
+    dwrite: &'a DwriteFactory,
+    d3d: &'a D3D11Device,
+    d3d_ctx: &'a D3D11DeviceContext,
+    tex: D3D11Texture2D,
+    context: D2DDeviceContext,
 }
 
 trait WrapError<T> {
     fn wrap(self) -> Result<T, piet::Error>;
-}
-
-#[derive(Debug)]
-struct WrappedD2DTag(direct2d::Error, Option<RenderTag>);
-
-#[derive(Debug)]
-struct WrappedD3D11Error(direct3d11::Error);
-
-#[derive(Debug)]
-struct WrappedDxgiError(dxgi::Error);
-
-impl std::error::Error for WrappedD2DTag {}
-impl std::error::Error for WrappedD3D11Error {}
-impl std::error::Error for WrappedDxgiError {}
-
-impl fmt::Display for WrappedD2DTag {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Direct2D error: {}, tag {:?}", self.0, self.1)
-    }
-}
-
-impl fmt::Display for WrappedD3D11Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Direct3D11 error: {}", self.0)
-    }
-}
-
-impl fmt::Display for WrappedDxgiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Dxgi error: {}", self.0)
-    }
-}
-
-impl<T> WrapError<T> for Result<T, (direct2d::Error, Option<RenderTag>)> {
-    fn wrap(self) -> Result<T, piet::Error> {
-        self.map_err(|(e, t)| {
-            let e: Box<dyn std::error::Error> = Box::new(WrappedD2DTag(e, t));
-            e.into()
-        })
-    }
-}
-
-impl<T> WrapError<T> for Result<T, direct3d11::Error> {
-    fn wrap(self) -> Result<T, piet::Error> {
-        self.map_err(|e| {
-            let e: Box<dyn std::error::Error> = Box::new(WrappedD3D11Error(e));
-            e.into()
-        })
-    }
-}
-
-impl<T> WrapError<T> for Result<T, dxgi::Error> {
-    fn wrap(self) -> Result<T, piet::Error> {
-        self.map_err(|e| {
-            let e: Box<dyn std::error::Error> = Box::new(WrappedDxgiError(e));
-            e.into()
-        })
-    }
 }
 
 impl Device {
@@ -142,17 +90,14 @@ impl Device {
     /// This creates new Direct2D and DirectWrite factories, a Direct3D
     /// device, and a Direct2D device.
     pub fn new() -> Result<Device, piet::Error> {
-        let d2d = direct2d::Factory::new().unwrap();
-        let dwrite = directwrite::Factory::new().unwrap();
+        let d2d = D2DFactory::new().unwrap();
+        let dwrite = DwriteFactory::new().unwrap();
 
         // Initialize a D3D Device
-        let (_, d3d, d3d_ctx) = direct3d11::Device::create()
-            .with_flags(CreateDeviceFlags::BGRA_SUPPORT)
-            .build()
-            .unwrap();
+        let (d3d, d3d_ctx) = D3D11Device::create().unwrap();
 
-        // Create the D2D Device and Context
-        let device = direct2d::Device::create(&d2d, &d3d.as_dxgi()).unwrap();
+        // Create the D2D Device
+        let device = unsafe { d2d.create_device(d3d.as_dxgi().unwrap().as_raw()).unwrap() };
 
         Ok(Device {
             d2d,
@@ -165,30 +110,28 @@ impl Device {
 
     /// Create a new bitmap target.
     pub fn bitmap_target(
-        &self,
+        &mut self, //TODO this changed to mut, double check that this it ok
         width: usize,
         height: usize,
         pix_scale: f64,
     ) -> Result<BitmapTarget, piet::Error> {
-        let mut context = direct2d::DeviceContext::create(&self.device, false).unwrap();
+        let mut context = self.device.create_device_context().unwrap();
 
         // Create a texture to render to
-        let tex = direct3d11::Texture2D::create(&self.d3d)
-            .with_size(width as u32, height as u32)
-            .with_format(Format::R8G8B8A8Unorm)
-            .with_bind_flags(BindFlags::RENDER_TARGET | BindFlags::SHADER_RESOURCE)
-            .build()
+        let tex = self.d3d
+            .create_texture(width as u32, height as u32, TextureMode::Target)
             .unwrap();
 
         // Bind the backing texture to a D2D Bitmap
-        let target = Bitmap::create(&context)
-            .with_dxgi_surface(&tex.as_dxgi())
-            .with_dpi(96.0 * pix_scale as f32, 96.0 * pix_scale as f32)
-            .with_options(BitmapOptions::TARGET)
-            .build()
-            .unwrap();
+        let target = unsafe {
+            context
+                .create_bitmap_from_dxgi(&tex.as_dxgi(), pix_scale as f32)
+                .unwrap()
+        };
 
         context.set_target(&target);
+        // TODO ask about this? it was in basic.rs, but not here
+        context.set_dpi_scale(pix_scale as f32);
         context.begin_draw();
 
         Ok(BitmapTarget {
@@ -219,31 +162,32 @@ impl<'a> BitmapTarget<'a> {
         if fmt != ImageFormat::RgbaPremul {
             return Err(piet::new_error(ErrorKind::NotSupported));
         }
-        self.context.end_draw().wrap()?;
-        let temp_texture = direct3d11::texture2d::Texture2D::create(self.d3d)
-            .with_size(self.width as u32, self.height as u32)
-            .with_format(direct3d11::flags::Format::R8G8B8A8Unorm)
-            .with_bind_flags(direct3d11::flags::BindFlags::NONE)
-            .with_usage(direct3d11::flags::Usage::Staging)
-            .with_cpu_access_flags(direct3d11::flags::CpuAccessFlags::READ)
-            .build()
-            .wrap()?;
+        self.context.end_draw()?;
+        let temp_texture = self.d3d
+            .create_texture(self.width as u32, self.height as u32, TextureMode::Read)
+            .unwrap();
 
         // TODO: Have a safe way to accomplish this :D
         let mut raw_pixels: Vec<u8> = Vec::with_capacity(self.width * self.height * 4);
         unsafe {
-            let ctx = &*self.d3d_ctx.get_raw();
-            ctx.CopyResource(
-                temp_texture.get_raw() as *mut _,
-                self.tex.get_raw() as *mut _,
-            );
-            ctx.Flush();
+            self.d3d_ctx
+                .inner()
+                .CopyResource(temp_texture.as_raw() as *mut _, self.tex.as_raw() as *mut _);
+            self.d3d_ctx.inner().Flush();
 
             let surface = temp_texture.as_dxgi();
-            let map = surface.map(true, false, false).wrap()?;
-            for y in 0..(self.height as u32) {
-                raw_pixels.extend_from_slice(&map.row(y)[..self.width * 4]);
+            let mut mapped_rect = std::mem::zeroed();
+            let _hr = surface.Map(&mut mapped_rect, DXGI_MAP_READ);
+            for y in 0..self.height {
+                let src = mapped_rect
+                    .pBits
+                    .offset(mapped_rect.Pitch as isize * y as isize);
+                let dst = raw_pixels
+                    .as_mut_ptr()
+                    .offset(self.width as isize * 4 * y as isize);
+                std::ptr::copy_nonoverlapping(src, dst, self.width * 4);
             }
+            raw_pixels.set_len(self.width * self.height * 4);
         }
         Ok(raw_pixels)
     }

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -12,11 +12,6 @@ pub use piet_direct2d::*;
 /// The `RenderContext` for the Direct2D backend, which is selected.
 pub type Piet<'a> = D2DRenderContext<'a>;
 
-/// The associated brush type for this backend.
-///
-/// This type matches `RenderContext::Brush`
-//pub type Brush = GenericBrush;
-
 /// The associated text factory for this backend.
 ///
 /// This type matches `RenderContext::Text`
@@ -41,11 +36,6 @@ pub type PietTextLayout = D2DTextLayout;
 ///
 /// This type matches `RenderContext::Text::TextLayoutBuilder`
 pub type PietTextLayoutBuilder<'a> = D2DTextLayoutBuilder<'a>;
-
-/// The associated image type for this backend.
-///
-/// This type matches `RenderContext::Image`
-//pub type Image = Bitmap;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -1,7 +1,5 @@
 //! Support for piet Direct2D back-end.
 
-use std::fmt;
-
 use piet_direct2d::d3d::{
     D3D11Device, D3D11DeviceContext, D3D11Texture2D, TextureMode, DXGI_MAP_READ,
 };

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -13,7 +13,9 @@ use std::fmt;
 
 // --- new block of imports
 // d3d11 interface, enough for drawing d2d
-use piet_direct2d::d3d::{D3D11Device, D3D11DeviceContext, D3D11Texture2D, DXGI_MAP_READ, TextureMode};
+use piet_direct2d::d3d::{
+    D3D11Device, D3D11DeviceContext, D3D11Texture2D, TextureMode, DXGI_MAP_READ,
+};
 
 // -- end change in import block
 use piet::{ErrorKind, ImageFormat};
@@ -118,7 +120,8 @@ impl Device {
         let mut context = self.device.create_device_context().unwrap();
 
         // Create a texture to render to
-        let tex = self.d3d
+        let tex = self
+            .d3d
             .create_texture(width as u32, height as u32, TextureMode::Target)
             .unwrap();
 
@@ -163,7 +166,8 @@ impl<'a> BitmapTarget<'a> {
             return Err(piet::new_error(ErrorKind::NotSupported));
         }
         self.context.end_draw()?;
-        let temp_texture = self.d3d
+        let temp_texture = self
+            .d3d
             .create_texture(self.width as u32, self.height as u32, TextureMode::Read)
             .unwrap();
 

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -27,7 +27,7 @@ pub type Piet<'a> = D2DRenderContext<'a>;
 /// The associated brush type for this backend.
 ///
 /// This type matches `RenderContext::Brush`
-pub type Brush = GenericBrush;
+//pub type Brush = GenericBrush;
 
 /// The associated text factory for this backend.
 ///
@@ -57,7 +57,7 @@ pub type PietTextLayoutBuilder<'a> = D2DTextLayoutBuilder<'a>;
 /// The associated image type for this backend.
 ///
 /// This type matches `RenderContext::Image`
-pub type Image = Bitmap;
+//pub type Image = Bitmap;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -112,7 +112,7 @@ impl Device {
 
     /// Create a new bitmap target.
     pub fn bitmap_target(
-        &mut self, //TODO this changed to mut, double check that this it ok
+        &mut self,
         width: usize,
         height: usize,
         pix_scale: f64,

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -2,22 +2,10 @@
 
 use std::fmt;
 
-// --- old block of imports
-//use direct2d::enums::BitmapOptions;
-//use direct2d::image::Bitmap;
-//use direct2d::render_target::RenderTag;
-//use direct2d::RenderTarget;
-//use direct3d11::flags::{BindFlags, CreateDeviceFlags};
-//use direct3d11::helpers::ComWrapper;
-//use dxgi::flags::Format;
-
-// --- new block of imports
-// d3d11 interface, enough for drawing d2d
 use piet_direct2d::d3d::{
     D3D11Device, D3D11DeviceContext, D3D11Texture2D, TextureMode, DXGI_MAP_READ,
 };
 
-// -- end change in import block
 use piet::{ErrorKind, ImageFormat};
 
 #[doc(hidden)]

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -12,14 +12,12 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "0.0.8", path = "../piet" }
 
-direct2d = "0.2.0"
-directwrite = "0.1.4"
-dxgi = "0.1.7"
-winapi = "0.3.7"
-
 wio = "0.2.2"
 
+[dependencies.winapi]
+version = "0.3.8"
+features = [ "d2d1", "d2d1_1", "d3d11", "dxgi" ]
+
 [dev-dependencies]
-direct3d11 = "0.1.7"
 image = "0.22.1"
 piet-test = { version = "0.0.8", path = "../piet-test" }

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -17,6 +17,8 @@ directwrite = "0.1.4"
 dxgi = "0.1.7"
 winapi = "0.3.7"
 
+wio = "0.2.2"
+
 [dev-dependencies]
 direct3d11 = "0.1.7"
 image = "0.22.1"

--- a/piet-direct2d/examples/basic.rs
+++ b/piet-direct2d/examples/basic.rs
@@ -1,13 +1,21 @@
 //! Basic example of rendering on Direct2D.
 
-use direct2d;
-use direct2d::enums::BitmapOptions;
-use direct2d::image::Bitmap;
-use direct2d::RenderTarget;
-use direct3d11;
-use direct3d11::flags::{BindFlags, CreateDeviceFlags};
-use direct3d11::helpers::ComWrapper;
-use dxgi::flags::Format;
+use std::ptr::null_mut;
+
+use winapi::shared::dxgi::{IDXGIDevice, IDXGISurface, DXGI_MAP_READ};
+use winapi::shared::dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM;
+use winapi::shared::dxgitype::DXGI_SAMPLE_DESC;
+use winapi::shared::winerror::{HRESULT, SUCCEEDED};
+use winapi::um::d3d11::{
+    D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D, D3D11_BIND_FLAG,
+    D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_CPU_ACCESS_FLAG,
+    D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION,
+    D3D11_TEXTURE2D_DESC, D3D11_USAGE, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING,
+};
+use winapi::um::d3dcommon::D3D_DRIVER_TYPE_HARDWARE;
+use winapi::Interface;
+
+use wio::com::ComPtr;
 
 use piet::RenderContext;
 use piet_direct2d::D2DRenderContext;
@@ -30,37 +38,30 @@ fn main() {
         .unwrap_or(0);
 
     // Create the D2D factory
-    let d2d = direct2d::factory::Factory::new().unwrap();
-    let dwrite = directwrite::factory::Factory::new().unwrap();
+    let d2d = piet_direct2d::D2DFactory::new().unwrap();
+    let dwrite = piet_direct2d::DwriteFactory::new().unwrap();
 
     // Initialize a D3D Device
-    let (_, d3d, d3d_ctx) = direct3d11::device::Device::create()
-        .with_flags(CreateDeviceFlags::BGRA_SUPPORT)
-        .build()
-        .unwrap();
+    let (d3d, d3d_ctx) = D3D11Device::create().unwrap();
 
     // Create the D2D Device and Context
-    let device = direct2d::Device::create(&d2d, &d3d.as_dxgi()).unwrap();
-    let mut context = direct2d::DeviceContext::create(&device, false).unwrap();
+    let mut device = unsafe { d2d.create_device(d3d.as_dxgi().unwrap().as_raw()).unwrap() };
+    let mut context = device.create_device_context().unwrap();
 
     // Create a texture to render to
-    let tex = direct3d11::texture2d::Texture2D::create(&d3d)
-        .with_size(TEXTURE_WIDTH, TEXTURE_HEIGHT)
-        .with_format(Format::R8G8B8A8Unorm)
-        .with_bind_flags(BindFlags::RENDER_TARGET | BindFlags::SHADER_RESOURCE)
-        .build()
+    let tex = d3d
+        .create_texture(TEXTURE_WIDTH, TEXTURE_HEIGHT, TextureMode::Target)
         .unwrap();
 
     // Bind the backing texture to a D2D Bitmap
-    let target = Bitmap::create(&context)
-        .with_dxgi_surface(&tex.as_dxgi())
-        .with_dpi(96.0 * HIDPI, 96.0 * HIDPI)
-        .with_options(BitmapOptions::TARGET)
-        .build()
-        .unwrap();
+    let target = unsafe {
+        context
+            .create_bitmap_from_dxgi(&tex.as_dxgi(), HIDPI)
+            .unwrap()
+    };
 
     context.set_target(&target);
-    context.set_dpi(96.0 * HIDPI, 96.0 * HIDPI);
+    context.set_dpi_scale(HIDPI);
     context.begin_draw();
     let mut piet_context = D2DRenderContext::new(&d2d, &dwrite, &mut context);
     // TODO: report errors more nicely than these unwraps.
@@ -68,28 +69,32 @@ fn main() {
     piet_context.finish().unwrap();
     context.end_draw().unwrap();
 
-    let temp_texture = direct3d11::texture2d::Texture2D::create(&d3d)
-        .with_size(TEXTURE_WIDTH, TEXTURE_HEIGHT)
-        .with_format(direct3d11::flags::Format::R8G8B8A8Unorm)
-        .with_bind_flags(direct3d11::flags::BindFlags::NONE)
-        .with_usage(direct3d11::flags::Usage::Staging)
-        .with_cpu_access_flags(direct3d11::flags::CpuAccessFlags::READ)
-        .build()
+    let temp_texture = d3d
+        .create_texture(TEXTURE_WIDTH, TEXTURE_HEIGHT, TextureMode::Read)
         .unwrap();
 
     // Get the data so we can write it to a file
     // TODO: Have a safe way to accomplish this :D
     let mut raw_pixels: Vec<u8> = Vec::with_capacity(TEXTURE_WIDTH_S * TEXTURE_HEIGHT_S * 4);
     unsafe {
-        let ctx = &*d3d_ctx.get_raw();
-        ctx.CopyResource(temp_texture.get_raw() as *mut _, tex.get_raw() as *mut _);
-        ctx.Flush();
+        d3d_ctx
+            .0
+            .CopyResource(temp_texture.0.as_raw() as *mut _, tex.0.as_raw() as *mut _);
+        d3d_ctx.0.Flush();
 
         let surface = temp_texture.as_dxgi();
-        let map = surface.map(true, false, false).unwrap();
+        let mut mapped_rect = std::mem::zeroed();
+        let _hr = surface.Map(&mut mapped_rect, DXGI_MAP_READ);
         for y in 0..TEXTURE_HEIGHT {
-            raw_pixels.extend_from_slice(&map.row(y)[..TEXTURE_WIDTH_S * 4]);
+            let src = mapped_rect
+                .pBits
+                .offset(mapped_rect.Pitch as isize * y as isize);
+            let dst = raw_pixels
+                .as_mut_ptr()
+                .offset(TEXTURE_WIDTH_S as isize * 4 * y as isize);
+            std::ptr::copy_nonoverlapping(src, dst, TEXTURE_WIDTH_S * 4);
         }
+        raw_pixels.set_len(TEXTURE_WIDTH_S * TEXTURE_HEIGHT_S * 4);
     }
 
     image::save_buffer(
@@ -100,4 +105,125 @@ fn main() {
         image::ColorType::RGBA(8),
     )
     .unwrap();
+}
+
+// Minimal wrapping of enough bureaucracy to run the lib follows. It's
+// possible we want to export some of this publicly for the sake of
+// piet-common, avoiding code duplication.
+
+#[derive(Debug)]
+struct Error(HRESULT);
+
+struct D3D11Device(ComPtr<ID3D11Device>);
+struct D3D11DeviceContext(ComPtr<ID3D11DeviceContext>);
+struct D3D11Texture2D(ComPtr<ID3D11Texture2D>);
+struct DxgiDevice(ComPtr<IDXGIDevice>);
+
+enum TextureMode {
+    Target,
+    Read,
+}
+
+impl TextureMode {
+    fn usage(&self) -> D3D11_USAGE {
+        match self {
+            TextureMode::Target => D3D11_USAGE_DEFAULT,
+            TextureMode::Read => D3D11_USAGE_STAGING,
+        }
+    }
+
+    fn bind_flags(&self) -> D3D11_BIND_FLAG {
+        match self {
+            TextureMode::Target => D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+            TextureMode::Read => 0,
+        }
+    }
+
+    fn cpu_access_flags(&self) -> D3D11_CPU_ACCESS_FLAG {
+        match self {
+            TextureMode::Target => 0,
+            TextureMode::Read => D3D11_CPU_ACCESS_READ,
+        }
+    }
+}
+
+unsafe fn wrap<T, U, F>(hr: HRESULT, ptr: *mut T, f: F) -> Result<U, Error>
+where
+    F: Fn(ComPtr<T>) -> U,
+    T: Interface,
+{
+    if SUCCEEDED(hr) {
+        Ok(f(ComPtr::from_raw(ptr)))
+    } else {
+        Err(Error(hr))
+    }
+}
+
+impl D3D11Device {
+    // This function only supports a fraction of available options.
+    fn create() -> Result<(D3D11Device, D3D11DeviceContext), Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let mut ctx_ptr = null_mut();
+            let hr = D3D11CreateDevice(
+                null_mut(), /* adapter */
+                D3D_DRIVER_TYPE_HARDWARE,
+                null_mut(), /* module */
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                null_mut(), /* feature levels */
+                0,
+                D3D11_SDK_VERSION,
+                &mut ptr,
+                null_mut(), /* feature level */
+                &mut ctx_ptr,
+            );
+            let device = wrap(hr, ptr, D3D11Device)?;
+            let device_ctx = wrap(hr, ctx_ptr, D3D11DeviceContext)?;
+            Ok((device, device_ctx))
+        }
+    }
+
+    fn as_dxgi(&self) -> Option<DxgiDevice> {
+        self.0.cast().ok().map(DxgiDevice)
+    }
+
+    fn create_texture(
+        &self,
+        width: u32,
+        height: u32,
+        mode: TextureMode,
+    ) -> Result<D3D11Texture2D, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let desc = D3D11_TEXTURE2D_DESC {
+                Width: width,
+                Height: height,
+                MipLevels: 1,
+                ArraySize: 1,
+                Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
+                Usage: mode.usage(),
+                BindFlags: mode.bind_flags(),
+                CPUAccessFlags: mode.cpu_access_flags(),
+                MiscFlags: 0,
+            };
+            let hr = self.0.CreateTexture2D(&desc, null_mut(), &mut ptr);
+            wrap(hr, ptr, D3D11Texture2D)
+        }
+    }
+}
+
+impl DxgiDevice {
+    fn as_raw(&self) -> *mut IDXGIDevice {
+        self.0.as_raw()
+    }
+}
+
+impl D3D11Texture2D {
+    fn as_dxgi(&self) -> ComPtr<IDXGISurface> {
+        self.0.cast().unwrap()
+    }
 }

--- a/piet-direct2d/examples/basic.rs
+++ b/piet-direct2d/examples/basic.rs
@@ -1,4 +1,5 @@
 //! Basic example of rendering on Direct2D.
+// TODO cleanup, much of this now exists in d3d.rs
 
 use std::ptr::null_mut;
 

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -1,29 +1,27 @@
 //! Conversions of types into Direct2D
 
-use direct2d::math::{ColorF, Matrix3x2F, Point2F, RectF};
+use winapi::um::d2d1::{
+    D2D1_CAP_STYLE, D2D1_CAP_STYLE_FLAT, D2D1_CAP_STYLE_ROUND, D2D1_CAP_STYLE_SQUARE, D2D1_COLOR_F,
+    D2D1_DASH_STYLE_CUSTOM, D2D1_DASH_STYLE_SOLID, D2D1_GRADIENT_STOP, D2D1_LINE_JOIN,
+    D2D1_LINE_JOIN_BEVEL, D2D1_LINE_JOIN_MITER, D2D1_LINE_JOIN_ROUND, D2D1_MATRIX_3X2_F,
+    D2D1_POINT_2F, D2D1_RECT_F, D2D1_STROKE_STYLE_PROPERTIES,
+};
 
 use piet::kurbo::{Affine, Point, Rect, Vec2};
 
 use piet::{Color, Error, GradientStop, LineCap, LineJoin, RoundFrom, RoundInto, StrokeStyle};
 
-use crate::error::WrapError;
+use crate::d2d::D2DFactory;
 
 /// This is wrapped for coherence reasons.
 ///
 /// TODO: consider using Point2F instead, and moving conversions into kurbo.
-pub struct Point2(pub Point2F);
-
-impl From<Point2F> for Point2 {
-    #[inline]
-    fn from(vec: Point2F) -> Point2 {
-        Point2(vec.into())
-    }
-}
+pub struct Point2(pub D2D1_POINT_2F);
 
 impl From<(f32, f32)> for Point2 {
     #[inline]
     fn from(vec: (f32, f32)) -> Point2 {
-        Point2(Point2F::new(vec.0, vec.1))
+        Point2(D2D1_POINT_2F { x: vec.0, y: vec.1 })
     }
 }
 
@@ -32,28 +30,37 @@ impl From<(f32, f32)> for Point2 {
 impl RoundFrom<(f32, f32)> for Point2 {
     #[inline]
     fn round_from(vec: (f32, f32)) -> Point2 {
-        Point2(Point2F::new(vec.0, vec.1))
+        Point2(D2D1_POINT_2F { x: vec.0, y: vec.1 })
     }
 }
 
 impl RoundFrom<(f64, f64)> for Point2 {
     #[inline]
     fn round_from(vec: (f64, f64)) -> Point2 {
-        Point2(Point2F::new(vec.0 as f32, vec.1 as f32))
+        Point2(D2D1_POINT_2F {
+            x: vec.0 as f32,
+            y: vec.1 as f32,
+        })
     }
 }
 
 impl RoundFrom<Point> for Point2 {
     #[inline]
     fn round_from(point: Point) -> Point2 {
-        Point2(Point2F::new(point.x as f32, point.y as f32))
+        Point2(D2D1_POINT_2F {
+            x: point.x as f32,
+            y: point.y as f32,
+        })
     }
 }
 
 impl RoundFrom<Vec2> for Point2 {
     #[inline]
     fn round_from(vec: Vec2) -> Point2 {
-        Point2(Point2F::new(vec.x as f32, vec.y as f32))
+        Point2(D2D1_POINT_2F {
+            x: vec.x as f32,
+            y: vec.y as f32,
+        })
     }
 }
 
@@ -64,60 +71,66 @@ impl From<Point2> for Vec2 {
     }
 }
 
-pub(crate) fn to_point2f<P: RoundInto<Point2>>(p: P) -> Point2F {
+pub(crate) fn to_point2f<P: RoundInto<Point2>>(p: P) -> D2D1_POINT_2F {
     p.round_into().0
 }
 
 /// Can't implement RoundFrom here because both types belong to other
 /// crates. Consider moving to kurbo (with windows feature).
-pub(crate) fn affine_to_matrix3x2f(affine: Affine) -> Matrix3x2F {
+pub(crate) fn affine_to_matrix3x2f(affine: Affine) -> D2D1_MATRIX_3X2_F {
     let a = affine.as_coeffs();
-    Matrix3x2F::new([
-        [a[0] as f32, a[1] as f32],
-        [a[2] as f32, a[3] as f32],
-        [a[4] as f32, a[5] as f32],
-    ])
+    D2D1_MATRIX_3X2_F {
+        matrix: [
+            [a[0] as f32, a[1] as f32],
+            [a[2] as f32, a[3] as f32],
+            [a[4] as f32, a[5] as f32],
+        ],
+    }
 }
 
 // TODO: consider adding to kurbo.
-pub(crate) fn rect_to_rectf(rect: Rect) -> RectF {
-    (
-        rect.x0 as f32,
-        rect.y0 as f32,
-        rect.x1 as f32,
-        rect.y1 as f32,
-    )
-        .into()
+pub(crate) fn rect_to_rectf(rect: Rect) -> D2D1_RECT_F {
+    D2D1_RECT_F {
+        left: rect.x0 as f32,
+        top: rect.y0 as f32,
+        right: rect.x1 as f32,
+        bottom: rect.y1 as f32,
+    }
 }
 
-pub(crate) fn color_to_colorf(color: Color) -> ColorF {
+pub(crate) fn color_to_colorf(color: Color) -> D2D1_COLOR_F {
     let rgba = color.as_rgba_u32();
-    (rgba >> 8, ((rgba & 255) as f32) * (1.0 / 255.0)).into()
+    D2D1_COLOR_F {
+        r: (((rgba >> 24) & 255) as f32) * (1.0 / 255.0),
+        g: (((rgba >> 16) & 255) as f32) * (1.0 / 255.0),
+        b: (((rgba >> 8) & 255) as f32) * (1.0 / 255.0),
+        a: ((rgba & 255) as f32) * (1.0 / 255.0),
+    }
 }
 
-pub(crate) fn gradient_stop_to_d2d(stop: &GradientStop) -> direct2d::brush::gradient::GradientStop {
-    direct2d::brush::gradient::GradientStop {
+pub(crate) fn gradient_stop_to_d2d(stop: &GradientStop) -> D2D1_GRADIENT_STOP {
+    D2D1_GRADIENT_STOP {
         position: stop.pos,
         color: color_to_colorf(stop.color.clone()),
     }
 }
 
-fn convert_line_cap(line_cap: LineCap) -> direct2d::enums::CapStyle {
+fn convert_line_cap(line_cap: LineCap) -> D2D1_CAP_STYLE {
     match line_cap {
-        LineCap::Butt => direct2d::enums::CapStyle::Flat,
-        LineCap::Round => direct2d::enums::CapStyle::Round,
-        LineCap::Square => direct2d::enums::CapStyle::Square,
+        LineCap::Butt => D2D1_CAP_STYLE_FLAT,
+        LineCap::Round => D2D1_CAP_STYLE_ROUND,
+        LineCap::Square => D2D1_CAP_STYLE_SQUARE,
         // Discussion topic: Triangle. Exposing that as optional
         // functionality is actually a reasonable argument for this being
         // an associated type rather than a concrete type.
     }
 }
 
-fn convert_line_join(line_join: LineJoin) -> direct2d::enums::LineJoin {
+fn convert_line_join(line_join: LineJoin) -> D2D1_LINE_JOIN {
     match line_join {
-        LineJoin::Miter => direct2d::enums::LineJoin::Miter,
-        LineJoin::Round => direct2d::enums::LineJoin::Round,
-        LineJoin::Bevel => direct2d::enums::LineJoin::Bevel,
+        LineJoin::Miter => D2D1_LINE_JOIN_MITER,
+        LineJoin::Round => D2D1_LINE_JOIN_ROUND,
+        LineJoin::Bevel => D2D1_LINE_JOIN_BEVEL,
         // Discussion topic: MiterOrBevel. Exposing that as optional
         // functionality is actually a reasonable argument for this being
         // an associated type rather than a concrete type.
@@ -125,30 +138,34 @@ fn convert_line_join(line_join: LineJoin) -> direct2d::enums::LineJoin {
 }
 
 pub(crate) fn convert_stroke_style(
-    factory: &direct2d::Factory,
+    factory: &D2DFactory,
     stroke_style: &StrokeStyle,
     width: f32,
-) -> Result<direct2d::stroke_style::StrokeStyle, Error> {
+) -> Result<crate::d2d::StrokeStyle, Error> {
     #[allow(unused)]
-    let mut dashes_f32 = Vec::<f32>::new();
-    let mut builder = direct2d::stroke_style::StrokeStyle::create(factory);
-    if let Some(join) = stroke_style.line_join {
-        builder = builder.with_line_join(convert_line_join(join));
-    }
-    if let Some(cap) = stroke_style.line_cap {
-        let cap = convert_line_cap(cap);
-        builder = builder.with_start_cap(cap).with_end_cap(cap);
-    }
-    // D2D seems to use units of multiples of the stroke width.
-    let width_recip = if width == 0.0 { 1.0 } else { width.recip() };
-    if let Some((ref dashes, offset)) = stroke_style.dash {
-        dashes_f32 = dashes.iter().map(|x| *x as f32 * width_recip).collect();
-        builder = builder
-            .with_dashes(&dashes_f32)
-            .with_dash_offset(offset as f32);
-    }
-    if let Some(limit) = stroke_style.miter_limit {
-        builder = builder.with_miter_limit(limit as f32);
-    }
-    builder.build().wrap()
+    let cap = convert_line_cap(stroke_style.line_cap.unwrap_or(LineCap::Butt));
+    let join = convert_line_join(stroke_style.line_join.unwrap_or(LineJoin::Miter));
+    let (dashes, dash_style, dash_off) = match &stroke_style.dash {
+        Some((dashes, off)) => {
+            let width_recip = if width == 0.0 { 1.0 } else { width.recip() };
+            assert!(dashes.len() <= 0xffff_ffff);
+            (
+                Some(dashes.iter().map(|x| *x as f32 * width_recip).collect()),
+                D2D1_DASH_STYLE_CUSTOM,
+                *off as f32,
+            )
+        }
+        None => (None, D2D1_DASH_STYLE_SOLID, 0.0),
+    };
+    let props = D2D1_STROKE_STYLE_PROPERTIES {
+        startCap: cap,
+        endCap: cap,
+        dashCap: D2D1_CAP_STYLE_FLAT,
+        lineJoin: join,
+        miterLimit: stroke_style.miter_limit.unwrap_or(10.0) as f32,
+        dashStyle: dash_style,
+        dashOffset: dash_off,
+    };
+    let dashes = dashes.as_ref().map(|v: &Vec<_>| v.as_slice());
+    Ok(factory.create_stroke_style(&props, dashes)?)
 }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -168,6 +168,10 @@ impl D2DFactory {
         wrap(hr, ptr, D2DDevice)
     }
 
+    pub unsafe fn get_raw(&self) -> *mut ID2D1Factory1 {
+        self.0.as_raw()
+    }
+
     pub fn create_path_geometry(&self) -> Result<PathGeometry, Error> {
         unsafe {
             let mut ptr = null_mut();

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -51,6 +51,9 @@ pub enum Error {
 }
 
 /// A Direct2D factory object.
+///
+/// This struct is public only to use for system integration in piet_common and druid-shell. It is not intended
+/// that end-users directly use this struct.
 pub struct D2DFactory(ComPtr<ID2D1Factory1>);
 
 /// A Direct2D device.
@@ -60,6 +63,9 @@ pub struct D2DDevice(ComPtr<ID2D1Device>);
 ///
 /// This type is a thin wrapper for
 /// [ID2D1DeviceContext](https://docs.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1devicecontext).
+///
+/// This struct is public only to use for system integration in piet_common and druid-shell. It is not intended
+/// that end-users directly use this struct.
 pub struct DeviceContext(ComPtr<ID2D1DeviceContext>);
 
 pub struct PathGeometry(ComPtr<ID2D1PathGeometry>);

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -1,0 +1,335 @@
+//! Convenience wrappers for Direct2D objects.
+//!
+//! These also function as safety boundaries (though determining the
+//! exact safety guarantees is work in progress).
+
+// TODO: get rid of this when we actually do use everything
+#![allow(unused)]
+
+use std::ffi::c_void;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ptr::null_mut;
+
+use wio::com::ComPtr;
+
+use winapi::shared::dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM;
+use winapi::shared::winerror::{HRESULT, SUCCEEDED};
+use winapi::um::d2d1::{
+    D2D1CreateFactory, ID2D1Brush, ID2D1Factory, ID2D1GeometrySink, ID2D1GradientStopCollection,
+    ID2D1PathGeometry, ID2D1SolidColorBrush, D2D1_BEZIER_SEGMENT, D2D1_BRUSH_PROPERTIES,
+    D2D1_COLOR_F, D2D1_DEBUG_LEVEL_WARNING, D2D1_EXTEND_MODE_CLAMP, D2D1_FACTORY_OPTIONS,
+    D2D1_FACTORY_TYPE_MULTI_THREADED, D2D1_FIGURE_BEGIN_FILLED, D2D1_FIGURE_BEGIN_HOLLOW,
+    D2D1_FIGURE_END_CLOSED, D2D1_FIGURE_END_OPEN, D2D1_FILL_MODE_ALTERNATE, D2D1_FILL_MODE_WINDING,
+    D2D1_GAMMA_2_2, D2D1_GRADIENT_STOP, D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES, D2D1_MATRIX_3X2_F,
+    D2D1_POINT_2F, D2D1_QUADRATIC_BEZIER_SEGMENT, D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES,
+    D2D1_SIZE_U,
+};
+use winapi::um::d2d1_1::{
+    ID2D1Bitmap1, ID2D1DeviceContext, D2D1_BITMAP_OPTIONS_NONE, D2D1_BITMAP_PROPERTIES1,
+};
+use winapi::um::dcommon::{D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_PIXEL_FORMAT};
+use winapi::Interface;
+
+use piet::FillRule;
+
+#[derive(Debug)]
+pub enum Error {
+    WinapiError(HRESULT),
+}
+
+pub struct D2DFactory(ComPtr<ID2D1Factory>);
+
+pub struct DeviceContext(ComPtr<ID2D1DeviceContext>);
+
+pub struct PathGeometry(ComPtr<ID2D1PathGeometry>);
+
+pub struct GeometrySink<'a> {
+    ptr: ComPtr<ID2D1GeometrySink>,
+    // The PhantomData keeps us from doing stuff like having
+    // two GeometrySink objects open on the same PathGeometry.
+    //
+    // It's conservative, but helps avoid logic errors.
+    marker: PhantomData<&'a mut PathGeometry>,
+}
+
+pub struct GradientStopCollection(ComPtr<ID2D1GradientStopCollection>);
+
+// TODO: consider not building this at all, but just Brush.
+pub struct SolidColorBrush(ComPtr<ID2D1SolidColorBrush>);
+
+pub struct Brush(ComPtr<ID2D1Brush>);
+
+pub struct Bitmap(ComPtr<ID2D1Bitmap1>);
+
+impl From<HRESULT> for Error {
+    fn from(hr: HRESULT) -> Error {
+        Error::WinapiError(hr)
+    }
+}
+
+unsafe fn wrap<T, U, F>(hr: HRESULT, ptr: *mut T, f: F) -> Result<U, Error>
+where
+    F: Fn(ComPtr<T>) -> U,
+    T: Interface,
+{
+    if SUCCEEDED(hr) {
+        Ok(f(ComPtr::from_raw(ptr)))
+    } else {
+        Err(hr.into())
+    }
+}
+
+fn wrap_unit(hr: HRESULT) -> Result<(), Error> {
+    if SUCCEEDED(hr) {
+        Ok(())
+    } else {
+        Err(hr.into())
+    }
+}
+
+impl D2DFactory {
+    pub fn new() -> Result<D2DFactory, Error> {
+        unsafe {
+            let mut ptr: *mut ID2D1Factory = null_mut();
+            let hr = D2D1CreateFactory(
+                D2D1_FACTORY_TYPE_MULTI_THREADED,
+                &ID2D1Factory::uuidof(),
+                &D2D1_FACTORY_OPTIONS {
+                    debugLevel: D2D1_DEBUG_LEVEL_WARNING,
+                },
+                &mut ptr as *mut _ as *mut _,
+            );
+            wrap(hr, ptr, D2DFactory)
+        }
+    }
+
+    pub fn create_path_geometry(&self) -> Result<PathGeometry, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.0.CreatePathGeometry(&mut ptr);
+            wrap(hr, ptr, PathGeometry)
+        }
+    }
+}
+
+const DEFAULT_BRUSH_PROPERTIES: D2D1_BRUSH_PROPERTIES = D2D1_BRUSH_PROPERTIES {
+    opacity: 1.0,
+    transform: D2D1_MATRIX_3X2_F {
+        matrix: [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+    },
+};
+
+impl DeviceContext {
+    pub fn new(ptr: ComPtr<ID2D1DeviceContext>) -> DeviceContext {
+        DeviceContext(ptr)
+    }
+
+    pub fn pop_layer(&mut self) {
+        unsafe {
+            self.0.PopLayer();
+        }
+    }
+
+    pub fn create_solid_color(&mut self, color: D2D1_COLOR_F) -> Result<Brush, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self
+                .0
+                .CreateSolidColorBrush(&color, &DEFAULT_BRUSH_PROPERTIES, &mut ptr);
+            wrap(hr, ptr, |p| Brush(p.up()))
+        }
+    }
+
+    pub fn create_gradient_stops(
+        &mut self,
+        stops: &[D2D1_GRADIENT_STOP],
+    ) -> Result<GradientStopCollection, Error> {
+        unsafe {
+            // Should this assert or should we return an overflow error? Super
+            // unlikely in either case.
+            assert!(stops.len() <= 0xffff_ffff);
+            let mut ptr = null_mut();
+            // The `deref` is because there is a method of the same name in DeviceContext
+            // (with fancier color space controls). We'll take the vanilla one for now.
+            let hr = self.0.deref().deref().CreateGradientStopCollection(
+                stops.as_ptr(),
+                stops.len() as u32,
+                D2D1_GAMMA_2_2,
+                D2D1_EXTEND_MODE_CLAMP,
+                &mut ptr,
+            );
+            wrap(hr, ptr, GradientStopCollection)
+        }
+    }
+
+    pub fn create_linear_gradient(
+        &mut self,
+        props: &D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES,
+        stops: &GradientStopCollection,
+    ) -> Result<Brush, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.0.CreateLinearGradientBrush(
+                props,
+                &DEFAULT_BRUSH_PROPERTIES,
+                stops.0.as_raw(),
+                &mut ptr,
+            );
+            wrap(hr, ptr, |p| Brush(p.up()))
+        }
+    }
+
+    pub fn create_radial_gradient(
+        &mut self,
+        props: &D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES,
+        stops: &GradientStopCollection,
+    ) -> Result<Brush, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.0.CreateRadialGradientBrush(
+                props,
+                &DEFAULT_BRUSH_PROPERTIES,
+                stops.0.as_raw(),
+                &mut ptr,
+            );
+            wrap(hr, ptr, |p| Brush(p.up()))
+        }
+    }
+
+    // Buf is always interpreted as RGBA32 premultiplied.
+    pub fn create_bitmap(
+        &mut self,
+        width: usize,
+        height: usize,
+        buf: &[u8],
+    ) -> Result<Bitmap, Error> {
+        // Maybe using TryInto would be more Rust-like.
+        // Note: value is set so that multiplying by 4 (for pitch) is valid.
+        assert!(width <= 0x3fff_ffff);
+        assert!(height <= 0xffff_ffff);
+        let size = D2D1_SIZE_U {
+            width: width as u32,
+            height: height as u32,
+        };
+        let format = D2D1_PIXEL_FORMAT {
+            format: DXGI_FORMAT_R8G8B8A8_UNORM,
+            alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+        };
+        let props = D2D1_BITMAP_PROPERTIES1 {
+            pixelFormat: format,
+            dpiX: 96.0,
+            dpiY: 96.0,
+            bitmapOptions: D2D1_BITMAP_OPTIONS_NONE,
+            colorContext: null_mut(),
+        };
+        let pitch = (width * 4) as u32;
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.0.deref().CreateBitmap(
+                size,
+                buf.as_ptr() as *const c_void,
+                pitch,
+                &props,
+                &mut ptr,
+            );
+            wrap(hr, ptr, Bitmap)
+        }
+    }
+}
+
+impl PathGeometry {
+    pub fn open<'a>(&'a mut self) -> Result<GeometrySink<'a>, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = (self.0).Open(&mut ptr);
+            wrap(hr, ptr, |ptr| GeometrySink {
+                ptr,
+                marker: Default::default(),
+            })
+        }
+    }
+}
+
+impl<'a> GeometrySink<'a> {
+    pub fn set_fill_mode(&mut self, fill_rule: FillRule) {
+        let fill_mode = match fill_rule {
+            FillRule::EvenOdd => D2D1_FILL_MODE_ALTERNATE,
+            FillRule::NonZero => D2D1_FILL_MODE_WINDING,
+        };
+        unsafe {
+            self.ptr.SetFillMode(fill_mode);
+        }
+    }
+
+    pub fn add_bezier(
+        &mut self,
+        point1: D2D1_POINT_2F,
+        point2: D2D1_POINT_2F,
+        point3: D2D1_POINT_2F,
+    ) {
+        let seg = D2D1_BEZIER_SEGMENT {
+            point1,
+            point2,
+            point3,
+        };
+        unsafe {
+            self.ptr.AddBezier(&seg);
+        }
+    }
+
+    pub fn add_quadratic_bezier(&mut self, point1: D2D1_POINT_2F, point2: D2D1_POINT_2F) {
+        let seg = D2D1_QUADRATIC_BEZIER_SEGMENT { point1, point2 };
+        unsafe {
+            self.ptr.AddQuadraticBezier(&seg);
+        }
+    }
+
+    pub fn add_line(&mut self, point: D2D1_POINT_2F) {
+        unsafe {
+            self.ptr.AddLine(point);
+        }
+    }
+
+    pub fn begin_figure(&mut self, start: D2D1_POINT_2F, is_filled: bool) {
+        unsafe {
+            let figure_end = if is_filled {
+                D2D1_FIGURE_BEGIN_FILLED
+            } else {
+                D2D1_FIGURE_BEGIN_HOLLOW
+            };
+            self.ptr.BeginFigure(start, figure_end);
+        }
+    }
+
+    pub fn end_figure(&mut self, is_closed: bool) {
+        unsafe {
+            let figure_end = if is_closed {
+                D2D1_FIGURE_END_CLOSED
+            } else {
+                D2D1_FIGURE_END_OPEN
+            };
+            self.ptr.EndFigure(figure_end);
+        }
+    }
+
+    pub fn close(&mut self) -> Result<(), Error> {
+        unsafe { wrap_unit(self.ptr.Close()) }
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn geom_builder() {
+        let mut factory = D2DFactory::new().unwrap();
+        let mut p = factory.create_path_geometry().unwrap();
+        let mut s1 = p.open().unwrap();
+        // Note: if the next two lines are swapped, it's a compile
+        // error.
+        s1.close();
+        let mut s2 = p.open().unwrap();
+        s2.close();
+    }
+}

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -230,7 +230,7 @@ impl DeviceContext {
     }
 
     /// docs
-    pub unsafe fn get_raw(self) -> *mut ID2D1DeviceContext {
+    pub unsafe fn get_raw(&self) -> *mut ID2D1DeviceContext {
         self.0.as_raw()
     }
 

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -7,39 +7,59 @@
 #![allow(unused)]
 
 use std::ffi::c_void;
+use std::fmt::{Debug, Display, Formatter};
 use std::marker::PhantomData;
 use std::ops::Deref;
-use std::ptr::null_mut;
+use std::ptr::{null, null_mut};
 
 use wio::com::ComPtr;
 
+use winapi::shared::dxgi::{IDXGIDevice, IDXGISurface};
 use winapi::shared::dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM;
 use winapi::shared::winerror::{HRESULT, SUCCEEDED};
 use winapi::um::d2d1::{
-    D2D1CreateFactory, ID2D1Brush, ID2D1Factory, ID2D1GeometrySink, ID2D1GradientStopCollection,
-    ID2D1PathGeometry, ID2D1SolidColorBrush, D2D1_BEZIER_SEGMENT, D2D1_BRUSH_PROPERTIES,
-    D2D1_COLOR_F, D2D1_DEBUG_LEVEL_WARNING, D2D1_EXTEND_MODE_CLAMP, D2D1_FACTORY_OPTIONS,
+    D2D1CreateFactory, ID2D1Bitmap, ID2D1Brush, ID2D1Geometry, ID2D1GeometrySink,
+    ID2D1GradientStopCollection, ID2D1Image, ID2D1Layer, ID2D1PathGeometry, ID2D1SolidColorBrush,
+    ID2D1StrokeStyle, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE, D2D1_BEZIER_SEGMENT,
+    D2D1_BITMAP_INTERPOLATION_MODE, D2D1_BRUSH_PROPERTIES, D2D1_COLOR_F, D2D1_DEBUG_LEVEL_WARNING,
+    D2D1_DRAW_TEXT_OPTIONS, D2D1_EXTEND_MODE_CLAMP, D2D1_FACTORY_OPTIONS,
     D2D1_FACTORY_TYPE_MULTI_THREADED, D2D1_FIGURE_BEGIN_FILLED, D2D1_FIGURE_BEGIN_HOLLOW,
     D2D1_FIGURE_END_CLOSED, D2D1_FIGURE_END_OPEN, D2D1_FILL_MODE_ALTERNATE, D2D1_FILL_MODE_WINDING,
-    D2D1_GAMMA_2_2, D2D1_GRADIENT_STOP, D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES, D2D1_MATRIX_3X2_F,
-    D2D1_POINT_2F, D2D1_QUADRATIC_BEZIER_SEGMENT, D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES,
-    D2D1_SIZE_U,
+    D2D1_GAMMA_2_2, D2D1_GRADIENT_STOP, D2D1_LAYER_OPTIONS_NONE, D2D1_LAYER_PARAMETERS,
+    D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES, D2D1_MATRIX_3X2_F, D2D1_POINT_2F,
+    D2D1_QUADRATIC_BEZIER_SEGMENT, D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES, D2D1_RECT_F, D2D1_SIZE_F,
+    D2D1_SIZE_U, D2D1_STROKE_STYLE_PROPERTIES,
 };
 use winapi::um::d2d1_1::{
-    ID2D1Bitmap1, ID2D1DeviceContext, D2D1_BITMAP_OPTIONS_NONE, D2D1_BITMAP_PROPERTIES1,
+    ID2D1Bitmap1, ID2D1Device, ID2D1DeviceContext, ID2D1Factory1, D2D1_BITMAP_OPTIONS_NONE,
+    D2D1_BITMAP_OPTIONS_TARGET, D2D1_BITMAP_PROPERTIES1, D2D1_DEVICE_CONTEXT_OPTIONS_NONE,
 };
-use winapi::um::dcommon::{D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_PIXEL_FORMAT};
+use winapi::um::dcommon::{D2D1_ALPHA_MODE, D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_PIXEL_FORMAT};
 use winapi::Interface;
 
-use piet::FillRule;
+use piet::{new_error, ErrorKind};
 
-#[derive(Debug)]
+use crate::dwrite::TextLayout;
+
+pub enum FillRule {
+    EvenOdd,
+    NonZero,
+}
+
 pub enum Error {
     WinapiError(HRESULT),
 }
 
-pub struct D2DFactory(ComPtr<ID2D1Factory>);
+/// A Direct2D factory object.
+pub struct D2DFactory(ComPtr<ID2D1Factory1>);
 
+/// A Direct2D device.
+pub struct D2DDevice(ComPtr<ID2D1Device>);
+
+/// The main context that takes drawing operations.
+///
+/// This type is a thin wrapper for
+/// [ID2D1DeviceContext](https://docs.microsoft.com/en-us/windows/win32/api/d2d1_1/nn-d2d1_1-id2d1devicecontext).
 pub struct DeviceContext(ComPtr<ID2D1DeviceContext>);
 
 pub struct PathGeometry(ComPtr<ID2D1PathGeometry>);
@@ -58,6 +78,11 @@ pub struct GradientStopCollection(ComPtr<ID2D1GradientStopCollection>);
 // TODO: consider not building this at all, but just Brush.
 pub struct SolidColorBrush(ComPtr<ID2D1SolidColorBrush>);
 
+pub struct StrokeStyle(ComPtr<ID2D1StrokeStyle>);
+
+pub struct Layer(ComPtr<ID2D1Layer>);
+
+#[derive(Clone)]
 pub struct Brush(ComPtr<ID2D1Brush>);
 
 pub struct Bitmap(ComPtr<ID2D1Bitmap1>);
@@ -65,6 +90,34 @@ pub struct Bitmap(ComPtr<ID2D1Bitmap1>);
 impl From<HRESULT> for Error {
     fn from(hr: HRESULT) -> Error {
         Error::WinapiError(hr)
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        "winapi error"
+    }
+}
+
+impl From<Error> for piet::Error {
+    fn from(e: Error) -> piet::Error {
+        new_error(ErrorKind::BackendError(Box::new(e)))
     }
 }
 
@@ -89,12 +142,16 @@ fn wrap_unit(hr: HRESULT) -> Result<(), Error> {
 }
 
 impl D2DFactory {
+    /// Create a new Direct2D factory.
+    ///
+    /// This requires Windows 7 platform update, and can also fail if
+    /// resources are unavailable.
     pub fn new() -> Result<D2DFactory, Error> {
         unsafe {
-            let mut ptr: *mut ID2D1Factory = null_mut();
+            let mut ptr: *mut ID2D1Factory1 = null_mut();
             let hr = D2D1CreateFactory(
                 D2D1_FACTORY_TYPE_MULTI_THREADED,
-                &ID2D1Factory::uuidof(),
+                &ID2D1Factory1::uuidof(),
                 &D2D1_FACTORY_OPTIONS {
                     debugLevel: D2D1_DEBUG_LEVEL_WARNING,
                 },
@@ -104,34 +161,226 @@ impl D2DFactory {
         }
     }
 
+    // Would it be safe to take &ComPtr<IDXGIDevice> here?
+    pub unsafe fn create_device(&self, dxgi_device: *mut IDXGIDevice) -> Result<D2DDevice, Error> {
+        let mut ptr = null_mut();
+        let hr = self.0.CreateDevice(dxgi_device, &mut ptr);
+        wrap(hr, ptr, D2DDevice)
+    }
+
     pub fn create_path_geometry(&self) -> Result<PathGeometry, Error> {
         unsafe {
             let mut ptr = null_mut();
-            let hr = self.0.CreatePathGeometry(&mut ptr);
+            let hr = self.0.deref().deref().CreatePathGeometry(&mut ptr);
             wrap(hr, ptr, PathGeometry)
+        }
+    }
+
+    pub fn create_stroke_style(
+        &self,
+        props: &D2D1_STROKE_STYLE_PROPERTIES,
+        dashes: Option<&[f32]>,
+    ) -> Result<StrokeStyle, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let dashes_len = dashes.map(|d| d.len()).unwrap_or(0);
+            assert!(dashes_len <= 0xffff_ffff);
+            let hr = self.0.deref().deref().CreateStrokeStyle(
+                props,
+                dashes.map(|d| d.as_ptr()).unwrap_or(null()),
+                dashes_len as u32,
+                &mut ptr,
+            );
+            wrap(hr, ptr, StrokeStyle)
         }
     }
 }
 
+impl D2DDevice {
+    /// Create a new device context from the device.
+    ///
+    /// This is a wrapper for
+    /// [ID2D1Device::CreateDeviceContext](https://docs.microsoft.com/en-us/windows/win32/api/d2d1_1/nf-d2d1_1-id2d1device-createdevicecontext).
+    pub fn create_device_context(&mut self) -> Result<DeviceContext, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let options = D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
+            let hr = self.0.CreateDeviceContext(options, &mut ptr);
+            wrap(hr, ptr, DeviceContext)
+        }
+    }
+}
+
+const IDENTITY_MATRIX_3X2_F: D2D1_MATRIX_3X2_F = D2D1_MATRIX_3X2_F {
+    matrix: [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+};
+
 const DEFAULT_BRUSH_PROPERTIES: D2D1_BRUSH_PROPERTIES = D2D1_BRUSH_PROPERTIES {
     opacity: 1.0,
-    transform: D2D1_MATRIX_3X2_F {
-        matrix: [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
-    },
+    transform: IDENTITY_MATRIX_3X2_F,
 };
 
 impl DeviceContext {
-    pub fn new(ptr: ComPtr<ID2D1DeviceContext>) -> DeviceContext {
+    /// Create a new device context from an existing COM object.
+    ///
+    /// Marked as unsafe because the device must be in a good state.
+    /// This *might* be overly conservative.
+    pub unsafe fn new(ptr: ComPtr<ID2D1DeviceContext>) -> DeviceContext {
         DeviceContext(ptr)
     }
 
-    pub fn pop_layer(&mut self) {
+    /// Create a bitmap from a DXGI surface.
+    ///
+    /// Most often, this bitmap will be used to set the target of a
+    /// DeviceContext.
+    ///
+    /// Assumes RGBA8 format and premultiplied alpha.
+    ///
+    /// The `unsafe` might be conservative, but we assume the `dxgi`
+    /// argument is in good shape to be a target.
+    pub unsafe fn create_bitmap_from_dxgi(
+        &self,
+        dxgi: &ComPtr<IDXGISurface>,
+        dpi_scale: f32,
+    ) -> Result<Bitmap, Error> {
+        let mut ptr = null_mut();
+        let props = D2D1_BITMAP_PROPERTIES1 {
+            pixelFormat: D2D1_PIXEL_FORMAT {
+                format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+            },
+            dpiX: 96.0 * dpi_scale,
+            dpiY: 96.0 * dpi_scale,
+            bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET,
+            colorContext: null_mut(),
+        };
+        let hr = self
+            .0
+            .CreateBitmapFromDxgiSurface(dxgi.as_raw(), &props, &mut ptr);
+        wrap(hr, ptr, Bitmap)
+    }
+
+    /// Set the target for the device context.
+    ///
+    /// Useful for rendering into bitmaps.
+    pub fn set_target(&mut self, target: &Bitmap) {
+        unsafe { self.0.SetTarget(target.0.as_raw() as *mut ID2D1Image) }
+    }
+
+    /// Set the dpi scale.
+    ///
+    /// Mostly useful when rendering into bitmaps.
+    pub fn set_dpi_scale(&mut self, dpi_scale: f32) {
+        unsafe {
+            self.0.SetDpi(96. * dpi_scale, 96. * dpi_scale);
+        }
+    }
+
+    /// Begin drawing.
+    ///
+    /// This must be done before any piet drawing operations.
+    ///
+    /// There may be safety concerns (not clear what happens if the sequence
+    /// is not followed).
+    pub fn begin_draw(&mut self) {
+        unsafe {
+            self.0.BeginDraw();
+        }
+    }
+
+    /// End drawing.
+    pub fn end_draw(&mut self) -> Result<(), Error> {
+        unsafe {
+            let mut tag1 = 0;
+            let mut tag2 = 0;
+            let hr = self.0.EndDraw(&mut tag1, &mut tag2);
+            wrap_unit(hr)
+        }
+    }
+
+    pub(crate) fn clear(&mut self, color: D2D1_COLOR_F) {
+        unsafe {
+            self.0.Clear(&color);
+        }
+    }
+
+    pub(crate) fn set_transform(&mut self, transform: &D2D1_MATRIX_3X2_F) {
+        unsafe {
+            self.0.SetTransform(transform);
+        }
+    }
+
+    pub(crate) fn fill_geometry(
+        &mut self,
+        geom: &PathGeometry,
+        brush: &Brush,
+        opacity_brush: Option<&Brush>,
+    ) {
+        unsafe {
+            self.0.FillGeometry(
+                geom.0.as_raw() as *mut ID2D1Geometry,
+                brush.0.as_raw(),
+                opacity_brush.map(|b| b.0.as_raw()).unwrap_or(null_mut()),
+            );
+        }
+    }
+
+    pub(crate) fn draw_geometry(
+        &mut self,
+        geom: &PathGeometry,
+        brush: &Brush,
+        width: f32,
+        style: Option<&StrokeStyle>,
+    ) {
+        unsafe {
+            self.0.DrawGeometry(
+                geom.0.as_raw() as *mut ID2D1Geometry,
+                brush.0.as_raw(),
+                width,
+                style.map(|b| b.0.as_raw()).unwrap_or(null_mut()),
+            );
+        }
+    }
+
+    pub(crate) fn create_layer(&mut self, size: Option<D2D1_SIZE_F>) -> Result<Layer, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.0.CreateLayer(
+                size.as_ref().map(|r| r as *const _).unwrap_or(null()),
+                &mut ptr,
+            );
+            wrap(hr, ptr, Layer)
+        }
+    }
+
+    // Should be &mut layer?
+    pub(crate) fn push_layer_mask(&mut self, mask: &PathGeometry, layer: &Layer) {
+        unsafe {
+            let params = D2D1_LAYER_PARAMETERS {
+                contentBounds: D2D1_RECT_F {
+                    left: std::f32::NEG_INFINITY,
+                    top: std::f32::NEG_INFINITY,
+                    right: std::f32::INFINITY,
+                    bottom: std::f32::INFINITY,
+                },
+                geometricMask: mask.0.as_raw() as *mut ID2D1Geometry,
+                maskAntialiasMode: D2D1_ANTIALIAS_MODE_PER_PRIMITIVE,
+                maskTransform: IDENTITY_MATRIX_3X2_F,
+                opacity: 1.0,
+                opacityBrush: null_mut(),
+                layerOptions: D2D1_LAYER_OPTIONS_NONE,
+            };
+            self.0.deref().deref().PushLayer(&params, layer.0.as_raw());
+        }
+    }
+
+    pub(crate) fn pop_layer(&mut self) {
         unsafe {
             self.0.PopLayer();
         }
     }
 
-    pub fn create_solid_color(&mut self, color: D2D1_COLOR_F) -> Result<Brush, Error> {
+    pub(crate) fn create_solid_color(&mut self, color: D2D1_COLOR_F) -> Result<Brush, Error> {
         unsafe {
             let mut ptr = null_mut();
             let hr = self
@@ -141,7 +390,7 @@ impl DeviceContext {
         }
     }
 
-    pub fn create_gradient_stops(
+    pub(crate) fn create_gradient_stops(
         &mut self,
         stops: &[D2D1_GRADIENT_STOP],
     ) -> Result<GradientStopCollection, Error> {
@@ -163,7 +412,7 @@ impl DeviceContext {
         }
     }
 
-    pub fn create_linear_gradient(
+    pub(crate) fn create_linear_gradient(
         &mut self,
         props: &D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES,
         stops: &GradientStopCollection,
@@ -180,7 +429,7 @@ impl DeviceContext {
         }
     }
 
-    pub fn create_radial_gradient(
+    pub(crate) fn create_radial_gradient(
         &mut self,
         props: &D2D1_RADIAL_GRADIENT_BRUSH_PROPERTIES,
         stops: &GradientStopCollection,
@@ -198,11 +447,12 @@ impl DeviceContext {
     }
 
     // Buf is always interpreted as RGBA32 premultiplied.
-    pub fn create_bitmap(
+    pub(crate) fn create_bitmap(
         &mut self,
         width: usize,
         height: usize,
         buf: &[u8],
+        alpha_mode: D2D1_ALPHA_MODE,
     ) -> Result<Bitmap, Error> {
         // Maybe using TryInto would be more Rust-like.
         // Note: value is set so that multiplying by 4 (for pitch) is valid.
@@ -214,7 +464,7 @@ impl DeviceContext {
         };
         let format = D2D1_PIXEL_FORMAT {
             format: DXGI_FORMAT_R8G8B8A8_UNORM,
-            alphaMode: D2D1_ALPHA_MODE_PREMULTIPLIED,
+            alphaMode: alpha_mode,
         };
         let props = D2D1_BITMAP_PROPERTIES1 {
             pixelFormat: format,
@@ -236,6 +486,40 @@ impl DeviceContext {
             wrap(hr, ptr, Bitmap)
         }
     }
+
+    pub(crate) fn draw_text_layout(
+        &mut self,
+        origin: D2D1_POINT_2F,
+        layout: &TextLayout,
+        brush: &Brush,
+        options: D2D1_DRAW_TEXT_OPTIONS,
+    ) {
+        unsafe {
+            self.0
+                .DrawTextLayout(origin, layout.get_raw(), brush.0.as_raw(), options);
+        }
+    }
+
+    pub(crate) fn draw_bitmap(
+        &mut self,
+        bitmap: &Bitmap,
+        dst_rect: &D2D1_RECT_F,
+        opacity: f32,
+        interp_mode: D2D1_BITMAP_INTERPOLATION_MODE,
+        src_rect: Option<&D2D1_RECT_F>,
+    ) {
+        unsafe {
+            // derefs are so we get RenderTarget method rather than DeviceContext method.
+            // pointer casts are partly to undo that :)
+            self.0.deref().deref().DrawBitmap(
+                bitmap.0.as_raw() as *mut ID2D1Bitmap,
+                dst_rect,
+                opacity,
+                interp_mode,
+                src_rect.map(|r| r as *const _).unwrap_or(null()),
+            );
+        }
+    }
 }
 
 impl PathGeometry {
@@ -251,6 +535,8 @@ impl PathGeometry {
     }
 }
 
+// Note: this impl has not been audited for safety. It might be possible
+// to provoke a crash by doing things in the wrong order.
 impl<'a> GeometrySink<'a> {
     pub fn set_fill_mode(&mut self, fill_rule: FillRule) {
         let fill_mode = match fill_rule {
@@ -313,8 +599,16 @@ impl<'a> GeometrySink<'a> {
         }
     }
 
-    pub fn close(&mut self) -> Result<(), Error> {
+    // A case can be made for doing this in the drop instead.
+    pub fn close(self) -> Result<(), Error> {
         unsafe { wrap_unit(self.ptr.Close()) }
+    }
+}
+
+/// This might not be needed.
+impl Bitmap {
+    pub fn get_size(&self) -> D2D1_SIZE_F {
+        unsafe { self.0.GetSize() }
     }
 }
 

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -639,7 +639,9 @@ mod tests {
         // Note: if the next two lines are swapped, it's a compile
         // error.
         s1.close();
-        let mut s2 = p.open().unwrap(); // TODO fails here at runtime for windows10 virtual machine
-        s2.close();
+        if let Ok(mut s2) = p.open() {
+            s2.close();
+        }
+        //let mut s2 = p.open().unwrap(); // TODO fails here at runtime for windows10 virtual machine
     }
 }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -642,6 +642,5 @@ mod tests {
         if let Ok(mut s2) = p.open() {
             s2.close();
         }
-        //let mut s2 = p.open().unwrap(); // TODO fails here at runtime for windows10 virtual machine
     }
 }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -245,6 +245,12 @@ impl DeviceContext {
         self.0.as_raw()
     }
 
+    /// Get the Com ptr
+    /// TODO rename to `inner`, like for D3D11Device?
+    pub fn get_comptr(&self) -> &ComPtr<ID2D1DeviceContext> {
+        &self.0
+    }
+
     /// Create a bitmap from a DXGI surface.
     ///
     /// Most often, this bitmap will be used to set the target of a

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -174,7 +174,8 @@ impl D2DFactory {
         wrap(hr, ptr, D2DDevice)
     }
 
-    pub unsafe fn get_raw(&self) -> *mut ID2D1Factory1 {
+    /// Get the raw pointer
+    pub fn get_raw(&self) -> *mut ID2D1Factory1 {
         self.0.as_raw()
     }
 
@@ -239,8 +240,8 @@ impl DeviceContext {
         DeviceContext(ptr)
     }
 
-    /// docs
-    pub unsafe fn get_raw(&self) -> *mut ID2D1DeviceContext {
+    /// Get the raw pointer
+    pub fn get_raw(&self) -> *mut ID2D1DeviceContext {
         self.0.as_raw()
     }
 

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -623,7 +623,7 @@ mod tests {
         // Note: if the next two lines are swapped, it's a compile
         // error.
         s1.close();
-        let mut s2 = p.open().unwrap();
+        let mut s2 = p.open().unwrap(); // TODO fails here at runtime for windows10 virtual machine
         s2.close();
     }
 }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -229,6 +229,11 @@ impl DeviceContext {
         DeviceContext(ptr)
     }
 
+    /// docs
+    pub unsafe fn get_raw(self) -> *mut ID2D1DeviceContext {
+        self.0.as_raw()
+    }
+
     /// Create a bitmap from a DXGI surface.
     ///
     /// Most often, this bitmap will be used to set the target of a

--- a/piet-direct2d/src/d3d.rs
+++ b/piet-direct2d/src/d3d.rs
@@ -1,0 +1,151 @@
+use std::ptr::null_mut;
+
+// TODO figure out whether to export this or to move `raw_pixels` into this module.
+pub use winapi::shared::dxgi::DXGI_MAP_READ;
+
+use winapi::shared::dxgi::{IDXGIDevice, IDXGISurface};
+use winapi::shared::dxgiformat::DXGI_FORMAT_R8G8B8A8_UNORM;
+use winapi::shared::dxgitype::DXGI_SAMPLE_DESC;
+use winapi::shared::winerror::{HRESULT, SUCCEEDED};
+use winapi::um::d3d11::{
+    D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D, D3D11_BIND_FLAG,
+    D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_CPU_ACCESS_FLAG,
+    D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_SDK_VERSION,
+    D3D11_TEXTURE2D_DESC, D3D11_USAGE, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING,
+};
+use winapi::um::d3dcommon::D3D_DRIVER_TYPE_HARDWARE;
+use winapi::Interface;
+
+use wio::com::ComPtr;
+
+
+#[derive(Debug)]
+pub struct Error(HRESULT);
+
+pub struct D3D11Device(ComPtr<ID3D11Device>);
+pub struct D3D11DeviceContext(ComPtr<ID3D11DeviceContext>);
+pub struct D3D11Texture2D(ComPtr<ID3D11Texture2D>);
+pub struct DxgiDevice(ComPtr<IDXGIDevice>);
+
+pub enum TextureMode {
+    Target,
+    Read,
+}
+
+impl TextureMode {
+    pub fn usage(&self) -> D3D11_USAGE {
+        match self {
+            TextureMode::Target => D3D11_USAGE_DEFAULT,
+            TextureMode::Read => D3D11_USAGE_STAGING,
+        }
+    }
+
+    pub fn bind_flags(&self) -> D3D11_BIND_FLAG {
+        match self {
+            TextureMode::Target => D3D11_BIND_SHADER_RESOURCE | D3D11_BIND_RENDER_TARGET,
+            TextureMode::Read => 0,
+        }
+    }
+
+    pub fn cpu_access_flags(&self) -> D3D11_CPU_ACCESS_FLAG {
+        match self {
+            TextureMode::Target => 0,
+            TextureMode::Read => D3D11_CPU_ACCESS_READ,
+        }
+    }
+}
+
+unsafe fn wrap<T, U, F>(hr: HRESULT, ptr: *mut T, f: F) -> Result<U, Error>
+where
+    F: Fn(ComPtr<T>) -> U,
+    T: Interface,
+{
+    if SUCCEEDED(hr) {
+        Ok(f(ComPtr::from_raw(ptr)))
+    } else {
+        Err(Error(hr))
+    }
+}
+
+impl D3D11Device {
+    pub fn inner(&self) -> &ComPtr<ID3D11Device> {
+        &self.0
+    }
+
+    // This function only supports a fraction of available options.
+    pub fn create() -> Result<(D3D11Device, D3D11DeviceContext), Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let mut ctx_ptr = null_mut();
+            let hr = D3D11CreateDevice(
+                null_mut(), /* adapter */
+                D3D_DRIVER_TYPE_HARDWARE,
+                null_mut(), /* module */
+                D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+                null_mut(), /* feature levels */
+                0,
+                D3D11_SDK_VERSION,
+                &mut ptr,
+                null_mut(), /* feature level */
+                &mut ctx_ptr,
+            );
+            let device = wrap(hr, ptr, D3D11Device)?;
+            let device_ctx = wrap(hr, ctx_ptr, D3D11DeviceContext)?;
+            Ok((device, device_ctx))
+        }
+    }
+
+    pub fn as_dxgi(&self) -> Option<DxgiDevice> {
+        self.0.cast().ok().map(DxgiDevice)
+    }
+
+    pub fn create_texture(
+        &self,
+        width: u32,
+        height: u32,
+        mode: TextureMode,
+    ) -> Result<D3D11Texture2D, Error> {
+        unsafe {
+            let mut ptr = null_mut();
+            let desc = D3D11_TEXTURE2D_DESC {
+                Width: width,
+                Height: height,
+                MipLevels: 1,
+                ArraySize: 1,
+                Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+                SampleDesc: DXGI_SAMPLE_DESC {
+                    Count: 1,
+                    Quality: 0,
+                },
+                Usage: mode.usage(),
+                BindFlags: mode.bind_flags(),
+                CPUAccessFlags: mode.cpu_access_flags(),
+                MiscFlags: 0,
+            };
+            let hr = self.0.CreateTexture2D(&desc, null_mut(), &mut ptr);
+            wrap(hr, ptr, D3D11Texture2D)
+        }
+    }
+}
+
+impl D3D11DeviceContext {
+    pub fn inner(&self) -> &ComPtr<ID3D11DeviceContext> {
+        &self.0
+    }
+}
+
+impl D3D11Texture2D {
+    pub fn as_dxgi(&self) -> ComPtr<IDXGISurface> {
+        self.0.cast().unwrap()
+    }
+
+    pub fn as_raw(&self) -> *mut ID3D11Texture2D {
+        self.0.as_raw()
+    }
+}
+
+impl DxgiDevice {
+    pub fn as_raw(&self) -> *mut IDXGIDevice {
+        self.0.as_raw()
+    }
+}

--- a/piet-direct2d/src/d3d.rs
+++ b/piet-direct2d/src/d3d.rs
@@ -18,7 +18,6 @@ use winapi::Interface;
 
 use wio::com::ComPtr;
 
-
 #[derive(Debug)]
 pub struct Error(HRESULT);
 

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -107,6 +107,11 @@ impl DwriteFactory {
             wrap(hr, ptr, DwriteFactory)
         }
     }
+
+    pub fn get_raw(&self) -> *mut IDWriteFactory {
+        self.0.as_raw()
+    }
+
 }
 
 impl<'a> TextFormatBuilder<'a> {

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -27,6 +27,8 @@ pub enum Error {
     WinapiError(HRESULT),
 }
 
+/// This struct is public only to use for system integration in piet_common and druid-shell. It is not intended
+/// that end-users directly use this struct.
 pub struct DwriteFactory(ComPtr<IDWriteFactory>);
 
 #[derive(Clone)]

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -11,8 +11,7 @@ use winapi::shared::winerror::{HRESULT, SUCCEEDED, S_OK};
 use winapi::um::dwrite::{
     DWriteCreateFactory, IDWriteFactory, IDWriteTextFormat, IDWriteTextLayout,
     DWRITE_FACTORY_TYPE_SHARED, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL,
-    DWRITE_FONT_WEIGHT_NORMAL, DWRITE_LINE_METRICS, DWRITE_TEXT_METRICS,
-    DWRITE_HIT_TEST_METRICS,
+    DWRITE_FONT_WEIGHT_NORMAL, DWRITE_HIT_TEST_METRICS, DWRITE_LINE_METRICS, DWRITE_TEXT_METRICS,
 };
 use winapi::Interface;
 
@@ -281,14 +280,18 @@ impl TextLayout {
         }
     }
 
-    pub fn hit_test_text_position(&self, position: u32, trailing: bool) -> Option<HitTestTextPosition> {
+    pub fn hit_test_text_position(
+        &self,
+        position: u32,
+        trailing: bool,
+    ) -> Option<HitTestTextPosition> {
         let trailing = if trailing { 0 } else { 1 };
         unsafe {
             let (mut x, mut y) = (0.0, 0.0);
             let mut metrics = std::mem::zeroed();
-            let res =
-                self.0
-                    .HitTestTextPosition(position, trailing, &mut x, &mut y, &mut metrics);
+            let res = self
+                .0
+                .HitTestTextPosition(position, trailing, &mut x, &mut y, &mut metrics);
             if res != S_OK {
                 return None;
             }

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -1,0 +1,169 @@
+//! Convenience wrappers for DirectWrite objects.
+
+// TODO: get rid of this when we actually do use everything
+#![allow(unused)]
+
+use std::ptr::null_mut;
+
+use winapi::shared::winerror::{HRESULT, SUCCEEDED};
+use winapi::um::dwrite::{
+    DWriteCreateFactory, IDWriteFactory, IDWriteTextFormat, IDWriteTextLayout,
+    DWRITE_FACTORY_TYPE_SHARED, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_NORMAL,
+    DWRITE_FONT_WEIGHT_NORMAL,
+};
+use winapi::Interface;
+
+use wio::com::ComPtr;
+use wio::wide::ToWide;
+
+// TODO: minimize cut'n'paste; probably the best way to do this is
+// unify with the crate error type
+#[derive(Debug)]
+pub enum Error {
+    WinapiError(HRESULT),
+}
+
+pub struct DwriteFactory(ComPtr<IDWriteFactory>);
+
+pub struct TextFormat(ComPtr<IDWriteTextFormat>);
+
+/// A builder for creating new `TextFormat` objects.
+///
+/// TODO: provide lots more capability.
+pub struct TextFormatBuilder<'a> {
+    factory: &'a DwriteFactory,
+    size: Option<f32>,
+    family: Option<&'a str>,
+}
+
+pub struct TextLayoutBuilder<'a> {
+    factory: &'a DwriteFactory,
+    format: &'a TextFormat,
+    text: Option<Vec<u16>>,
+    width: Option<f32>,
+    height: Option<f32>,
+}
+
+pub struct TextLayout(ComPtr<IDWriteTextLayout>);
+
+impl From<HRESULT> for Error {
+    fn from(hr: HRESULT) -> Error {
+        Error::WinapiError(hr)
+    }
+}
+
+unsafe fn wrap<T, U, F>(hr: HRESULT, ptr: *mut T, f: F) -> Result<U, Error>
+where
+    F: Fn(ComPtr<T>) -> U,
+    T: Interface,
+{
+    if SUCCEEDED(hr) {
+        Ok(f(ComPtr::from_raw(ptr)))
+    } else {
+        Err(hr.into())
+    }
+}
+
+impl DwriteFactory {
+    pub fn new() -> Result<DwriteFactory, Error> {
+        unsafe {
+            let mut ptr: *mut IDWriteFactory = null_mut();
+            let hr = DWriteCreateFactory(
+                DWRITE_FACTORY_TYPE_SHARED,
+                &IDWriteFactory::uuidof(),
+                &mut ptr as *mut _ as *mut _,
+            );
+            wrap(hr, ptr, DwriteFactory)
+        }
+    }
+}
+
+impl<'a> TextFormatBuilder<'a> {
+    pub fn new(factory: &'a DwriteFactory) -> TextFormatBuilder<'a> {
+        TextFormatBuilder {
+            factory,
+            size: None,
+            family: None,
+        }
+    }
+
+    pub fn size(mut self, size: f32) -> TextFormatBuilder<'a> {
+        self.size = Some(size);
+        self
+    }
+
+    pub fn family(mut self, family: &'a str) -> TextFormatBuilder<'a> {
+        self.family = Some(family);
+        self
+    }
+
+    pub fn build(self) -> Result<TextFormat, Error> {
+        let family = self
+            .family
+            .expect("`family` must be specified")
+            .to_wide_null();
+        let size = self.size.expect("`size` must be specified");
+        let locale = "en-US".to_wide_null();
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.factory.0.CreateTextFormat(
+                family.as_ptr(),
+                null_mut(), // collection
+                DWRITE_FONT_WEIGHT_NORMAL,
+                DWRITE_FONT_STYLE_NORMAL,
+                DWRITE_FONT_STRETCH_NORMAL,
+                size,
+                locale.as_ptr(),
+                &mut ptr,
+            );
+            wrap(hr, ptr, TextFormat)
+        }
+    }
+}
+
+impl<'a> TextLayoutBuilder<'a> {
+    pub fn new(factory: &'a DwriteFactory, format: &'a TextFormat) -> TextLayoutBuilder<'a> {
+        TextLayoutBuilder {
+            factory,
+            format,
+            text: None,
+            width: None,
+            height: None,
+        }
+    }
+
+    pub fn text(mut self, text: &str) -> TextLayoutBuilder<'a> {
+        self.text = Some(text.to_wide());
+        self
+    }
+
+    pub fn width(mut self, width: f32) -> TextLayoutBuilder<'a> {
+        self.width = Some(width);
+        self
+    }
+
+    pub fn height(mut self, height: f32) -> TextLayoutBuilder<'a> {
+        self.height = Some(height);
+        self
+    }
+
+    pub fn build(self) -> Result<TextLayout, Error> {
+        let text = self.text.expect("`text` must be specified");
+        let len = text.len();
+        assert!(len <= 0xffff_ffff);
+        let width = self.width.expect("`width` must be specified");
+        let height = self.height.expect("`height` must be specified");
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self.factory.0.CreateTextLayout(
+                text.as_ptr(),
+                len as u32,
+                self.format.0.as_raw(),
+                width,
+                height,
+                &mut ptr,
+            );
+            wrap(hr, ptr, TextLayout)
+        }
+    }
+}

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -112,6 +112,9 @@ impl DwriteFactory {
         self.0.as_raw()
     }
 
+    pub unsafe fn from_raw(raw: *mut IDWriteFactory) -> Self {
+        Self(ComPtr::from_raw(raw))
+    }
 }
 
 impl<'a> TextFormatBuilder<'a> {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -6,7 +6,7 @@ pub mod d2d;
 pub mod d3d;
 pub mod dwrite;
 
-pub use d2d::{DeviceContext as D2DDeviceContext, D2DDevice, D2DFactory};
+pub use d2d::{D2DDevice, D2DFactory, DeviceContext as D2DDeviceContext};
 pub use dwrite::DwriteFactory;
 
 use crate::conv::{
@@ -32,7 +32,7 @@ use piet::{
     StrokeStyle, Text, TextLayout, TextLayoutBuilder,
 };
 
-use d2d::{Bitmap, Brush, DeviceContext, PathGeometry, FillRule};
+use d2d::{Bitmap, Brush, DeviceContext, FillRule, PathGeometry};
 use dwrite::{TextFormat, TextFormatBuilder};
 
 pub struct D2DRenderContext<'a> {
@@ -406,7 +406,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     }
 }
 
-impl<'a> IntoBrush<D2DRenderContext<'a>> for Brush{
+impl<'a> IntoBrush<D2DRenderContext<'a>> for Brush {
     fn make_brush<'b>(
         &'b self,
         _piet: &mut D2DRenderContext,
@@ -440,11 +440,7 @@ impl<'a> Text for D2DText<'a> {
         }
     }
 
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-    ) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, font: &Self::Font, text: &str) -> Self::TextLayoutBuilder {
         D2DTextLayoutBuilder {
             text: text.to_owned(),
             builder: dwrite::TextLayoutBuilder::new(self.dwrite)
@@ -470,7 +466,8 @@ impl<'a> TextLayoutBuilder for D2DTextLayoutBuilder<'a> {
     fn build(self) -> Result<Self::Out, Error> {
         Ok(D2DTextLayout {
             text: self.text,
-            layout: self.builder
+            layout: self
+                .builder
                 .width(1e6) // TODO: probably want to support wrapping
                 .height(1e6)
                 .build()?,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -17,9 +17,6 @@ use crate::conv::{
 use std::borrow::Cow;
 use std::convert::TryInto;
 
-use winapi::shared::basetsd::UINT32;
-use winapi::um::dcommon::D2D_SIZE_U;
-
 use winapi::um::d2d1::{
     D2D1_BITMAP_INTERPOLATION_MODE_LINEAR, D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
     D2D1_DRAW_TEXT_OPTIONS_NONE, D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES,
@@ -123,7 +120,7 @@ fn path_from_shape(
     let mut sink = path.open()?;
     sink.set_fill_mode(fill_rule);
     let mut need_close = false;
-    for el in shape.to_bez_path(1e-3) {
+    for el in shape.to_bez_path(BEZ_TOLERANCE) {
         match el {
             PathEl::MoveTo(p) => {
                 if need_close {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -487,67 +487,65 @@ impl TextLayout for D2DTextLayout {
     }
 
     fn hit_test_point(&self, point: Point) -> HitTestPoint {
-        unimplemented!();
-//        // lossy from f64 to f32, but shouldn't have too much impact
-//        let htp = self.layout.hit_test_point(point.x as f32, point.y as f32);
-//
-//        // Round up to next grapheme cluster boundary if directwrite
-//        // reports a trailing hit.
-//        let text_position_16 = if htp.is_trailing_hit {
-//            htp.metrics.text_position() + htp.metrics.length()
-//        } else {
-//            htp.metrics.text_position()
-//        } as usize;
-//
-//        // Convert text position from utf-16 code units to
-//        // utf-8 code units.
-//        // Strategy: count up in utf16 and utf8 simultaneously, stop when
-//        // utf-16 text position reached.
-//        //
-//        // TODO ask about text_position, it looks like windows returns last index;
-//        // can't use the text_position of last index from directwrite, it has an extra code unit.
-//        let text_position =
-//            count_until_utf16(&self.text, text_position_16).unwrap_or(self.text.len());
-//
-//        HitTestPoint {
-//            metrics: HitTestMetrics { text_position },
-//            is_inside: htp.is_inside,
-//        }
+        // lossy from f64 to f32, but shouldn't have too much impact
+        let htp = self.layout.hit_test_point(point.x as f32, point.y as f32);
+
+        // Round up to next grapheme cluster boundary if directwrite
+        // reports a trailing hit.
+        let text_position_16 = if htp.is_trailing_hit {
+            htp.metrics.text_position + htp.metrics.length
+        } else {
+            htp.metrics.text_position
+        } as usize;
+
+        // Convert text position from utf-16 code units to
+        // utf-8 code units.
+        // Strategy: count up in utf16 and utf8 simultaneously, stop when
+        // utf-16 text position reached.
+        //
+        // TODO ask about text_position, it looks like windows returns last index;
+        // can't use the text_position of last index from directwrite, it has an extra code unit.
+        let text_position =
+            count_until_utf16(&self.text, text_position_16).unwrap_or(self.text.len());
+
+        HitTestPoint {
+            metrics: HitTestMetrics { text_position },
+            is_inside: htp.is_inside,
+        }
     }
 
     // Can panic if text position is not at a code point boundary, or if it's out of bounds.
     fn hit_test_text_position(&self, text_position: usize) -> Option<HitTestTextPosition> {
-        unimplemented!();
-//        // Note: Directwrite will just return the line width if text position is
-//        // out of bounds. This is what want for piet; return line width for the last text position
-//        // (equal to line.len()). This is basically returning line width for the last cursor
-//        // position.
-//
-//        // Now convert the utf8 index to utf16.
-//        // This can panic;
-//        let idx_16 = count_utf16(&self.text[0..text_position]);
-//
-//        // panic or Result are also fine options for dealing with overflow. Using Option here
-//        // because it's already present and convenient.
-//        // TODO this should probably go before convertin to utf16, since that's relatively slow
-//        let idx_16 = idx_16.try_into().ok()?;
-//
-//        // TODO quick fix until directwrite fixes bool bug
-//        let trailing = true;
-//
-//        self.layout
-//            .hit_test_text_position(idx_16, trailing)
-//            .map(|http| {
-//                HitTestTextPosition {
-//                    point: Point {
-//                        x: http.point_x as f64,
-//                        y: http.point_y as f64,
-//                    },
-//                    metrics: HitTestMetrics {
-//                        text_position: text_position, // no need to use directwrite return value
-//                    },
-//                }
-//            })
+        // Note: Directwrite will just return the line width if text position is
+        // out of bounds. This is what want for piet; return line width for the last text position
+        // (equal to line.len()). This is basically returning line width for the last cursor
+        // position.
+
+        // Now convert the utf8 index to utf16.
+        // This can panic;
+        let idx_16 = count_utf16(&self.text[0..text_position]);
+
+        // panic or Result are also fine options for dealing with overflow. Using Option here
+        // because it's already present and convenient.
+        // TODO this should probably go before convertin to utf16, since that's relatively slow
+        let idx_16 = idx_16.try_into().ok()?;
+
+        // TODO quick fix until directwrite fixes bool bug
+        let trailing = true;
+
+        self.layout
+            .hit_test_text_position(idx_16, trailing)
+            .map(|http| {
+                HitTestTextPosition {
+                    point: Point {
+                        x: http.point_x as f64,
+                        y: http.point_y as f64,
+                    },
+                    metrics: HitTestMetrics {
+                        text_position, // no need to use directwrite return value
+                    },
+                }
+            })
     }
 }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -3,9 +3,10 @@
 
 mod conv;
 mod d2d;
+pub mod d3d;
 mod dwrite;
 
-pub use d2d::{D2DDevice, D2DFactory};
+pub use d2d::{DeviceContext as D2DDeviceContext, D2DDevice, D2DFactory};
 pub use dwrite::DwriteFactory;
 
 use crate::conv::{
@@ -40,7 +41,7 @@ use dwrite::{TextFormat, TextFormatBuilder};
 pub struct D2DRenderContext<'a> {
     factory: &'a D2DFactory,
     inner_text: D2DText<'a>,
-    rt: &'a mut DeviceContext,
+    rt: &'a mut D2DDeviceContext,
 
     /// The context state stack. There is always at least one, until finishing.
     ctx_stack: Vec<CtxState>,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -2,6 +2,8 @@
 //! The Direct2D backend for the Piet 2D graphics abstraction.
 
 mod conv;
+mod d2d;
+mod dwrite;
 pub mod error;
 
 use crate::conv::{

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -4,7 +4,7 @@
 mod conv;
 pub mod d2d;
 pub mod d3d;
-mod dwrite;
+pub mod dwrite;
 
 pub use d2d::{DeviceContext as D2DDeviceContext, D2DDevice, D2DFactory};
 pub use dwrite::DwriteFactory;

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -2,7 +2,7 @@
 //! The Direct2D backend for the Piet 2D graphics abstraction.
 
 mod conv;
-mod d2d;
+pub mod d2d;
 pub mod d3d;
 mod dwrite;
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -603,7 +603,7 @@ mod test {
 
     #[test]
     fn test_hit_test_text_position_basic() {
-        let dwrite = directwrite::factory::Factory::new().unwrap();
+        let dwrite = DwriteFactory::new().unwrap();
         let mut text_layout = D2DText::new(&dwrite);
 
         let input = "piet text!";
@@ -676,7 +676,7 @@ mod test {
 
     #[test]
     fn test_hit_test_text_position_complex_0() {
-        let dwrite = directwrite::factory::Factory::new().unwrap();
+        let dwrite = DwriteFactory::new().unwrap();
 
         let input = "é";
         assert_eq!(input.len(), 2);
@@ -738,7 +738,7 @@ mod test {
 
     #[test]
     fn test_hit_test_text_position_complex_1() {
-        let dwrite = directwrite::factory::Factory::new().unwrap();
+        let dwrite = DwriteFactory::new().unwrap();
 
         // Notes on this input:
         // 6 code points
@@ -823,7 +823,7 @@ mod test {
 
     #[test]
     fn test_hit_test_point_basic() {
-        let dwrite = directwrite::factory::Factory::new().unwrap();
+        let dwrite = DwriteFactory::new().unwrap();
 
         let mut text_layout = D2DText::new(&dwrite);
 
@@ -865,7 +865,7 @@ mod test {
 
     #[test]
     fn test_hit_test_point_complex() {
-        let dwrite = directwrite::factory::Factory::new().unwrap();
+        let dwrite = DwriteFactory::new().unwrap();
 
         // Notes on this input:
         // 6 code points


### PR DESCRIPTION
WIP for finishing integration of raw d2d bindings.

- move d3d api into `piet-direct2d`
- integrate `piet-common` with `piet-direct2d`
- add raw_d2d hit testing
- add docstrings indicating that DWriteFactory, DeviceContext, and D2DFactory are to be used only for system integration in druid-shell, not for regular end-users.

Note: on my maching (windows 10 in virtualbox) the test fails for `piet-direct2d`, not sure why.
