### PR TITLE
Update github actions checkout to v2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: rustfmt
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -35,7 +35,7 @@ jobs:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo test stable
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install cairo
         run: brew install cairo
@@ -126,7 +126,7 @@ jobs:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo test nightly
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install cairo
         run: brew install cairo
@@ -167,7 +167,7 @@ jobs:
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: install cairo
         run: brew install cairo


### PR DESCRIPTION
Checkout v1 is broken, see [druid#724](https://github.com/xi-editor/druid/pull/724) for more.