### PR TITLE
Wasm bitmap target

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -36,3 +36,6 @@ png = { version = "0.16.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 piet-web = { version = "0.0.12", path = "../piet-web" }
+web-sys = { version = "0.3.36", features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule", "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"] }
+wasm-bindgen = "0.2.59"
+

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -38,4 +38,4 @@ png = { version = "0.16.1", optional = true }
 piet-web = { version = "0.0.12", path = "../piet-web" }
 web-sys = { version = "0.3.36", features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule", "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"] }
 wasm-bindgen = "0.2.59"
-
+png = { version = "0.16.1", optional = true }

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -38,3 +38,73 @@ pub type PietTextLayoutBuilder<'a> = WebTextLayoutBuilder;
 ///
 /// This type matches `RenderContext::Image`
 pub type Image = WebImage;
+
+/// A struct that can be used to create bitmap render contexts.
+pub struct Device;
+
+/// A struct provides a `RenderContext` and then can have its bitmap extracted.
+pub struct BitmapTarget<'a> {
+    canvas: HtmlCanvasElement,
+    context: CanvasRenderingContext2d,
+    phantom: PhantomData<&'a ()>,
+}
+
+impl Device {
+    /// Create a new device.
+    pub fn new() -> Result<Device, piet::Error> {
+        Ok(Device)
+    }
+
+    /// Create a new bitmap target.
+    pub fn bitmap_target(
+        &mut self,
+        width: usize,
+        height: usize,
+        pix_scale: f64,
+    ) -> Result<BitmapTarget, piet::Error> {
+        let document = web_sys::window().unwrap().document().unwrap();
+        let canvas = document
+            .create_element("canvas")
+            .unwrap()
+            .dyn_into::<web_sys::HtmlCanvasElement>()
+            .unwrap()
+        let context = canvas
+            .get_context("2d")
+            .unwrap()
+            .dyn_into::<web_sys::CanvasRenderingContext2d>()
+            .unwrap();
+
+        canvas.set_width(width as u32);
+        canvas.set_height(height as u32);
+        let _ = context.scale(pix_scale, pix_scale);
+
+        Ok(BitmapTarget {
+            canvas,
+            context,
+            phantom: Default::default(),
+        })
+    }
+}
+
+impl<'a> BitmapTarget<'a> {
+    /// Get a piet `RenderContext` for the bitmap.
+    pub fn render_context(&mut self) -> WebRenderContext {
+        WebRenderContext::new(self.ctx.clone(), web_sys::window().unwrap())
+    }
+
+    /// Get raw RGBA pixels from the bitmap.
+    pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+        // TODO: This code is just a snippet. A thorough review and testing should be done before
+        // this is used. It is here for compatibility with druid.
+        if fmt != ImageFormat::RgbaPremul {
+            return Err(piet::new_eror(ErrorKind::NotSupported));
+        }
+
+        let mut raw_data = vec![0; width * height * 4];
+        let img_data = self.context.get_image_data()
+            .map_err(Into::<Box<dyn std::error::Error>>::into)?;
+
+        // ImageDate is in RGBA order. This should be the same as expected on the output.
+        Ok(img_data.data().0)
+    }
+}

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -120,6 +120,29 @@ impl<'a> BitmapTarget<'a> {
         // ImageDate is in RGBA order. This should be the same as expected on the output.
         Ok(img_data.data().0)
     }
+
+    /// Save bitmap to RGBA PNG file
+    #[cfg(feature = "png")]
+    pub fn save_to_file<P: AsRef<Path>>(self, path: P) -> Result<(), piet::Error> {
+        let height = self.canvas.height();
+        let width = self.canvas.width();
+        let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
+        let file = BufWriter::new(File::create(path).map_err(|e| Into::<Box<_>>::into(e))?);
+        let mut encoder = Encoder::new(file, width as u32, height as u32);
+        encoder.set_color(ColorType::RGBA);
+        encoder
+            .write_header()
+            .map_err(|e| Into::<Box<_>>::into(e))?
+            .write_image_data(&image)
+            .map_err(|e| Into::<Box<_>>::into(e))?;
+        Ok(())
+    }
+
+    /// Stub for feature is missing
+    #[cfg(not(feature = "png"))]
+    pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
+        Err(piet::new_error(ErrorKind::MissingFeature))
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -1,7 +1,14 @@
 //! Support for piet Web back-end.
 
+use piet::{ErrorKind, ImageFormat};
 #[doc(hidden)]
 pub use piet_web::*;
+
+use std::fmt;
+use std::marker::PhantomData;
+
+use wasm_bindgen::JsCast;
+
 pub type Piet<'a> = WebRenderContext<'a>;
 
 /// The associated brush type for this backend.
@@ -44,8 +51,8 @@ pub struct Device;
 
 /// A struct provides a `RenderContext` and then can have its bitmap extracted.
 pub struct BitmapTarget<'a> {
-    canvas: HtmlCanvasElement,
-    context: CanvasRenderingContext2d,
+    canvas: web_sys::HtmlCanvasElement,
+    context: web_sys::CanvasRenderingContext2d,
     phantom: PhantomData<&'a ()>,
 }
 
