### PR TITLE
[text] TextLayout width as Option<f64> instead of f64, fix update_width

### DIFF
--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -29,7 +29,7 @@ impl piet::Text for Text {
         &mut self,
         _font: &Self::Font,
         _text: &str,
-        _width: f64,
+        _width: impl Into<Option<f64>>,
     ) -> TextLayoutBuilder {
         TextLayoutBuilder(())
     }
@@ -71,7 +71,7 @@ impl piet::TextLayout for TextLayout {
     }
 
     #[allow(clippy::unimplemented)]
-    fn update_width(&mut self, _new_width: f64) -> Result<()> {
+    fn update_width(&mut self, _new_width: impl Into<Option<f64>>) -> Result<()> {
         unimplemented!();
     }
 

--- a/piet-test/src/picture_0.rs
+++ b/piet-test/src/picture_0.rs
@@ -29,7 +29,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let font = rc.text().new_font_by_name("Segoe UI", 12.0).build()?;
     let layout = rc
         .text()
-        .new_text_layout(&font, "Hello piet!", std::f64::INFINITY)
+        .new_text_layout(&font, "Hello piet!", None)
         .build()?;
     let w: f64 = layout.width();
     let brush = rc.solid_brush(Color::rgba8(0x80, 0x00, 0x00, 0xC0));
@@ -73,7 +73,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clip(clip_path);
     let layout = rc
         .text()
-        .new_text_layout(&font, "Clipped text", std::f64::INFINITY)
+        .new_text_layout(&font, "Clipped text", None)
         .build()?;
     rc.draw_text(&layout, (80.0, 50.0), &brush);
 

--- a/piet-test/src/picture_5.rs
+++ b/piet-test/src/picture_5.rs
@@ -12,7 +12,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let layout = rc
         .text()
-        .new_text_layout(&font, "piet text!", std::f64::INFINITY)
+        .new_text_layout(&font, "piet text!", None)
         .build()?;
 
     let width = layout.width();

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -150,7 +150,7 @@ impl Text for NullText {
         &mut self,
         _font: &Self::Font,
         _text: &str,
-        _width: f64,
+        _width: impl Into<Option<f64>>,
     ) -> Self::TextLayoutBuilder {
         NullTextLayoutBuilder
     }
@@ -179,7 +179,7 @@ impl TextLayout for NullTextLayout {
         42.0
     }
 
-    fn update_width(&mut self, _new_width: f64) -> Result<(), Error> {
+    fn update_width(&mut self, _new_width: impl Into<Option<f64>>) -> Result<(), Error> {
         Ok(())
     }
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -16,7 +16,7 @@ pub trait Text {
         &mut self,
         font: &Self::Font,
         text: &str,
-        width: f64,
+        width: impl Into<Option<f64>>,
     ) -> Self::TextLayoutBuilder;
 }
 
@@ -78,7 +78,7 @@ pub trait TextLayout: Clone {
 
     /// Used for changing the width of a text layout. Given a width, returns a [`TextLayout`]
     /// struct with recalculated lines and line metrics.
-    fn update_width(&mut self, new_width: f64) -> Result<(), Error>;
+    fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error>;
 
     /// Given a line number, return a reference to that line's underlying string.
     fn line_text(&self, line_number: usize) -> Option<&str>;

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -76,8 +76,10 @@ pub trait TextLayout: Clone {
     /// Measure the advance width of the text.
     fn width(&self) -> f64;
 
-    /// Used for changing the width of a text layout. Given a width, returns a [`TextLayout`]
-    /// struct with recalculated lines and line metrics.
+    /// Change the width of this `TextLayout`.
+    ///
+    /// This may be an `f64`, or `None` if this layout is not constrained;
+    /// `None` is equivalent to `std::f64::INFINITY`.
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error>;
 
     /// Given a line number, return a reference to that line's underlying string.


### PR DESCRIPTION
Updates `Text::new_text_layout` and `TextLayout::update_width` to use
`impl Into<Option<f64>>` for width and new width parameters. Internally,
`f64` is still used.

Fixed a bug for piet-web and piet-d2d where `TextLayout::update_width` did
not recalculate new width. Should add tests for recalculating width.