### PR TITLE
Fixup sample_picture_0

### DIFF
--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -6,39 +6,37 @@ use crate::{
     TextLayoutBuilder,
 };
 
+const BLUE: Color = Color::rgb8(0x00, 0x00, 0x80);
+const GREEN: Color = Color::rgb8(0x00, 0x80, 0x00);
+const BLUE_ALPHA: Color = Color::rgba8(0x00, 0x00, 0x80, 0xC0);
+const RED_ALPHA: Color = Color::rgba8(0x80, 0x00, 0x00, 0xC0);
+const YELLOW_ALPHA: Color = Color::rgba8(0xCF, 0xCF, 0x00, 0x60);
+
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::WHITE);
-    let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
-    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
+    rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &BLUE, 1.0);
 
-    let mut path = BezPath::new();
-    path.move_to((50.0, 10.0));
-    path.quad_to((60.0, 50.0), (100.0, 90.0));
-    let brush = rc.solid_brush(Color::rgb8(0x00, 0x80, 0x00));
-    rc.stroke(path, &brush, 1.0);
+    let path = arc1();
+    rc.stroke(path, &GREEN, 1.0);
 
-    let mut path = BezPath::new();
-    path.move_to((10.0, 20.0));
-    path.curve_to((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
-    let brush = rc.solid_brush(Color::rgba8(0x00, 0x00, 0x80, 0xC0));
-    rc.fill(path, &brush);
+    let path = arc2();
+    rc.fill(path, &BLUE_ALPHA);
 
-    rc.stroke(RoundedRect::new(145.0, 45.0, 185.0, 85.0, 5.0), &brush, 1.0);
+    rc.stroke(
+        RoundedRect::new(145.0, 45.0, 185.0, 85.0, 5.0),
+        &BLUE_ALPHA,
+        1.0,
+    );
 
-    let font = rc.text().new_font_by_name("Segoe UI", 12.0).build()?;
-    let layout = rc
-        .text()
-        .new_text_layout(&font, "Hello piet!", None)
-        .build()?;
+    let layout = make_text(rc.text(), "Segoe UI", 12., "Hello piet!");
     let w: f64 = layout.width();
-    let brush = rc.solid_brush(Color::rgba8(0x80, 0x00, 0x00, 0xC0));
-    rc.draw_text(&layout, (80.0, 10.0), &brush);
+    rc.draw_text(&layout, (80.0, 10.0), &RED_ALPHA);
 
-    rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &brush, 1.0);
+    rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &RED_ALPHA, 1.0);
 
     rc.with_save(|rc| {
         rc.transform(Affine::rotate(0.1));
-        rc.draw_text(&layout, (80.0, 10.0), &brush);
+        rc.draw_text(&layout, (80.0, 10.0), &RED_ALPHA);
         Ok(())
     })?;
 
@@ -69,14 +67,32 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     );
 
     let clip_path = star(Point::new(90.0, 45.0), 10.0, 30.0, 24);
+    rc.fill(&clip_path, &YELLOW_ALPHA);
     rc.clip(clip_path);
-    let layout = rc
-        .text()
-        .new_text_layout(&font, "Clipped text", None)
-        .build()?;
-    rc.draw_text(&layout, (80.0, 50.0), &brush);
+
+    let layout = make_text(rc.text(), "Georgia", 8.0, "CLIPPED");
+    rc.draw_text(&layout, (80.0, 50.0), &RED_ALPHA);
 
     Ok(())
+}
+
+fn make_text<T: Text>(ctx: &mut T, font: &str, size: f64, text: &str) -> T::TextLayout {
+    let font = ctx.new_font_by_name(font, size).build().unwrap();
+    ctx.new_text_layout(&font, text, None).build().unwrap()
+}
+
+fn arc1() -> BezPath {
+    let mut path = BezPath::new();
+    path.move_to((50.0, 10.0));
+    path.quad_to((60.0, 50.0), (100.0, 90.0));
+    path
+}
+
+fn arc2() -> BezPath {
+    let mut path = BezPath::new();
+    path.move_to((10.0, 20.0));
+    path.curve_to((10.0, 80.0), (100.0, 80.0), (100.0, 60.0));
+    path
 }
 
 // Note: this could be a Shape.
@@ -101,11 +117,20 @@ fn star(center: Point, inner: f64, outer: f64, n: usize) -> BezPath {
 fn make_image_data(width: usize, height: usize) -> Vec<u8> {
     let mut result = vec![0; width * height * 4];
     for y in 0..height {
+        let in_top = (y / (height / 2)) == 0;
         for x in 0..width {
+            let in_left = (x / (width / 2)) == 0;
             let ix = (y * width + x) * 4;
-            result[ix + 0] = x as u8;
-            result[ix + 1] = y as u8;
-            result[ix + 2] = !(x as u8);
+            // I love branching,so sue me
+            let (r, g, b) = match (in_top, in_left) {
+                (true, true) => (0xff, 0x00, 0x00),
+                (true, false) => (0x00, 0xff, 0x00),
+                (false, true) => (0x00, 0x00, 0xff),
+                (false, false) => (0x00, 0x00, 0x00),
+            };
+            result[ix + 0] = r;
+            result[ix + 1] = g;
+            result[ix + 2] = b;
             result[ix + 3] = 127;
         }
     }


### PR DESCRIPTION
This does some cleanup, and a few tweaks:
- we now draw the area that is used for clipping
- the image is simpler, to make it easier to distinguish whether
it is oriented correctly


before:
![temp-cairo](https://user-images.githubusercontent.com/3330916/81488022-b0791700-9231-11ea-96e6-2b9db9660a9a.png)
after:

![new-cairo](https://user-images.githubusercontent.com/3330916/81488021-af47ea00-9231-11ea-88eb-25482e2d3c36.png)

