### PR TITLE
Expose current_transform() for contexts

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -255,6 +255,10 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.ctx.transform(affine_to_matrix(transform));
     }
 
+    fn current_transform(&self) -> Affine {
+        matrix_to_affine(self.ctx.get_matrix())
+    }
+
     fn make_image(
         &mut self,
         width: usize,
@@ -490,6 +494,12 @@ fn affine_to_matrix(affine: Affine) -> Matrix {
         x0: a[4],
         y0: a[5],
     }
+}
+
+fn matrix_to_affine(matrix: Matrix) -> Affine {
+    Affine::new([
+        matrix.xx, matrix.yx, matrix.xy, matrix.yy, matrix.x0, matrix.y0,
+    ])
 }
 
 fn scale_matrix(scale: f64) -> Matrix {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -109,11 +109,6 @@ impl<'b, 'a: 'b> D2DRenderContext<'a> {
         }
     }
 
-    pub fn current_transform(&self) -> Affine {
-        // This is an unwrap because we protect the invariant.
-        self.ctx_stack.last().unwrap().transform
-    }
-
     fn pop_state(&mut self) {
         // This is an unwrap because we protect the invariant.
         let old_state = self.ctx_stack.pop().unwrap();
@@ -426,7 +421,8 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     }
 
     fn current_transform(&self) -> Affine {
-        self.current_transform()
+        // This is an unwrap because we protect the invariant.
+        self.ctx_stack.last().unwrap().transform
     }
 
     fn make_image(

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -109,7 +109,7 @@ impl<'b, 'a: 'b> D2DRenderContext<'a> {
         }
     }
 
-    fn current_transform(&self) -> Affine {
+    pub fn current_transform(&self) -> Affine {
         // This is an unwrap because we protect the invariant.
         self.ctx_stack.last().unwrap().transform
     }
@@ -423,6 +423,10 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         self.ctx_stack.last_mut().unwrap().transform *= transform;
         self.rt
             .set_transform(&affine_to_matrix3x2f(self.current_transform()));
+    }
+
+    fn current_transform(&self) -> Affine {
+        self.current_transform()
     }
 
     fn make_image(

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -236,6 +236,10 @@ impl piet::RenderContext for RenderContext {
         self.state.xf *= transform;
     }
 
+    fn current_transform(&self) -> Affine {
+        self.state.xf
+    }
+
     fn make_image(
         &mut self,
         _width: usize,

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -262,6 +262,13 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         let _ = self.ctx.transform(a[0], a[1], a[2], a[3], a[4], a[5]);
     }
 
+    fn current_transform(&self) -> Affine {
+        // todo
+        // current_transform() and get_transform() currently not implemented:
+        // https://github.com/rustwasm/wasm-bindgen/blob/f8354b3a88de013845a304ea77d8b9b9286a0d7b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl#L136
+        Affine::default()
+    }
+
     fn make_image(
         &mut self,
         width: usize,

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -117,6 +117,10 @@ impl RenderContext for NullRenderContext {
         _interp: InterpolationMode,
     ) {
     }
+
+    fn current_transform(&self) -> Affine {
+        Affine::default()
+    }
 }
 
 impl Text for NullText {

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -80,7 +80,7 @@ where
     ///
     /// TODO: figure out how to document lifetime and rebuilding requirements. Should
     /// that be the responsibility of the client, or should the back-end take
-    /// responsiblity? We could have a cache that is flushed when the Direct2D
+    /// responsibility? We could have a cache that is flushed when the Direct2D
     /// render target is rebuilt. Solid brushes are super lightweight, but
     /// other potentially retained objects will be heavier.
     fn solid_brush(&mut self, color: Color) -> Self::Brush;
@@ -185,6 +185,9 @@ where
     /// The image is scaled to the provided `rect`. It will be squashed if
     /// aspect ratios don't match.
     fn draw_image(&mut self, image: &Self::Image, rect: impl Into<Rect>, interp: InterpolationMode);
+
+    /// Returns the transformations currently applied to the context.
+    fn current_transform(&self) -> Affine;
 }
 
 /// A trait for various types that can be used as brushes. These include


### PR DESCRIPTION
This is related to https://github.com/xi-editor/druid/issues/430 and exposes `current_transform()` and required for https://github.com/xi-editor/druid/pull/466