### PR TITLE
Clean up workspace compilation and testing.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install cairo
-        run: brew install cairo
-        if: contains(matrix.os, 'mac')
-
       - name: install libgtk-dev
         run: |
           sudo apt update
@@ -55,47 +51,85 @@ jobs:
           profile: minimal
           override: true
 
-      - name: cargo clippy (windows)
+      # Clippy packages in deeper-to-higher dependency order
+      - name: cargo clippy piet
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets --exclude piet-cairo --exclude piet-coregraphics -- -D warnings
-        if: contains(matrix.os, 'windows')
+          args: --manifest-path=piet/Cargo.toml --all-targets --all-features -- -D warnings
 
-      - name: cargo clippy (mac)
+      - name: cargo clippy piet-cairo
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets --exclude piet-direct2d -- -D warnings
-        if: contains(matrix.os, 'macOS')
-
-      - name: cargo clippy (linux)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets --exclude piet-direct2d --exclude piet-coregraphics -- -D warnings
+          args: --manifest-path=piet-cairo/Cargo.toml --all-targets --all-features -- -D warnings
         if: contains(matrix.os, 'ubuntu')
 
-      - name: cargo test (windows)
+      - name: cargo clippy piet-coregraphics
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --workspace --exclude piet-cairo --exclude piet-coregraphics
-        if: contains(matrix.os, 'windows')
-
-      - name: cargo test (mac)
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --exclude piet-direct2d
+          command: clippy
+          args: --manifest-path=piet-coregraphics/Cargo.toml --all-targets --all-features -- -D warnings
         if: contains(matrix.os, 'macOS')
 
-      - name: cargo test (linux)
+      - name: cargo clippy piet-direct2d
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=piet-direct2d/Cargo.toml --all-targets --all-features -- -D warnings
+        if: contains(matrix.os, 'windows')
+
+      - name: cargo clippy piet-svg
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=piet-svg/Cargo.toml --all-targets --all-features -- -D warnings
+
+      - name: cargo clippy piet-common
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=piet-common/Cargo.toml --all-targets --features=png -- -D warnings
+
+      # Test packages in deeper-to-higher dependency order
+      - name: cargo test piet
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude piet-direct2d --exclude piet-coregraphics
+          args: --manifest-path=piet/Cargo.toml --all-features
+
+      - name: cargo test piet-cairo
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-cairo/Cargo.toml --all-features
         if: contains(matrix.os, 'ubuntu')
+
+      - name: cargo test piet-coregraphics
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-coregraphics/Cargo.toml --all-features
+        if: contains(matrix.os, 'macOS')
+
+      - name: cargo test piet-direct2d
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-direct2d/Cargo.toml --all-features
+        if: contains(matrix.os, 'windows')
+
+      - name: cargo test piet-svg
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-svg/Cargo.toml --all-features
+
+      - name: cargo test piet-common
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-common/Cargo.toml --features=png
 
   test-stable-wasm:
     runs-on: ${{ matrix.os }}
@@ -115,17 +149,44 @@ jobs:
           profile: minimal
           override: true
 
-      - name: cargo clippy
+      # Clippy packages in deeper-to-higher dependency order
+      - name: cargo clippy piet
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets --exclude piet-cairo --exclude piet-direct2d --exclude piet-coregraphics --target wasm32-unknown-unknown -- -D warnings
+          args: --manifest-path=piet/Cargo.toml --all-targets --all-features --target wasm32-unknown-unknown -- -D warnings
 
-      - name: cargo test compile
+      - name: cargo clippy piet-web
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=piet-web/Cargo.toml --all-targets --all-features --target wasm32-unknown-unknown -- -D warnings
+
+      - name: cargo clippy piet-common
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --manifest-path=piet-common/Cargo.toml --all-targets --features=png --target wasm32-unknown-unknown -- -D warnings
+
+      # Test packages in deeper-to-higher dependency order
+      # TODO: Find a way to make tests work. Until then the tests are merely compiled.
+      - name: cargo test piet
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude piet-cairo --exclude piet-direct2d --exclude piet-coregraphics --no-run --target wasm32-unknown-unknown
+          args: --manifest-path=piet/Cargo.toml --all-features --no-run --target wasm32-unknown-unknown
+
+      - name: cargo test piet-web
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-web/Cargo.toml --all-features --no-run --target wasm32-unknown-unknown
+
+      - name: cargo test piet-common
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-common/Cargo.toml --features=png --no-run --target wasm32-unknown-unknown
 
   test-nightly:
     runs-on: ${{ matrix.os }}
