### PR TITLE
Fix/text/hard soft break

### DIFF
--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -210,6 +210,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_hard_soft_break_end() {
         // This tests that the hard break is not handled before the soft break when the hard break
         // exceeds text layout width. In this case, it's the last line `best text!` which is too
@@ -219,6 +220,37 @@ mod test {
 
         let mut text = CairoText::new();
         let font = text.new_font_by_name("sans-serif", 12.0).build().unwrap();
+        let line_metrics = calculate_line_metrics(input, &font.0, width);
+
+        // Some print debugging, in case font size/width needs to be changed in future because of
+        // brittle tests
+        println!(
+            "{}: \"piet text \"",
+            font.0.text_extents("piet text ").x_advance
+        );
+        for lm in &line_metrics {
+            let line_text = &input[lm.start_offset..lm.end_offset];
+            println!(
+                "{}: {:?}",
+                font.0.text_extents(line_text).x_advance,
+                line_text
+            );
+        }
+
+        assert_eq!(line_metrics.len(), 5);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_hard_soft_break_end() {
+        // This tests that the hard break is not handled before the soft break when the hard break
+        // exceeds text layout width. In this case, it's the last line `best text!` which is too
+        // long. The line should be soft-broken at the space before the EOL breaks.
+        let input = "piet text is the best text!";
+        let width = 50.0;
+
+        let mut text = CairoText::new();
+        let font = text.new_font_by_name("sans-serif", 14.0).build().unwrap();
         let line_metrics = calculate_line_metrics(input, &font.0, width);
 
         // Some print debugging, in case font size/width needs to be changed in future because of

--- a/piet-web/src/text/lines.rs
+++ b/piet-web/src/text/lines.rs
@@ -117,6 +117,35 @@ pub(crate) fn calculate_line_metrics(
             }
         } else {
             // this section is for hard breaks
+
+            // even when there's a hard break, need to check first to see if width is too wide. If
+            // it is, need to break at the previous soft break first.
+            let curr_str = &text[line_start..line_break];
+            let curr_width = text_width(curr_str, ctx);
+
+            if curr_width > width {
+                // if line is too wide but can't break down anymore, just skip to the next
+                // add_line_metric. But here, since prev_break is not equal to line_start, that
+                // means there another break opportunity so take it.
+                //
+                // TODO consider refactoring to make more parallel with above soft break
+                // comparison.
+                if prev_break != line_start {
+                    add_line_metric(
+                        text,
+                        line_start,
+                        prev_break,
+                        baseline,
+                        height,
+                        &mut cumulative_height,
+                        &mut line_metrics,
+                    );
+
+                    line_start = prev_break;
+                }
+            }
+
+            // now do the hard break
             add_line_metric(
                 text,
                 line_start,


### PR DESCRIPTION
Had incorrectly handled hard breaks on cairo/web:

at a hard break, when a preceding soft break should be a line break, the hard break incorrectly took precedence.

Fixed this and added a test.

Also added another test to make sure that hard break correctly handles cases where the line is too long but can't be broken down further. (Basically makes sure that an extra "zero" line metric is not inserted)