### PR TITLE
[cg] Fix image drawing

### DIFF
--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -312,11 +312,14 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
     ) {
         // TODO: apply interpolation mode
         self.ctx.save();
-        let rect = to_cgrect(rect);
-        // CGImage is drawn flipped by default
-        self.ctx.translate(0., rect.size.height);
+        let rect = rect.into();
+        // CGImage is drawn flipped by default; it's easier for us to handle
+        // this transformation if we're drawing into a rect at the origin, so
+        // we convert our origin into a translation of the drawing context.
+        self.ctx.translate(rect.min_x(), rect.max_y());
         self.ctx.scale(1.0, -1.0);
-        self.ctx.draw_image(rect, image);
+        self.ctx
+            .draw_image(to_cgrect(rect.with_origin(Point::ZERO)), image);
         self.ctx.restore();
     }
 


### PR DESCRIPTION
Images were not drawing correctly if the rect they were drawn into
was not at the origin.

This is related to coregraphics coordinate space wonkiness; the
easiest solution I see is to transform the context and then draw
the image at the origin, instead of bothering with correctly
transforming the rect.

This wasn't an issue in druid, which always draws images at the origin of the image widget; it was a problem when using piet directly, though.