@@ -136,10 +197,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install cairo
-        run: brew install cairo
-        if: contains(matrix.os, 'mac')
-
       - name: install libgtk-dev
         run: |
           sudo apt update
@@ -153,26 +210,45 @@ jobs:
           profile: minimal
           override: true
 
-      - name: cargo test (windows)
+      # Test packages in deeper-to-higher dependency order
+      - name: cargo test piet
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude piet-cairo --exclude piet-coregraphics
-        if: contains(matrix.os, 'windows')
+          args: --manifest-path=piet/Cargo.toml --all-features
 
-      - name: cargo test (mac)
+      - name: cargo test piet-cairo
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude piet-direct2d
+          args: --manifest-path=piet-cairo/Cargo.toml --all-features
+        if: contains(matrix.os, 'ubuntu')
+
+      - name: cargo test piet-coregraphics
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-coregraphics/Cargo.toml --all-features
         if: contains(matrix.os, 'macOS')
 
-      - name: cargo test (linux)
+      - name: cargo test piet-direct2d
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --exclude piet-direct2d --exclude piet-coregraphics
-        if: contains(matrix.os, 'ubuntu')
+          args: --manifest-path=piet-direct2d/Cargo.toml --all-features
+        if: contains(matrix.os, 'windows')
+
+      - name: cargo test piet-svg
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-svg/Cargo.toml --all-features
+
+      - name: cargo test piet-common
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --manifest-path=piet-common/Cargo.toml --features=png
 
   check-docs:
     name: Docs
@@ -183,10 +259,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install cairo
-        run: brew install cairo
-        if: contains(matrix.os, 'mac')
-
       - name: install libgtk-dev
         run: |
           sudo apt update
@@ -197,11 +269,52 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
+          target: wasm32-unknown-unknown
           profile: minimal
           override: true
 
-      - name: check docs in piet/
+      # Doc packages in deeper-to-higher dependency order
+      - name: cargo doc piet
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: --document-private-items
+          args: --manifest-path=piet/Cargo.toml --all-features --document-private-items
+
+      - name: cargo doc piet-cairo
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=piet-cairo/Cargo.toml --all-features --document-private-items
+        if: contains(matrix.os, 'ubuntu')
+
+      - name: cargo doc piet-coregraphics
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=piet-coregraphics/Cargo.toml --all-features --document-private-items
+        if: contains(matrix.os, 'macOS')
+
+      - name: cargo doc piet-direct2d
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=piet-direct2d/Cargo.toml --all-features --document-private-items
+        if: contains(matrix.os, 'windows')
+
+      - name: cargo doc piet-svg
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=piet-svg/Cargo.toml --all-features --document-private-items
+
+      - name: cargo doc piet-common
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=piet-common/Cargo.toml --features=png --document-private-items
+
+      - name: cargo doc piet-web
+        uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --manifest-path=piet-web/Cargo.toml --all-features --document-private-items --target wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -5,26 +5,36 @@
 
 This repo holds an API for 2D graphics drawing.
 
-The motivation for this crate is set forth in this [blog post]. Ideally it will become a layer to help [druid] become cross-platform.
+The motivation for this crate is set forth in this [blog post].
+Ideally it will become a layer to help [druid] become cross-platform.
 
-This repo is structured as a core API crate, "piet" and a separate crate for each back-end. One motivation for this structure is that additional back-ends can be written without coupling to the main crate, and clients can opt in to the back-ends they need. In addition, it's possible use multiple back-ends, which will likely be useful for testing.
+This repo is structured as a core API crate, "piet" and a separate crate for each back-end.
+One motivation for this structure is that additional back-ends can be written without coupling
+to the main crate, and clients can opt in to the back-ends they need. In addition,
+it's possible use multiple back-ends, which will likely be useful for testing.
 
 A companion for Bézier path representation and geometry is [kurbo].
 
 ## Backends
 
 #### `piet-cairo` [![crates.io](https://img.shields.io/crates/v/piet-cairo)](https://crates.io/crates/piet-cairo)
