### PR TITLE
Simplify piet Errors

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -14,8 +14,8 @@ use cairo::{BorrowError, Context, Filter, Format, ImageSurface, Matrix, Status, 
 use piet::kurbo::{Affine, PathEl, Point, QuadBez, Rect, Shape, Size};
 
 use piet::{
-    new_error, Color, Error, ErrorKind, FixedGradient, ImageFormat, InterpolationMode, IntoBrush,
-    LineCap, LineJoin, RenderContext, StrokeStyle,
+    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, LineCap, LineJoin,
+    RenderContext, StrokeStyle,
 };
 
 pub use crate::text::{
@@ -254,7 +254,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         let cairo_fmt = match format {
             ImageFormat::Rgb => Format::Rgb24,
             ImageFormat::RgbaSeparate | ImageFormat::RgbaPremul => Format::ARgb32,
-            _ => return Err(new_error(ErrorKind::NotSupported)),
+            _ => return Err(Error::NotSupported),
         };
         let mut image = ImageSurface::create(cairo_fmt, width as i32, height as i32).wrap()?;
         // Confident no borrow errors because we just created it.
@@ -298,7 +298,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                             data[dst_off + x * 4 + 3] = a;
                         }
                     }
-                    _ => return Err(new_error(ErrorKind::NotSupported)),
+                    _ => return Err(Error::NotSupported),
                 }
             }
         }

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -13,7 +13,7 @@ use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::Path;
 
-use piet::{ErrorKind, ImageFormat};
+use piet::ImageFormat;
 #[doc(hidden)]
 pub use piet_cairo::*;
 
@@ -105,7 +105,7 @@ impl<'a> BitmapTarget<'a> {
     pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         // TODO: convert other formats.
         if fmt != ImageFormat::RgbaPremul {
-            return Err(piet::new_error(ErrorKind::NotSupported));
+            return Err(piet::Error::NotSupported);
         }
         std::mem::drop(self.cr);
         self.surface.flush();
@@ -150,6 +150,6 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(piet::new_error(ErrorKind::MissingFeature))
+        Err(piet::Error::MissingFeature)
     }
 }

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 #[cfg(feature = "png")]
 use png::{ColorType, Encoder};
 
-use piet::{ErrorKind, ImageFormat};
+use piet::ImageFormat;
 use piet_direct2d::d2d::{Bitmap, Brush as D2DBrush};
 use piet_direct2d::d3d::{
     D3D11Device, D3D11DeviceContext, D3D11Texture2D, TextureMode, DXGI_MAP_READ,
@@ -159,7 +159,7 @@ impl<'a> BitmapTarget<'a> {
         self.context.end_draw()?;
         // TODO: convert other formats.
         if fmt != ImageFormat::RgbaPremul {
-            return Err(piet::new_error(ErrorKind::NotSupported));
+            return Err(piet::Error::NotSupported);
         }
         let temp_texture = self
             .d3d
@@ -211,7 +211,7 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(piet::new_error(ErrorKind::MissingFeature))
+        Err(piet::Error::MissingFeature)
     }
 }
 

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -1,9 +1,5 @@
 //! Support for piet Web back-end.
 
-use piet::{ErrorKind, ImageFormat};
-#[doc(hidden)]
-pub use piet_web::*;
-
 use std::fmt;
 use std::marker::PhantomData;
 use std::path::Path;
@@ -15,8 +11,11 @@ use std::io::BufWriter;
 
 #[cfg(feature = "png")]
 use png::{ColorType, Encoder};
-
 use wasm_bindgen::JsCast;
+
+use piet::ImageFormat;
+#[doc(hidden)]
+pub use piet_web::*;
 
 pub type Piet<'a> = WebRenderContext<'a>;
 
