### PR TITLE
Add draw_image_area to RenderContext.

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -255,14 +255,36 @@ impl piet::RenderContext for RenderContext {
         Err(new_error(ErrorKind::NotSupported))
     }
 
+    #[inline]
     fn draw_image(
         &mut self,
-        _image: &Self::Image,
-        _rect: impl Into<Rect>,
-        _interp: InterpolationMode,
+        image: &Self::Image,
+        dst_rect: impl Into<Rect>,
+        interp: InterpolationMode,
     ) {
-        unimplemented!()
+        draw_image(self, image, None, dst_rect.into(), interp);
     }
+
+    #[inline]
+    fn draw_image_area(
+        &mut self,
+        image: &Self::Image,
+        src_rect: impl Into<Rect>,
+        dst_rect: impl Into<Rect>,
+        interp: InterpolationMode,
+    ) {
+        draw_image(self, image, Some(src_rect.into()), dst_rect.into(), interp);
+    }
+}
+
+fn draw_image(
+    _ctx: &mut RenderContext,
+    _image: &<RenderContext as piet::RenderContext>::Image,
+    _src_rect: Option<Rect>,
+    _dst_rect: Rect,
+    _interp: InterpolationMode,
+) {
+    unimplemented!()
 }
 
 #[derive(Default)]

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -48,6 +48,22 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
         InterpolationMode::Bilinear,
     );
 
+    // 3x3 px red image with a single blue pixel in the middle
+    #[rustfmt::skip]
+    let blue_dot_data = [
+        255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255,
+        255, 0, 0, 255, 0, 0, 255, 255, 255, 0, 0, 255,
+        255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255,
+    ];
+    let blue_dot_image = rc.make_image(3, 3, &blue_dot_data, ImageFormat::RgbaPremul)?;
+    // Draw using only the single blue pixel
+    rc.draw_image_area(
+        &blue_dot_image,
+        Rect::new(1.0, 1.0, 2.0, 2.0),
+        Rect::new(160.0, 20.0, 170.0, 30.0),
+        InterpolationMode::NearestNeighbor,
+    );
+
     let clip_path = star(Point::new(90.0, 45.0), 10.0, 30.0, 24);
     rc.clip(clip_path);
     let layout = rc.text().new_text_layout(&font, "Clipped text").build()?;

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -304,26 +304,58 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         })
     }
 
+    #[inline]
     fn draw_image(
         &mut self,
         image: &Self::Image,
-        rect: impl Into<Rect>,
-        _interp: InterpolationMode,
+        dst_rect: impl Into<Rect>,
+        interp: InterpolationMode,
     ) {
-        let result = self.with_save(|rc| {
-            let rect = rect.into();
-            let _ = rc.ctx.translate(rect.x0, rect.y0);
-            let _ = rc.ctx.scale(
-                rect.width() / (image.width as f64),
-                rect.height() / (image.height as f64),
-            );
-            rc.ctx
-                .draw_image_with_html_canvas_element(&image.inner, 0.0, 0.0)
-                .wrap()
-        });
-        if let Err(e) = result {
-            self.err = Err(e);
-        }
+        draw_image(self, image, None, dst_rect.into(), interp);
+    }
+
+    #[inline]
+    fn draw_image_area(
+        &mut self,
+        image: &Self::Image,
+        src_rect: impl Into<Rect>,
+        dst_rect: impl Into<Rect>,
+        interp: InterpolationMode,
+    ) {
+        draw_image(self, image, Some(src_rect.into()), dst_rect.into(), interp);
+    }
+}
+
+fn draw_image<'a>(
+    ctx: &mut WebRenderContext<'a>,
+    image: &<WebRenderContext<'a> as RenderContext>::Image,
+    src_rect: Option<Rect>,
+    dst_rect: Rect,
+    _interp: InterpolationMode,
+) {
+    let result = ctx.with_save(|rc| {
+        // TODO: Implement InterpolationMode::NearestNeighbor in software
+        //       See for inspiration http://phrogz.net/tmp/canvas_image_zoom.html
+        let src_rect = match src_rect {
+            Some(src_rect) => src_rect,
+            None => Rect::new(0.0, 0.0, image.width as f64, image.height as f64),
+        };
+        rc.ctx
+            .draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+                &image.inner,
+                src_rect.x0,
+                src_rect.y0,
+                src_rect.width(),
+                src_rect.height(),
+                dst_rect.x0,
+                dst_rect.y0,
+                dst_rect.width(),
+                dst_rect.height(),
+            )
+            .wrap()
+    });
+    if let Err(e) = result {
+        ctx.err = Err(e);
     }
 }
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -114,7 +114,15 @@ impl RenderContext for NullRenderContext {
     fn draw_image(
         &mut self,
         _image: &Self::Image,
-        _rect: impl Into<Rect>,
+        _dst_rect: impl Into<Rect>,
+        _interp: InterpolationMode,
+    ) {
+    }
+    fn draw_image_area(
+        &mut self,
+        _image: &Self::Image,
+        _src_rect: impl Into<Rect>,
+        _dst_rect: impl Into<Rect>,
         _interp: InterpolationMode,
     ) {
     }

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -182,9 +182,26 @@ where
 
     /// Draw an image.
     ///
-    /// The image is scaled to the provided `rect`. It will be squashed if
-    /// aspect ratios don't match.
-    fn draw_image(&mut self, image: &Self::Image, rect: impl Into<Rect>, interp: InterpolationMode);
+    /// The `image` is scaled to the provided `dst_rect`.
+    /// It will be squashed if the aspect ratios don't match.
+    fn draw_image(
+        &mut self,
+        image: &Self::Image,
+        dst_rect: impl Into<Rect>,
+        interp: InterpolationMode,
+    );
+
+    /// Draw a specified area of an image.
+    ///
+    /// The `src_rect` area of `image` is scaled to the provided `dst_rect`.
+    /// It will be squashed if the aspect ratios don't match.
+    fn draw_image_area(
+        &mut self,
+        image: &Self::Image,
+        src_rect: impl Into<Rect>,
+        dst_rect: impl Into<Rect>,
+        interp: InterpolationMode,
+    );
 
     /// Returns the transformations currently applied to the context.
     fn current_transform(&self) -> Affine;


### PR DESCRIPTION
This PR expands the `draw_image` API call by adding a `src_rect` parameter. The drawing works as before, but now it uses the area of the image that is specified.

This is motivated by an image gallery app I'm writing using druid, where I need to show different areas of known images for every animation frame.

Previously this was possible by either having different images in memory or using `clip`. The new API makes it easier and probably more efficient.

Keeping ergonomics in mind for people who just want to draw the whole image (or upgrade to this new API) I also wanted it to be easy to do that. I tried a few ways of doing this.

First idea was to use `Option<impl Into<Rect>>` but unfortunately this ended up looking less than ideal.

```rust
Some(Rect::new(10.0, 10.0, 20.0, 20.0)) // Subimage
None as Option<Rect> // Whole image, the compiler demands the type info for None
```

Thus I ended up using just `impl Into<Rect>` with a special case. Less typing and better errors.

```rust
Rect::new(10.0, 10.0, 20.0, 20.0) // Subimage
Rect::ZERO // Whole image, can also be any rect for which .area() == 0
```