-The piet-cairo crate depends on the cairo library, found at
-https://www.cairographics.org/download/.  A simple test of the cairo
+
+The `piet-cairo` crate depends on the cairo library, found at
+https://www.cairographics.org/download/. A simple test of the cairo
 backend is to run `cargo run --example basic-cairo`, which should
-produce an image file called "temp-cairo.png".
+produce an image file called `temp-cairo.png`.
+
+#### `piet-coregraphics` [![crates.io](https://img.shields.io/crates/v/piet-coregraphics)](https://crates.io/crates/piet-coregraphics)
+
+The `piet-coregraphics` crate works on macOS only. A simple test of the coregraphics
+backend is to run `cargo run --example test-picture`, which should
+produce an image file called `coregraphics-test-0.png`.
 
 #### `piet-direct2d` [![crates.io](https://img.shields.io/crates/v/piet-direct2d)](https://crates.io/crates/piet-direct2d)
 
-The piet-direct2d create works on Windows only.  Build with `cargo
-build --all` to include it.  A simple test of the direct2d backend is
-to run `cargo run --example basic`, which should produce an image
-called "temp-image.png".
+The `piet-direct2d` create works on Windows only. A simple test of the direct2d
+backend is to run `cargo run --example basic`, which should
+produce an image called `temp-image.png`.
 
 #### `piet-svg` [![crates.io](https://img.shields.io/crates/v/piet-svg)](https://crates.io/crates/piet-svg)
 #### `piet-web` [![crates.io](https://img.shields.io/crates/v/piet-web)](https://crates.io/crates/piet-web)

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -11,18 +11,12 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "0.1.0", path = "../piet" }
+
+cairo-rs = { version = "0.8.1", default-features = false } # We don't need glib
 unicode-segmentation = "1.3.0"
 xi-unicode = "0.2.0"
-
-[dependencies.cairo-rs]
-version = "0.8.1"
-# We don't need glib
-default-features = false
 
 [dev-dependencies]
 piet = { version = "0.1.0", path = "../piet", features = ["samples"] }
 
-[dev-dependencies.cairo-rs]
-version = "0.8.1"
-features = ["png"]
-default-features = false
+cairo-rs = { version = "0.8.1", default-features = false, features = ["png"] }

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -14,23 +14,23 @@ cairo = ["piet-cairo", "cairo-rs"]
 web = ["piet-web"]
 
 [dependencies]
-cfg-if = "0.1.10"
 piet = { version = "0.1.0", path = "../piet" }
 piet-cairo = { version = "0.1.0", path = "../piet-cairo", optional = true }
 piet-coregraphics = { version = "0.1.0", path = "../piet-coregraphics", optional = true }
 piet-direct2d = { version = "0.1.0", path = "../piet-direct2d", optional = true }
 piet-web = { version = "0.1.0", path = "../piet-web", optional = true }
-cairo-rs = { version = "0.8.1", default_features = false, optional = true}
 
-[target.'cfg(not(any(target_arch="wasm32", target_os="windows", target_os="macos")))'.dependencies]
+cfg-if = "0.1.10"
+cairo-rs = { version = "0.8.1", default_features = false, optional = true }
+png = { version = "0.16.1", optional = true }
+
+[target.'cfg(target_os="linux")'.dependencies]
 piet-cairo = { version = "0.1.0", path = "../piet-cairo" }
 cairo-rs = { version = "0.8.1", default_features = false}
