### PR TITLE
Restore common types for Direct2D.

### DIFF
--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use png::{ColorType, Encoder};
 
 use piet::{ErrorKind, ImageFormat};
+use piet_direct2d::d2d::{Bitmap, Brush as D2DBrush};
 use piet_direct2d::d3d::{
     D3D11Device, D3D11DeviceContext, D3D11Texture2D, TextureMode, DXGI_MAP_READ,
 };
@@ -19,6 +20,11 @@ pub use piet_direct2d::*;
 
 /// The `RenderContext` for the Direct2D backend, which is selected.
 pub type Piet<'a> = D2DRenderContext<'a>;
+
+/// The associated brush type for this backend.
+///
+/// This type matches `RenderContext::Brush`
+pub type Brush = D2DBrush;
 
 /// The associated text factory for this backend.
 ///
@@ -44,6 +50,11 @@ pub type PietTextLayout = D2DTextLayout;
 ///
 /// This type matches `RenderContext::Text::TextLayoutBuilder`
 pub type PietTextLayoutBuilder<'a> = D2DTextLayoutBuilder<'a>;
+
+/// The associated image type for this backend.
+///
+/// This type matches `RenderContext::Image`
+pub type Image = Bitmap;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -45,3 +45,21 @@ mod backend;
 mod backend;
 
 pub use backend::*;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Make sure all the common types exist and don't get accidentally removed
+    #[allow(dead_code)]
+    struct Types<'a> {
+        piet: Piet<'a>,
+        brush: Brush,
+        piet_text: PietText<'a>,
+        piet_font: PietFont,
+        piet_font_builder: PietFontBuilder<'a>,
+        piet_text_layout: PietTextLayout,
+        piet_text_layout_builder: PietTextLayoutBuilder<'a>,
+        image: Image,
+    }
+}


### PR DESCRIPTION
The common types `Brush` and `Image` got removed from the Direct2D backend with #111. They weren't removed from other backends nor did the removal have a deprecation period. Thus I imagine it was a mistake.

This PR adds the types back. It also adds a test to prevent accidental removal in the future.