### PR TITLE
[cairo, web] impl draw_text for multiline

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -213,8 +213,13 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.ctx.set_scaled_font(&layout.font);
         self.set_brush(&*brush);
         let pos = pos.into();
-        self.ctx.move_to(pos.x, pos.y);
-        self.ctx.show_text(&layout.text);
+
+        for lm in &layout.line_metrics {
+            self.ctx
+                .move_to(pos.x, pos.y + lm.cumulative_height - lm.height);
+            self.ctx
+                .show_text(&layout.text[lm.start_offset..lm.end_offset]);
+        }
     }
 
     fn save(&mut self) -> Result<(), Error> {

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -41,7 +41,7 @@ pub struct CairoTextLayout {
     pub text: String,
 
     // currently calculated on build
-    line_metrics: Vec<LineMetric>,
+    pub(crate) line_metrics: Vec<LineMetric>,
 }
 
 pub struct CairoTextLayoutBuilder(CairoTextLayout);

--- a/piet-test/src/picture_5.rs
+++ b/piet-test/src/picture_5.rs
@@ -15,11 +15,17 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
         .new_text_layout(&font, "piet text!", None)
         .build()?;
 
+    let layout_multiline = rc
+        .text()
+        .new_text_layout(&font, "piet text is the best text!", 50.0)
+        .build()?;
+
     let width = layout.width();
 
     let brush = rc.solid_brush(Color::rgba8(0x00, 0x80, 0x80, 0xF0));
 
     rc.draw_text(&layout, (100.0, 50.0), &brush);
+    rc.draw_text(&layout_multiline, (20.0, 50.0), &brush);
 
     // underline text
     rc.stroke(Line::new((100.0, 52.0), (100.0 + width, 52.0)), &brush, 1.0);

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -211,8 +211,19 @@ impl<'a> RenderContext for WebRenderContext<'a> {
         self.ctx.set_font(&layout.font.get_font_string());
         self.set_brush(&*brush, true);
         let pos = pos.into();
-        if let Err(e) = self.ctx.fill_text(&layout.text, pos.x, pos.y).wrap() {
-            self.err = Err(e);
+        for lm in &layout.line_metrics {
+            let draw_line = self
+                .ctx
+                .fill_text(
+                    &layout.text[lm.start_offset..lm.end_offset],
+                    pos.x,
+                    pos.y + lm.cumulative_height - lm.height,
+                )
+                .wrap();
+
+            if let Err(e) = draw_line {
+                self.err = Err(e);
+            }
         }
     }
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -36,7 +36,7 @@ pub struct WebTextLayout {
     pub text: String,
 
     // Calculated on build
-    line_metrics: Vec<LineMetric>,
+    pub(crate) line_metrics: Vec<LineMetric>,
     width: f64,
 }
 


### PR DESCRIPTION
Whoops, `draw_text` was not implemented for web and cairo backends. This fixes that.

Should fix #169 