@@ -115,7 +114,7 @@ impl<'a> BitmapTarget<'a> {
         // this is used. It is here for compatibility with druid.
 
         if fmt != ImageFormat::RgbaPremul {
-            return Err(piet::new_error(ErrorKind::NotSupported));
+            return Err(piet::Error::NotSupported);
         }
 
         let width = self.canvas.width() as usize;
@@ -124,7 +123,7 @@ impl<'a> BitmapTarget<'a> {
         let img_data = self
             .context
             .get_image_data(0.0, 0.0, width as f64, height as f64)
-            .map_err(|jsv| piet::new_error(ErrorKind::BackendError(Box::new(JsError::new(jsv)))))?;
+            .map_err(|jsv| piet::Error::BackendError(Box::new(JsError::new(jsv))))?;
 
         // ImageDate is in RGBA order. This should be the same as expected on the output.
         Ok(img_data.data().0)
@@ -150,7 +149,7 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(piet::new_error(ErrorKind::MissingFeature))
+        Err(piet::Error::MissingFeature)
     }
 }
 

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -42,8 +42,6 @@ use winapi::um::d2d1effects::{CLSID_D2D1GaussianBlur, D2D1_GAUSSIANBLUR_PROP_STA
 use winapi::um::dcommon::{D2D1_ALPHA_MODE, D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_PIXEL_FORMAT};
 use winapi::Interface;
 
-use piet::{new_error, ErrorKind};
-
 use crate::dwrite::TextLayout;
 
 pub enum FillRule {
@@ -134,7 +132,7 @@ impl std::error::Error for Error {
 
 impl From<Error> for piet::Error {
     fn from(e: Error) -> piet::Error {
-        new_error(ErrorKind::BackendError(Box::new(e)))
+        piet::Error::BackendError(Box::new(e))
     }
 }
 

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -18,8 +18,6 @@ use winapi::Interface;
 use wio::com::ComPtr;
 use wio::wide::ToWide;
 
-use piet::{new_error, ErrorKind};
-
 // TODO: minimize cut'n'paste; probably the best way to do this is
 // unify with the crate error type
 pub enum Error {
@@ -84,7 +82,7 @@ impl std::error::Error for Error {
 
 impl From<Error> for piet::Error {
     fn from(e: Error) -> piet::Error {
-        new_error(ErrorKind::BackendError(Box::new(e)))
+        piet::Error::BackendError(Box::new(e))
     }
 }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -24,8 +24,8 @@ use winapi::um::dcommon::{D2D1_ALPHA_MODE_IGNORE, D2D1_ALPHA_MODE_PREMULTIPLIED}
 use piet::kurbo::{Affine, PathEl, Point, Rect, Shape};
 
 use piet::{
-    new_error, Color, Error, ErrorKind, FixedGradient, ImageFormat, InterpolationMode, IntoBrush,
-    RenderContext, StrokeStyle,
+    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, RenderContext,
+    StrokeStyle,
 };
 
 use crate::d2d::wrap_unit;
@@ -307,7 +307,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
 
     fn restore(&mut self) -> Result<(), Error> {
         if self.ctx_stack.len() <= 1 {
-            return Err(new_error(ErrorKind::StackUnbalance));
+            return Err(Error::StackUnbalance);
         }
         self.pop_state();
         // Move this code into impl to avoid duplication with transform?
@@ -321,7 +321,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     // to do other stuff, possibly related to incremental paint.
     fn finish(&mut self) -> Result<(), Error> {
         if self.ctx_stack.len() != 1 {
-            return Err(new_error(ErrorKind::StackUnbalance));
+            return Err(Error::StackUnbalance);
         }
         self.pop_state();
         std::mem::replace(&mut self.err, Ok(()))
@@ -349,7 +349,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         let alpha_mode = match format {
             ImageFormat::Rgb => D2D1_ALPHA_MODE_IGNORE,
             ImageFormat::RgbaPremul | ImageFormat::RgbaSeparate => D2D1_ALPHA_MODE_PREMULTIPLIED,
-            _ => return Err(new_error(ErrorKind::NotSupported)),
+            _ => return Err(Error::NotSupported),
         };
         let buf = match format {
             ImageFormat::Rgb => {
@@ -379,7 +379,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             }
             ImageFormat::RgbaPremul => Cow::from(buf),
             // This should be unreachable, we caught it above.
-            _ => return Err(new_error(ErrorKind::NotSupported)),
+            _ => return Err(Error::NotSupported),
         };
         let bitmap = self.rt.create_bitmap(width, height, &buf, alpha_mode)?;
         Ok(bitmap)

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -9,8 +9,8 @@ use std::{io, mem};
 
 use piet::kurbo::{Affine, Point, Rect, Shape};
 use piet::{
-    new_error, Color, Error, ErrorKind, FixedGradient, ImageFormat, InterpolationMode, IntoBrush,
-    LineCap, LineJoin, StrokeStyle,
+    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, LineCap, LineJoin,
+    StrokeStyle,
 };
 use svg::node::Node;
 
@@ -226,10 +226,7 @@ impl piet::RenderContext for RenderContext {
     }
 
     fn restore(&mut self) -> Result<()> {
-        self.state = self
-            .stack
-            .pop()
-            .ok_or_else(|| new_error(ErrorKind::StackUnbalance))?;
+        self.state = self.stack.pop().ok_or_else(|| Error::StackUnbalance)?;
         Ok(())
     }
 
@@ -252,7 +249,7 @@ impl piet::RenderContext for RenderContext {
         _buf: &[u8],
         _format: ImageFormat,
     ) -> Result<Self::Image> {
-        Err(new_error(ErrorKind::NotSupported))
+        Err(Error::NotSupported)
     }
 
     #[inline]

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -1,7 +1,7 @@
 //! Text functionality for Piet svg backend
 
 use piet::kurbo::Point;
-use piet::{new_error, Error, ErrorKind, HitTestPoint, HitTestTextPosition, LineMetric};
+use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -42,7 +42,7 @@ impl piet::FontBuilder for FontBuilder {
     type Out = Font;
 
     fn build(self) -> Result<Font> {
-        Err(new_error(ErrorKind::NotSupported))
+        Err(Error::NotSupported)
     }
 }
 
@@ -57,7 +57,7 @@ impl piet::TextLayoutBuilder for TextLayoutBuilder {
     type Out = TextLayout;
 
     fn build(self) -> Result<TextLayout> {
-        Err(new_error(ErrorKind::NotSupported))
+        Err(Error::NotSupported)
     }
 }
 

--- a/piet/src/error.rs
+++ b/piet/src/error.rs
@@ -4,35 +4,28 @@ use std::fmt;
 
 /// An error that can occur while rendering 2D graphics.
 #[derive(Debug)]
-pub struct Error(Box<ErrorKind>);
-
-#[derive(Debug)]
-pub enum ErrorKind {
+#[non_exhaustive]
+pub enum Error {
     InvalidInput,
     NotSupported,
     StackUnbalance,
     BackendError(Box<dyn std::error::Error>),
-    #[doc(hidden)]
-    _NonExhaustive,
     MissingFeature,
-}
-
-/// Create a new error of the given kind.
-pub fn new_error(kind: ErrorKind) -> Error {
-    Error(Box::new(kind))
+    MissingFont,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self.0 {
-            ErrorKind::InvalidInput => write!(f, "Invalid input"),
-            ErrorKind::NotSupported => write!(f, "Option not supported"),
-            ErrorKind::StackUnbalance => write!(f, "Stack unbalanced"),
-            ErrorKind::BackendError(ref e) => {
+        match self {
+            Error::InvalidInput => write!(f, "Invalid input"),
+            Error::NotSupported => write!(f, "Option not supported"),
+            Error::StackUnbalance => write!(f, "Stack unbalanced"),
+            Error::MissingFont => write!(f, "A font could not be found"),
+            Error::MissingFeature => write!(f, "A feature is not implemented on this backend"),
+            Error::BackendError(e) => {
                 write!(f, "Backend error: ")?;
                 e.fmt(f)
             }
-            _ => write!(f, "Unknown piet error (case not covered)"),
         }
     }
 }
@@ -41,6 +34,6 @@ impl std::error::Error for Error {}
 
 impl From<Box<dyn std::error::Error>> for Error {
     fn from(e: Box<dyn std::error::Error>) -> Error {
-        new_error(ErrorKind::BackendError(e))
+        Error::BackendError(e)
     }
 }


### PR DESCRIPTION
This removes ErrorKind and the new_error method; the Error type
can just be used directly when needed.

I was in this code to add a MissingFont error, and did a bit of cleanup.