### PR TITLE
Switch to offset_{width,height} when clearing web context

### DIFF
--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
 
     fn clear(&mut self, color: Color) {
         let (width, height) = match self.ctx.canvas() {
-            Some(canvas) => (canvas.width(), canvas.height()),
+            Some(canvas) => (canvas.offset_width(), canvas.offset_height()),
             None => return,
             /* Canvas might be null if the dom node is not in
              * the document; do nothing. */


### PR DESCRIPTION
This enables proper browser zooming through the dpi/devicePixelRatio mechanism.

For reference this addresses the zooming issue in druid wasm support found in the [#759](https://github.com/xi-editor/druid/pull/759).