### PR TITLE
Remove refs from WebRenderContext constructor API

### DIFF
--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -19,7 +19,7 @@ pub fn run() {
         .unwrap()
         .dyn_into::<HtmlCanvasElement>()
         .unwrap();
-    let mut context = canvas
+    let context = canvas
         .get_context("2d")
         .unwrap()
         .unwrap()
@@ -31,7 +31,7 @@ pub fn run() {
     canvas.set_height((canvas.offset_height() as f64 * dpr) as u32);
     let _ = context.scale(dpr, dpr);
 
-    let mut piet_context = WebRenderContext::new(&mut context, &window);
+    let mut piet_context = WebRenderContext::new(context, window);
     run_tests(&mut piet_context);
 
     // TODO: make the test picture selectable

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -26,18 +26,20 @@ use piet::{
 pub use text::{WebFont, WebFontBuilder, WebTextLayout, WebTextLayoutBuilder};
 
 pub struct WebRenderContext<'a> {
-    ctx: &'a mut CanvasRenderingContext2d,
+    ctx: CanvasRenderingContext2d,
     /// Used for creating image bitmaps and possibly other resources.
-    window: &'a Window,
+    window: Window,
     err: Result<(), Error>,
+    phantom: std::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> WebRenderContext<'a> {
-    pub fn new(ctx: &'a mut CanvasRenderingContext2d, window: &'a Window) -> WebRenderContext<'a> {
+    pub fn new(ctx: CanvasRenderingContext2d, window: Window) -> WebRenderContext<'a> {
         WebRenderContext {
             ctx,
             window,
             err: Ok(()),
+            phantom: std::marker::PhantomData,
         }
     }
 }
@@ -326,9 +328,9 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     }
 }
 
-fn draw_image<'a>(
-    ctx: &mut WebRenderContext<'a>,
-    image: &<WebRenderContext<'a> as RenderContext>::Image,
+fn draw_image(
+    ctx: &mut WebRenderContext,
+    image: &<WebRenderContext as RenderContext>::Image,
     src_rect: Option<Rect>,
     dst_rect: Rect,
     _interp: InterpolationMode,
@@ -393,7 +395,7 @@ fn set_gradient_stops(dst: &mut CanvasGradient, src: &[GradientStop]) {
     }
 }
 
-impl<'a> WebRenderContext<'a> {
+impl WebRenderContext<'_> {
     /// Set the source pattern to the brush.
     ///
     /// Web canvas is super stateful, and we're trying to have more retained stuff.


### PR DESCRIPTION
Specifically, the lifetime of `WebRenderContext` is changed to not depend on lifetimes of  `CanvasRenderingContext2d` and `Window` objects, since these lifetimes don't actually enforce the existence of web resources anyways.

The `mut `is also removed from `CanvasRenderingContext2d` since its API has no `mut` calls and this generally makes the `WebRenderContext` difficult to use in libraries like druid.

For compatibility the `WebRenderContext` maintains a phantom lifetime placeholder for compatibility as well as for anticipating a correct lifetime there.