### PR TITLE
Fix piet-web build

### DIFF
--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -23,7 +23,7 @@ use piet::{
     LineJoin, RenderContext, StrokeStyle,
 };
 
-pub use text::WebTextLayout;
+pub use text::{WebFont, WebFontBuilder, WebTextLayout, WebTextLayoutBuilder};
 
 pub struct WebRenderContext<'a> {
     ctx: &'a mut CanvasRenderingContext2d,


### PR DESCRIPTION
WebFont, WebFontBuilder and WebTextLayoutBuilder were not exported in
piet-web but expected in piet-common.

The compilation error on `cargo build --target wasm32-unknown-unknown` was:

```rust
error[E0412]: cannot find type `WebFont` in this scope
  --> piet-common/src/web_back.rs:20:21
   |
20 | pub type PietFont = WebFont;
   |                     ^^^^^^^ not found in this scope

error[E0412]: cannot find type `WebFontBuilder` in this scope
  --> piet-common/src/web_back.rs:25:32
   |
25 | pub type PietFontBuilder<'a> = WebFontBuilder;
   | -------------------------------^^^^^^^^^^^^^^-
   | |                              |
   | |                              help: a type alias with a similar name exists: `PietFontBuilder`
   | similarly named type alias `PietFontBuilder` defined here

error[E0412]: cannot find type `WebTextLayoutBuilder` in this scope
  --> piet-common/src/web_back.rs:35:38
   |
35 | pub type PietTextLayoutBuilder<'a> = WebTextLayoutBuilder;
   | -------------------------------------^^^^^^^^^^^^^^^^^^^^-
   | |                                    |
   | |                                    help: a type alias with a similar name exists: `PietTextLayoutBuilder`
   | similarly named type alias `PietTextLayoutBuilder` defined here

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0412`.
error: could not compile `piet-common`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```