-png = { version = "0.16.1", optional = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 piet-coregraphics = { version = "0.1.0", path = "../piet-coregraphics" }
 core-graphics = { version = "0.19" }
-png = { version = "0.16.1", optional = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 piet-direct2d = { version = "0.1.0", path = "../piet-direct2d" }
@@ -38,10 +38,12 @@ direct2d = "0.2.0"
 directwrite = "0.1.4"
 dxgi = "0.1.7"
 direct3d11 = "0.1.7"
-png = { version = "0.16.1", optional = true }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 piet-web = { version = "0.1.0", path = "../piet-web" }
-web-sys = { version = "0.3.36", features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule", "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"] }
 wasm-bindgen = "0.2.59"
-png = { version = "0.16.1", optional = true }
+
+[target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
+version = "0.3.36"
+features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
+            "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -136,14 +136,14 @@ impl<'a> BitmapTarget<'a> {
         let height = self.surface.get_height();
         let width = self.surface.get_width();
         let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
-        let file = BufWriter::new(File::create(path).map_err(|e| Into::<Box<_>>::into(e))?);
+        let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);
         encoder
             .write_header()
-            .map_err(|e| Into::<Box<_>>::into(e))?
+            .map_err(Into::<Box<_>>::into)?
             .write_image_data(&image)
-            .map_err(|e| Into::<Box<_>>::into(e))?;
+            .map_err(Into::<Box<_>>::into)?;
         Ok(())
     }
 

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -141,15 +141,15 @@ impl<'a> BitmapTarget<'a> {
         let height = self.ctx.height() as usize;
         let mut data = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
         piet_coregraphics::unpremultiply_rgba(&mut data);
-        let file = BufWriter::new(File::create(path).map_err(|e| Into::<Box<_>>::into(e))?);
+        let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);
         encoder.set_depth(png::BitDepth::Eight);
         encoder
             .write_header()
-            .map_err(|e| Into::<Box<_>>::into(e))?
+            .map_err(Into::<Box<_>>::into)?
             .write_image_data(&data)
-            .map_err(|e| Into::<Box<_>>::into(e))?;
+            .map_err(Into::<Box<_>>::into)?;
         Ok(())
     }
 

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -197,14 +197,14 @@ impl<'a> BitmapTarget<'a> {
         let height = self.height;
         let width = self.width;
         let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
-        let file = BufWriter::new(File::create(path).map_err(|e| Into::<Box<_>>::into(e))?);
+        let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);
         encoder
             .write_header()
-            .map_err(|e| Into::<Box<_>>::into(e))?
+            .map_err(Into::<Box<_>>::into)?
             .write_image_data(&image)
-            .map_err(|e| Into::<Box<_>>::into(e))?;
+            .map_err(Into::<Box<_>>::into)?;
         Ok(())
     }
 

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -135,14 +135,14 @@ impl<'a> BitmapTarget<'a> {
         let height = self.canvas.height();
         let width = self.canvas.width();
         let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
-        let file = BufWriter::new(File::create(path).map_err(|e| Into::<Box<_>>::into(e))?);
+        let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);
         encoder
             .write_header()
-            .map_err(|e| Into::<Box<_>>::into(e))?
+            .map_err(Into::<Box<_>>::into)?
             .write_image_data(&image)
-            .map_err(|e| Into::<Box<_>>::into(e))?;
+            .map_err(Into::<Box<_>>::into)?;
         Ok(())
     }
 

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -10,11 +10,13 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "0.1.0", path = "../piet" }
+
 core-graphics = "0.19"
 core-text = "15.0"
 core-foundation = "0.7"
 core-foundation-sys = "0.7"
 
 [dev-dependencies]
-png = "0.16.2"
 piet = { version = "0.1.0", path = "../piet", features = ["samples"] }
+
+png = "0.16.2"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -11,12 +11,14 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "0.1.0", path = "../piet" }
+
 wio = "0.2.2"
 
 [dependencies.winapi]
 version = "0.3.8"
-features = [ "d2d1", "d2d1_1", "d2d1effects", "d3d11", "dxgi" ]
+features = ["d2d1", "d2d1_1", "d2d1effects", "d3d11", "dxgi"]
 
 [dev-dependencies]
 piet = { version = "0.1.0", path = "../piet", features = ["samples"] }
+
 image = "0.23.2"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "0.1.0", path = "../piet" }
+
 svg = "0.8.0"
 
 [dev-dependencies]

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -14,15 +14,17 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 piet = { version = "0.1.0", path = "../piet" }
+
 unicode-segmentation = "1.6.0"
+xi-unicode = "0.2.0"
 wasm-bindgen = "0.2.60"
 js-sys = "0.3.36"
-xi-unicode = "0.2.0"
 
 [dependencies.web-sys]
 version = "0.3.36"
 features = ["Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
-    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]
+            "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap",
+            "ImageData", "TextMetrics"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"
@@ -30,4 +32,5 @@ wasm-bindgen-test = "0.3.0"
 [dev-dependencies.web-sys]
 version = "0.3.36"
 features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
-    "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]
+            "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData",
+            "TextMetrics"]


### PR DESCRIPTION
This PR refactors the CI script to allow for easier expansion and testing of features. The cargo manifest files are cleaned up a bit and unified in style. I also updated `README.md` to better reflect the current state of things.

Fixes  #192.