### PR TITLE
Fix StrokeStyle.set_miter_limit by borrowing instead of moving.

### DIFF
--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -47,7 +47,7 @@ impl StrokeStyle {
         self.dash = Some((dashes, offset));
     }
 
-    pub fn set_miter_limit(mut self, miter_limit: f64) {
+    pub fn set_miter_limit(&mut self, miter_limit: f64) {
         self.miter_limit = Some(miter_limit);
     }
 }


### PR DESCRIPTION
This seems like a bug to me. Changing it to a borrow makes the function more useful.