### PR TITLE
current_transform() for web backend

### DIFF
--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -15,14 +15,14 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 piet = { version = "0.0.12", path = "../piet" }
 unicode-segmentation = "1.6.0"
-wasm-bindgen = "0.2.59"
+wasm-bindgen = "0.2.60"
 js-sys = "0.3.36"
 xi-unicode = "0.2.0"
 
 [dependencies.web-sys]
 version = "0.3.36"
 features = ["Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
-    "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]
+    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
@@ -30,4 +30,4 @@ wasm-bindgen-test = "0.3.0"
 [dev-dependencies.web-sys]
 version = "0.3.36"
 features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
-    "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]
+    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -12,8 +12,8 @@ use std::ops::Deref;
 use js_sys::{Float64Array, Reflect};
 use wasm_bindgen::{Clamped, JsCast, JsValue};
 use web_sys::{
-    CanvasGradient, CanvasRenderingContext2d, CanvasWindingRule, HtmlCanvasElement, ImageData,
-    Window,
+    CanvasGradient, CanvasRenderingContext2d, CanvasWindingRule, DomMatrix, HtmlCanvasElement,
+    ImageData, Window,
 };
 
 use piet::kurbo::{Affine, PathEl, Point, Rect, Shape};
@@ -236,10 +236,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     }
 
     fn current_transform(&self) -> Affine {
-        // todo
-        // current_transform() and get_transform() currently not implemented:
-        // https://github.com/rustwasm/wasm-bindgen/blob/f8354b3a88de013845a304ea77d8b9b9286a0d7b/crates/web-sys/webidls/enabled/CanvasRenderingContext2D.webidl#L136
-        Affine::default()
+        matrix_to_affine(self.ctx.get_transform().unwrap())
     }
 
     fn make_image(
@@ -491,4 +488,15 @@ impl WebRenderContext<'_> {
 
 fn byte_to_frac(byte: u32) -> f64 {
     ((byte & 255) as f64) * (1.0 / 255.0)
+}
+
+fn matrix_to_affine(matrix: DomMatrix) -> Affine {
+    Affine::new([
+        matrix.a(),
+        matrix.b(),
+        matrix.c(),
+        matrix.d(),
+        matrix.e(),
+        matrix.f(),
+    ])
 }


### PR DESCRIPTION
Follow-up to https://github.com/linebender/piet/pull/117

The newest version of `wasm-bindgen` now exposes `get_transform()`