### PR TITLE
Clippy cleanup

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -29,6 +29,7 @@ pub struct RenderContext {
 
 impl RenderContext {
     /// Construct an empty `RenderContext`
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
             stack: Vec::new(),
@@ -273,6 +274,8 @@ struct Attrs<'a> {
 }
 
 impl Attrs<'_> {
+    // allow clippy warning for `width != 1.0` in if statement
+    #[allow(clippy::float_cmp)]
     fn apply_to(&self, node: &mut impl Node) {
         node.assign("transform", xf_val(&self.xf));
         if let Some(id) = self.clip {
@@ -414,6 +417,8 @@ pub struct Image(());
 struct Id(u64);
 
 impl Id {
+    // TODO allowing clippy warning temporarily. But this should be changed to impl Display
+    #[allow(clippy::inherent_to_string)]
     fn to_string(self) -> String {
         const ALPHABET: &[u8; 52] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
         let mut out = String::with_capacity(4);

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -9,6 +9,7 @@ type Result<T> = std::result::Result<T, Error>;
 pub struct Text(());
 
 impl Text {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Text(())
     }

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -28,7 +28,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let font = rc.text().new_font_by_name("Segoe UI", 12.0).build()?;
     let layout = rc.text().new_text_layout(&font, "Hello piet!").build()?;
-    let w: f64 = layout.width().into();
+    let w: f64 = layout.width();
     let brush = rc.solid_brush(Color::rgba8(0x80, 0x00, 0x00, 0xC0));
     rc.draw_text(&layout, (80.0, 10.0), &brush);
 
@@ -72,6 +72,8 @@ fn star(center: Point, inner: f64, outer: f64, n: usize) -> BezPath {
     result
 }
 
+// allows for nice vertical formatting for `result[ix + 0]`
+#[allow(clippy::identity_op)]
 fn make_image_data(width: usize, height: usize) -> Vec<u8> {
     let mut result = vec![0; width * height * 4];
     for y in 0..height {

--- a/piet-test/src/picture_1.rs
+++ b/piet-test/src/picture_1.rs
@@ -27,7 +27,7 @@ fn circle<V: Into<Point>>(center: V, radius: f64, num_segments: usize) -> BezPat
     }
 
     path.close_path();
-    return path;
+    path
 }
 
 fn draw_cubic_bezier<V: Into<Point>>(

--- a/piet-test/src/picture_2.rs
+++ b/piet-test/src/picture_2.rs
@@ -38,6 +38,9 @@ fn make_image_data(width: usize, height: usize, format: ImageFormat) -> Vec<u8> 
             let b = !r;
             let r2 = ((x as f64) - 8.0).powi(2) + ((y as f64) - 8.0).powi(2);
             let a = (255.0 * (-0.01 * r2).exp()) as u8;
+
+            // allows for nice vertical formatting for `result[ix + 0]`
+            #[allow(clippy::identity_op)]
             match format {
                 ImageFormat::RgbaSeparate => {
                     result[ix + 0] = r;

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -33,9 +33,8 @@ pub enum ImageFormat {
 }
 
 impl ImageFormat {
-    #[allow(clippy::trivially_copy_pass_by_ref)]
-    pub fn bytes_per_pixel(&self) -> usize {
-        match *self {
+    pub fn bytes_per_pixel(self) -> usize {
+        match self {
             ImageFormat::Rgb => 3,
             ImageFormat::RgbaPremul | ImageFormat::RgbaSeparate => 4,
             _ => panic!(),


### PR DESCRIPTION
- [x] Fix all clippy lints in piet

Includes a change from `&self` to `self` for `render_context::ImageFormat::bytes_per_pixel`, referenced at https://github.com/linebender/piet/pull/133#discussion_r377208811

This should have no effect on API