### PR TITLE
Impl From for Color

### DIFF
--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -171,43 +171,31 @@ impl Color {
         }
     }
 
+    /// Convert a color value to four 8-bit rgba values.
+    pub fn as_rgba_u8(&self) -> (u8, u8, u8, u8) {
+        let rgba = self.as_rgba_u32();
+        (
+            (rgba >> 24 & 255) as u8,
+            ((rgba >> 16) & 255) as u8,
+            ((rgba >> 8) & 255) as u8,
+            (rgba & 255) as u8,
+        )
+    }
+
+    /// Convert a color value to four f64 values, each in the range 0.0 to 1.0.
+    pub fn as_rgba_f64(rgba: &Color) -> (f64, f64, f64, f64) {
+        let rgba = rgba.as_rgba_u32();
+        (
+            (rgba >> 24) as f64 / 255.0,
+            ((rgba >> 16) & 255) as f64 / 255.0,
+            ((rgba >> 8) & 255) as f64 / 255.0,
+            (rgba & 255) as f64 / 255.0,
+        )
+    }
+
     /// Opaque white.
     pub const WHITE: Color = Color::rgb8(0xff, 0xff, 0xff);
 
     /// Opaque black.
     pub const BLACK: Color = Color::rgb8(0, 0, 0);
-}
-
-impl From<(u8, u8, u8)> for Color {
-    /// Create a color from a tuple of 8 bit per sample RGB values.
-    fn from(color: (u8, u8, u8)) -> Color {
-        let (r, g, b) = color;
-        Color::rgb8(r, g, b)
-    }
-}
-
-impl From<(u8, u8, u8, u8)> for Color {
-    /// Create a color from a tuple of 8 bit per sample RGBA values.
-    fn from(color: (u8, u8, u8, u8)) -> Color {
-        let (r, g, b, a) = color;
-        Color::rgba8(r, g, b, a)
-    }
-}
-
-impl From<(f64, f64, f64)> for Color {
-    /// Create a color from a tuple of three floating point values, each in the
-    /// range 0.0 to 1.0.
-    fn from(color: (f64, f64, f64)) -> Color {
-        let (r, g, b) = color;
-        Color::rgb(r, g, b)
-    }
-}
-
-impl From<(f64, f64, f64, f64)> for Color {
-    /// Create a color from a tuple of four floating point values, each in the
-    /// range 0.0 to 1.0.
-    fn from(color: (f64, f64, f64, f64)) -> Color {
-        let (r, g, b, a) = color;
-        Color::rgba(r, g, b, a)
-    }
 }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -178,18 +178,36 @@ impl Color {
     pub const BLACK: Color = Color::rgb8(0, 0, 0);
 }
 
-impl From<(u8, u8, u8, u8)> for Color {
-    fn from(color: (u8, u8, u8, u8)) -> Color {
-        let (r, g, b, a) = color;
-        Color::from_rgba32_u32(
-            ((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | (a as u32),
-        )
+impl From<(u8, u8, u8)> for Color {
+    /// Create a color from a tuple of 8 bit per sample RGB values.
+    fn from(color: (u8, u8, u8)) -> Color {
+        let (r, g, b) = color;
+        Color::rgb8(r, g, b)
     }
 }
 
-impl From<(u8, u8, u8)> for Color {
-    fn from(color: (u8, u8, u8)) -> Color {
+impl From<(u8, u8, u8, u8)> for Color {
+    /// Create a color from a tuple of 8 bit per sample RGBA values.
+    fn from(color: (u8, u8, u8, u8)) -> Color {
+        let (r, g, b, a) = color;
+        Color::rgba8(r, g, b, a)
+    }
+}
+
+impl From<(f64, f64, f64)> for Color {
+    /// Create a color from a tuple of three floating point values, each in the
+    /// range 0.0 to 1.0.
+    fn from(color: (f64, f64, f64)) -> Color {
         let (r, g, b) = color;
-        Color::from((r, g, b, 255))
+        Color::rgb(r, g, b)
+    }
+}
+
+impl From<(f64, f64, f64, f64)> for Color {
+    /// Create a color from a tuple of four floating point values, each in the
+    /// range 0.0 to 1.0.
+    fn from(color: (f64, f64, f64, f64)) -> Color {
+        let (r, g, b, a) = color;
+        Color::rgba(r, g, b, a)
     }
 }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -177,3 +177,19 @@ impl Color {
     /// Opaque black.
     pub const BLACK: Color = Color::rgb8(0, 0, 0);
 }
+
+impl From<(u8, u8, u8, u8)> for Color {
+    fn from(color: (u8, u8, u8, u8)) -> Color {
+        let (r, g, b, a) = color;
+        Color::from_rgba32_u32(
+            ((r as u32) << 24) | ((g as u32) << 16) | ((b as u32) << 8) | (a as u32),
+        )
+    }
+}
+
+impl From<(u8, u8, u8)> for Color {
+    fn from(color: (u8, u8, u8)) -> Color {
+        let (r, g, b) = color;
+        Color::from((r, g, b, 255))
+    }
+}

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -183,7 +183,7 @@ impl Color {
     }
 
     /// Convert a color value to four f64 values, each in the range 0.0 to 1.0.
-    pub fn as_rgba_f64(rgba: &Color) -> (f64, f64, f64, f64) {
+    pub fn as_rgba(rgba: &Color) -> (f64, f64, f64, f64) {
         let rgba = rgba.as_rgba_u32();
         (
             (rgba >> 24) as f64 / 255.0,


### PR DESCRIPTION
I find myself copy pasting a "split_rgba" function in a few projects. By impling From we get Into for free and this will cover my use case. I could also add a From<[f64; 4]> / From<[u8; 4]> if those are interesting, but I haven't personally needed those yet.