### PR TITLE
direct2d: Add swapchain support and a winit example

### DIFF
--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -123,11 +123,11 @@ impl Device {
         // Bind the backing texture to a D2D Bitmap
         let target = unsafe {
             context
-                .create_bitmap_from_dxgi(&tex.as_dxgi(), pix_scale as f32)
+                .create_bitmap_from_dxgi(&tex.as_dxgi(), pix_scale as f32, BitmapOptions::TARGET)
                 .unwrap()
         };
 
-        context.set_target(&target);
+        context.set_target(Some(&target));
         // TODO ask about this? it was in basic.rs, but not here
         context.set_dpi_scale(pix_scale as f32);
         context.begin_draw();

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -11,13 +11,14 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "0.0.9", path = "../piet" }
-
+bitflags = "1.2"
 wio = "0.2.2"
 
 [dependencies.winapi]
 version = "0.3.8"
-features = [ "d2d1", "d2d1_1", "d3d11", "dxgi" ]
+features = [ "d2d1", "d2d1_1", "d3d11", "dxgi", "dxgi1_2" ]
 
 [dev-dependencies]
 image = "0.22.1"
 piet-test = { version = "0.0.9", path = "../piet-test" }
+winit = "0.22"

--- a/piet-direct2d/examples/basic.rs
+++ b/piet-direct2d/examples/basic.rs
@@ -3,7 +3,7 @@
 use winapi::shared::dxgi::DXGI_MAP_READ;
 
 use piet::RenderContext;
-use piet_direct2d::D2DRenderContext;
+use piet_direct2d::{BitmapOptions, D2DRenderContext};
 
 use piet_test::draw_test_picture;
 
@@ -45,11 +45,11 @@ fn main() {
     // Bind the backing texture to a D2D Bitmap
     let target = unsafe {
         context
-            .create_bitmap_from_dxgi(&tex.as_dxgi(), HIDPI)
+            .create_bitmap_from_dxgi(&tex.as_dxgi(), HIDPI, BitmapOptions::TARGET)
             .unwrap()
     };
 
-    context.set_target(&target);
+    context.set_target(Some(&target));
     context.set_dpi_scale(HIDPI);
     context.begin_draw();
     let mut piet_context = D2DRenderContext::new(&d2d, &dwrite, &mut context);

--- a/piet-direct2d/examples/winit.rs
+++ b/piet-direct2d/examples/winit.rs
@@ -1,0 +1,90 @@
+use piet::RenderContext;
+use piet_direct2d::{BitmapOptions, D2DRenderContext};
+use piet_test::draw_test_picture;
+use winit::{
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    platform::windows::WindowExtWindows,
+    window::WindowBuilder,
+};
+
+const HIDPI: f32 = 1.0;
+fn main() {
+    let event_loop = EventLoop::new();
+    let window = WindowBuilder::new().build(&event_loop).unwrap();
+
+    // Create the D2D factory
+    let d2d = piet_direct2d::D2DFactory::new().unwrap();
+    let dwrite = piet_direct2d::DwriteFactory::new().unwrap();
+
+    // Initialize a D3D Device
+    let (d3d, _d3d_ctx) = piet_direct2d::d3d::D3D11Device::create().unwrap();
+
+    // Create the D2D Device and Context
+    let mut device = unsafe { d2d.create_device(d3d.as_dxgi().unwrap().as_raw()).unwrap() };
+    let mut context = device.create_device_context().unwrap();
+
+    let swapchain = unsafe { d3d.create_swapchain_from_hwnd(window.hwnd() as _).unwrap() };
+    let mut backbuffer = Some(swapchain.get_buffer().unwrap());
+    let mut target = Some(unsafe {
+        context
+            .create_bitmap_from_dxgi(
+                &backbuffer.as_ref().unwrap().as_dxgi(),
+                HIDPI,
+                BitmapOptions::TARGET | BitmapOptions::CANNOT_DRAW,
+            )
+            .unwrap()
+    });
+    context.set_target(target.as_ref());
+    context.set_dpi_scale(HIDPI);
+
+    event_loop.run(move |event, _, control_flow| {
+        &device; // capture the device otherwise it won't be dropped..
+
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => {
+                *control_flow = ControlFlow::Exit;
+            }
+            Event::WindowEvent {
+                event: WindowEvent::Resized(_),
+                window_id,
+            } if window_id == window.id() => {
+                // Release current references to the backbuffer, resize and recreate
+                context.set_target(None);
+                target.take();
+                backbuffer.take();
+
+                swapchain.resize().unwrap();
+
+                backbuffer = Some(swapchain.get_buffer().unwrap());
+                target = Some(unsafe {
+                    context
+                        .create_bitmap_from_dxgi(
+                            &backbuffer.as_ref().unwrap().as_dxgi(),
+                            HIDPI,
+                            BitmapOptions::TARGET | BitmapOptions::CANNOT_DRAW,
+                        )
+                        .unwrap()
+                });
+                context.set_target(target.as_ref());
+            }
+            Event::RedrawRequested(window_id) if window_id == window.id() => {
+                context.begin_draw();
+
+                let mut piet_context = D2DRenderContext::new(&d2d, &dwrite, &mut context);
+                draw_test_picture(&mut piet_context, 1).unwrap();
+                piet_context.finish().unwrap();
+
+                context.end_draw().unwrap();
+
+                swapchain.present().unwrap();
+            }
+            _ => (),
+        }
+    });
+}

--- a/piet-direct2d/src/d3d.rs
+++ b/piet-direct2d/src/d3d.rs
@@ -131,6 +131,8 @@ impl D3D11Device {
         }
     }
 
+    /// # Safety
+    /// TODO
     pub unsafe fn create_swapchain_from_hwnd(
         &self,
         hwnd: winapi::shared::windef::HWND,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -26,7 +26,7 @@ use piet::{
     RenderContext, StrokeStyle,
 };
 
-pub use crate::d2d::{D2DDevice, D2DFactory, DeviceContext as D2DDeviceContext};
+pub use crate::d2d::{BitmapOptions, D2DDevice, D2DFactory, DeviceContext as D2DDeviceContext};
 pub use crate::dwrite::DwriteFactory;
 pub use crate::text::{D2DFont, D2DFontBuilder, D2DText, D2DTextLayout, D2DTextLayoutBuilder};
 


### PR DESCRIPTION
This adds basic support for creating a swapchain froma HWND handle including a sample using winit.
I'm not sure if surface/swapchain handling is in scope of `piet` but I feel it's reasonable to have as extension to make it easier to get started.