### PR TITLE
Add 'samples' example to piet-common

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -22,6 +22,9 @@ piet-direct2d = { version = "0.0.13", path = "../piet-direct2d", optional = true
 piet-web = { version = "0.0.13", path = "../piet-web", optional = true }
 cairo-rs = { version = "0.8.1", default_features = false, optional = true}
 
+[dev-dependencies]
+piet = { version = "0.0.13", path = "../piet", features = ["samples"] }
+
 [target.'cfg(not(any(target_arch="wasm32", target_os="windows", target_os="macos")))'.dependencies]
 piet-cairo = { version = "0.0.13", path = "../piet-cairo" }
 cairo-rs = { version = "0.8.1", default_features = false}

--- a/piet-common/examples/sample.rs
+++ b/piet-common/examples/sample.rs
@@ -1,0 +1,37 @@
+//! Draw a sample image with this backend.
+
+// TODO: Remove all the wasm32 cfg guards once this compiles with piet-web
+//
+#[cfg(all(feature = "png", not(target_arch = "wasm32")))]
+fn main() {
+    use piet::RenderContext;
+    use piet_common::Device;
+
+    const WIDTH: usize = 400;
+    const HEIGHT: usize = 200;
+    const HIDPI: f64 = 2.0;
+
+    let test_picture_number = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(0);
+    let mut device = Device::new().unwrap();
+    let mut bitmap = device.bitmap_target(WIDTH, HEIGHT, HIDPI).unwrap();
+    let mut rc = bitmap.render_context();
+    piet::draw_test_picture(&mut rc, test_picture_number).unwrap();
+    rc.finish().unwrap();
+    std::mem::drop(rc);
+
+    let path = format!(
+        "{}-sample-{}.png",
+        piet_common::BACKEND_NAME,
+        test_picture_number
+    );
+
+    bitmap.save_to_file(&path).expect("file save error");
+}
+
+#[cfg(any(not(feature = "png"), target_arch = "wasm32"))]
+fn main() {
+    panic!("This example requires the 'png' feature, and does not run on wasm32")
+}

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -17,6 +17,9 @@ use piet::ImageFormat;
 #[doc(hidden)]
 pub use piet_cairo::*;
 
+/// A short human-readable name for this backend, for things like logging.
+pub const BACKEND_NAME: &str = "cairo";
+
 /// The `RenderContext` for the Cairo backend, which is selected.
 pub type Piet<'a> = CairoRenderContext<'a>;
 

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -16,6 +16,9 @@ use piet::{Error, ImageFormat};
 #[doc(hidden)]
 pub use piet_coregraphics::*;
 
+/// A short human-readable name for this backend, for things like logging.
+pub const BACKEND_NAME: &str = "coregraphics";
+
 /// The `RenderContext` for the CoreGraphics backend, which is selected.
 pub type Piet<'a> = CoreGraphicsContext<'a>;
 

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -18,6 +18,9 @@ use piet_direct2d::d3d::{
 #[doc(hidden)]
 pub use piet_direct2d::*;
 
+/// A short human-readable name for this backend, for things like logging.
+pub const BACKEND_NAME: &str = "direct2d";
+
 /// The `RenderContext` for the Direct2D backend, which is selected.
 pub type Piet<'a> = D2DRenderContext<'a>;
 

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -19,6 +19,9 @@ pub use piet_web::*;
 
 pub type Piet<'a> = WebRenderContext<'a>;
 
+/// A short human-readable name for this backend, for things like logging.
+pub const BACKEND_NAME: &str = "wasm";
+
 /// The associated brush type for this backend.
 ///
 /// This type matches `RenderContext::Brush`


### PR DESCRIPTION
This can be used to print one of the sample images using the active
backend.

Not sure how totally useful this is? But it's something I wanted when debugging the core-graphics backend.