### PR TITLE
Add phantom lifetime to cairo Text object to match d2d API

### DIFF
--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -20,7 +20,7 @@ pub type Brush = piet_cairo::Brush;
 /// The associated text factory for this backend.
 ///
 /// This type matches `RenderContext::Text`
-pub type PietText<'a> = CairoText;
+pub type PietText<'a> = CairoText<'a>;
 
 /// The associated font type for this backend.
 ///


### PR DESCRIPTION
This makes cairo behave like d2d, which keeps me honest when writing code against the piet api.

I'm not sure this makes sense to include, But I'm also not sure it doesn't. 🤔