### PR TITLE
Fix backend choice collision

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -14,6 +14,7 @@ cairo = ["piet-cairo", "cairo-rs"]
 web = ["piet-web"]
 
 [dependencies]
+cfg-if = "0.1.10"
 piet = { version = "0.0.11", path = "../piet" }
 piet-cairo = { version = "0.0.11", path = "../piet-cairo", optional = true }
 piet-direct2d = { version = "0.0.11", path = "../piet-direct2d", optional = true }

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -29,20 +29,21 @@ pub use piet::*;
 #[doc(hidden)]
 pub use piet::kurbo;
 
-#[cfg(any(
-    feature = "cairo",
-    not(any(target_arch = "wasm32", target_os = "windows", feature = "direct2d"))
-))]
-#[path = "cairo_back.rs"]
-mod backend;
-
-#[cfg(any(feature = "d2d", all(target_os = "windows", not(feature = "cairo"))))]
-#[path = "direct2d_back.rs"]
-mod backend;
-
-#[cfg(any(feature = "web", target_arch = "wasm32"))]
-#[path = "web_back.rs"]
-mod backend;
+cfg_if::cfg_if! {
+    // if we have explicitly asked for cairo *or* we are not wasm, web, or windows:
+    if #[cfg(any(feature = "cairo", not(any(target_arch = "wasm32", feature="web", target_os = "windows"))))] {
+        #[path = "cairo_back.rs"]
+        mod backend;
+    } else if #[cfg(target_os = "windows")] {
+        #[path = "direct2d_back.rs"]
+        mod backend;
+    } else if #[cfg(any(feature = "web", target_arch = "wasm32"))] {
+        #[path = "web_back.rs"]
+        mod backend;
+    } else {
+        compile_error!("could not select an appropriate backend");
+    }
+}
 
 pub use backend::*;
 


### PR DESCRIPTION
Previously it was possible to select both cairo and the web
backend by passing --features=web without having the target be
wasm32.

This attempts to simplfy how we choose the backend.

We will use cairo if it is selected explicitly, or if we're not on
wasm32, windows, or don't see the 'web' feature;

We will use d2d if we're on windows and don't see the 'cairo' feature;

And we will use the web backend if our target arch is wasm32 or
we see the "web" feature.

We will fail to compile if we cannot select a backend.