### PR TITLE
Add test to make sure into_raw_pixels doesn't crash.

### DIFF
--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -221,11 +221,25 @@ impl<'a> Drop for BitmapTarget<'a> {
     }
 }
 
+#[cfg(test)]
 mod tests {
+    use super::*;
+    use piet::kurbo::*;
+    use piet::*;
+
     #[test]
     fn bitmap_target_drop() {
-        let mut device = crate::Device::new().unwrap();
-        let bitmap_target = device.bitmap_target(640, 480, 1.0);
+        let mut device = Device::new().unwrap();
+        let bitmap_target = device.bitmap_target(640, 480, 1.0).unwrap();
         std::mem::drop(bitmap_target);
+    }
+
+    #[test]
+    fn into_raw_pixels() {
+        let mut device = Device::new().unwrap();
+        let mut target = device.bitmap_target(640, 480, 1.0).unwrap();
+        let mut piet = target.render_context();
+        piet.clip(Rect::ZERO);
+        target.into_raw_pixels(ImageFormat::RgbaPremul).unwrap();
     }
 }


### PR DESCRIPTION
The provided `into_raw_pixels` test crashes when calling the system d2d `EndDraw` funtion. This doesn't seem like desired behavior. If this test does something invalid, I think a Rust panic would be better and if this test should work then we have a bug.

Found this issue while investigating [druid#784](https://github.com/xi-editor/druid/pull/784)