### PR TITLE
Add wasm32 test compiling of piet-web/piet-common to the CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
           args: --all --exclude piet-cairo
         if: contains(matrix.os, 'windows')
 
+      - name: cargo test compile (wasm32)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p piet-common -p piet-web --no-run --target wasm32-unknown-unknown
+
       - name: Run rustc -D warnings in piet/
         uses: actions-rs/cargo@v1
         with:
@@ -146,6 +152,8 @@ jobs:
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo test nightly
+    env:
+      PKG_CONFIG_ALLOW_CROSS: 1
     steps:
       - uses: actions/checkout@v2
 
@@ -163,6 +171,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          target: wasm32-unknown-unknown
           profile: minimal
           override: true
 
@@ -179,6 +188,12 @@ jobs:
           command: test
           args: --all --exclude piet-cairo
         if: contains(matrix.os, 'windows')
+
+      - name: cargo test compile (wasm32)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -p piet-common -p piet-web --no-run --target wasm32-unknown-unknown
 
   check-docs:
     name: Docs

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -1,21 +1,29 @@
+// TODO: Remove all the wasm32 cfg guards once this compiles with piet-web
+
+#[cfg(not(target_arch = "wasm32"))]
 use piet::kurbo::Line;
+#[cfg(not(target_arch = "wasm32"))]
 use piet::{Color, RenderContext};
+#[cfg(not(target_arch = "wasm32"))]
 use piet_common::Device;
 
 /// Feature "png" needed for save_to_file() and it's disabled by default for optionsl dependencies
 /// cargo run --example png --features png
 fn main() {
-    let mut device = Device::new().unwrap();
-    let width = 640;
-    let height = 480;
-    let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();
-    let mut rc = bitmap.render_context();
-    rc.clear(Color::WHITE);
-    let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
-    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
-    rc.finish().unwrap();
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let mut device = Device::new().unwrap();
+        let width = 640;
+        let height = 480;
+        let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();
+        let mut rc = bitmap.render_context();
+        rc.clear(Color::WHITE);
+        let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
+        rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
+        rc.finish().unwrap();
 
-    bitmap
-        .save_to_file("temp-image.png")
-        .expect("file save error");
+        bitmap
+            .save_to_file("temp-image.png")
+            .expect("file save error");
+    }
 }


### PR DESCRIPTION
Cargo can't natively run wasm32 tests, but we can at least build them to catch compile errors.

The `png` example doesn't work with wasm32 right now due to lacking `piet_common::Device`. I disabled the example for wasm32 until it gets fixed.

In the future we might be able to get proper testing via `wasm-pack test` and node.js or something, but I'm not sure how all of that works so it's not part of this PR.