### PR TITLE
Correct date and name in LICENSE-APACHE

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -52,7 +52,7 @@ You may add Your own copyright statement to Your modifications and may provide a
 
 END OF TERMS AND CONDITIONS
 
-Copyright 2016 Maik Klein
+Copyright 2019 Raph Levien
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copy and paste error: name and date in LICENSE-APACHE is Maik Klein and 2016. Changed these respectively to Raph Levien and 2019, in order to match LICENSE-MIT.