### PR TITLE
Increment macOS version

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         mac:
-          imageName: 'macos-10.13'
+          imageName: 'macos-10.14'
         windows:
           imageName: 'vs2017-win2016'
         linux:


### PR DESCRIPTION
Azure Pipelines will shortly stop supporting macOS 10.13.