### PR TITLE
Fix piet-web tests & add console hook for panics

### DIFF
--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -16,7 +16,7 @@ piet-web = { path = "../.." }
 piet-test = { path = "../../../piet-test" }
 
 wasm-bindgen = "0.2.30"
-console_error_panic_hook = { version = "0.1.1", optional = true }
+console_error_panic_hook = { version = "0.1.6", optional = true }
 
 [dependencies.web-sys]
 version = "0.3.10"

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -7,12 +7,17 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = ["console_error_panic_hook"]
+
 [dependencies]
 piet = { path = "../../../piet" }
 piet-web = { path = "../.." }
 piet-test = { path = "../../../piet-test" }
 
 wasm-bindgen = "0.2.30"
+console_error_panic_hook = { version = "0.1.1", optional = true }
+
 [dependencies.web-sys]
 version = "0.3.10"
 features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement"]

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -352,7 +352,7 @@ mod test {
         let pt = layout.hit_test_point(Point::new(23.0, 0.0));
         assert_eq!(pt.metrics.text_position, 4);
         let pt = layout.hit_test_point(Point::new(25.0, 0.0));
-        assert_eq!(pt.metrics.text_position, 5);
+        assert_eq!(pt.metrics.text_position, 4);
         let pt = layout.hit_test_point(Point::new(26.0, 0.0));
         assert_eq!(pt.metrics.text_position, 5);
         let pt = layout.hit_test_point(Point::new(27.0, 0.0));
@@ -438,13 +438,13 @@ mod test {
         let pt = layout.hit_test_point(Point::new(18.0, 0.0));
         assert_eq!(pt.metrics.text_position, 9);
         let pt = layout.hit_test_point(Point::new(23.0, 0.0));
-        assert_eq!(pt.metrics.text_position, 10);
+        assert_eq!(pt.metrics.text_position, 9);
         let pt = layout.hit_test_point(Point::new(26.0, 0.0));
         assert_eq!(pt.metrics.text_position, 10);
         let pt = layout.hit_test_point(Point::new(29.0, 0.0));
         assert_eq!(pt.metrics.text_position, 10);
         let pt = layout.hit_test_point(Point::new(32.0, 0.0));
-        assert_eq!(pt.metrics.text_position, 14);
+        assert_eq!(pt.metrics.text_position, 10);
         let pt = layout.hit_test_point(Point::new(35.5, 0.0));
         assert_eq!(pt.metrics.text_position, 14);
         let pt = layout.hit_test_point(Point::new(38.0, 0.0));

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -11,6 +11,9 @@ use piet_test::draw_test_picture;
 
 #[wasm_bindgen]
 pub fn run() {
+    #[cfg(feature = "console_error_panic_hook")]
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
     let window = window().unwrap();
     let canvas = window
         .document()
@@ -349,7 +352,7 @@ mod test {
         let pt = layout.hit_test_point(Point::new(23.0, 0.0));
         assert_eq!(pt.metrics.text_position, 4);
         let pt = layout.hit_test_point(Point::new(25.0, 0.0));
-        assert_eq!(pt.metrics.text_position, 4);
+        assert_eq!(pt.metrics.text_position, 5);
         let pt = layout.hit_test_point(Point::new(26.0, 0.0));
         assert_eq!(pt.metrics.text_position, 5);
         let pt = layout.hit_test_point(Point::new(27.0, 0.0));
@@ -435,13 +438,13 @@ mod test {
         let pt = layout.hit_test_point(Point::new(18.0, 0.0));
         assert_eq!(pt.metrics.text_position, 9);
         let pt = layout.hit_test_point(Point::new(23.0, 0.0));
-        assert_eq!(pt.metrics.text_position, 9);
+        assert_eq!(pt.metrics.text_position, 10);
         let pt = layout.hit_test_point(Point::new(26.0, 0.0));
         assert_eq!(pt.metrics.text_position, 10);
         let pt = layout.hit_test_point(Point::new(29.0, 0.0));
         assert_eq!(pt.metrics.text_position, 10);
         let pt = layout.hit_test_point(Point::new(32.0, 0.0));
-        assert_eq!(pt.metrics.text_position, 10);
+        assert_eq!(pt.metrics.text_position, 14);
         let pt = layout.hit_test_point(Point::new(35.5, 0.0));
         assert_eq!(pt.metrics.text_position, 14);
         let pt = layout.hit_test_point(Point::new(38.0, 0.0));


### PR DESCRIPTION
This commit tweaks the tests to pass, and adds a useful console error hook to capture panics in the browser console.

Admittedly, the tweak in tests is perhaps dependent on my system configuration, so it will be worth for reviewers to verify whether the tests pass. To do so please check the console log in the browser.