@@ -67,9 +74,10 @@ impl Device {
             .create_element("canvas")
             .unwrap()
             .dyn_into::<web_sys::HtmlCanvasElement>()
-            .unwrap()
+            .unwrap();
         let context = canvas
             .get_context("2d")
+            .unwrap()
             .unwrap()
             .dyn_into::<web_sys::CanvasRenderingContext2d>()
             .unwrap();
@@ -89,22 +97,46 @@ impl Device {
 impl<'a> BitmapTarget<'a> {
     /// Get a piet `RenderContext` for the bitmap.
     pub fn render_context(&mut self) -> WebRenderContext {
-        WebRenderContext::new(self.ctx.clone(), web_sys::window().unwrap())
+        WebRenderContext::new(self.context.clone(), web_sys::window().unwrap())
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    pub fn into_raw_pixels(self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         // TODO: This code is just a snippet. A thorough review and testing should be done before
         // this is used. It is here for compatibility with druid.
+
         if fmt != ImageFormat::RgbaPremul {
-            return Err(piet::new_eror(ErrorKind::NotSupported));
+            return Err(piet::new_error(ErrorKind::NotSupported));
         }
 
-        let mut raw_data = vec![0; width * height * 4];
-        let img_data = self.context.get_image_data()
-            .map_err(Into::<Box<dyn std::error::Error>>::into)?;
+        let width = self.canvas.width() as usize;
+        let height = self.canvas.height() as usize;
+
+        let img_data = self
+            .context
+            .get_image_data(0.0, 0.0, width as f64, height as f64)
+            .map_err(|jsv| piet::new_error(ErrorKind::BackendError(Box::new(JsError::new(jsv)))))?;
 
         // ImageDate is in RGBA order. This should be the same as expected on the output.
         Ok(img_data.data().0)
     }
 }
+
+#[derive(Clone, Debug)]
+struct JsError {
+    jsv: wasm_bindgen::JsValue,
+}
+
+impl JsError {
+    fn new(jsv: wasm_bindgen::JsValue) -> Self {
+        JsError { jsv }
+    }
+}
+
+impl fmt::Display for JsError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.jsv)
+    }
+}
+
+impl std::error::Error for JsError {}

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -6,6 +6,15 @@ pub use piet_web::*;
 
 use std::fmt;
 use std::marker::PhantomData;
+use std::path::Path;
+
+#[cfg(feature = "png")]
+use std::fs::File;
+#[cfg(feature = "png")]
+use std::io::BufWriter;
+
+#[cfg(feature = "png")]
+use png::{ColorType, Encoder};
 
 use wasm_bindgen::JsCast;
 


### PR DESCRIPTION
This PR adds a placeholder for the bitmap target rendering mechanism present in other backends. In the current state this PR will enable druid unit tests to be built with WASM, although their execution will need to be thought out further.

I intend this PR to simply get the ball rolling toward getting testing working for the wasm backend in druid since https://github.com/xi-editor/druid/pull/759 doesn't provide any testing in wasm.