### PR TITLE
Clean up dependencies

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -34,10 +34,6 @@ core-graphics = { version = "0.19" }
 
 [target.'cfg(target_os="windows")'.dependencies]
 piet-direct2d = { version = "0.1.0", path = "../piet-direct2d" }
-direct2d = "0.2.0"
-directwrite = "0.1.4"
-dxgi = "0.1.7"
-direct3d11 = "0.1.7"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 piet-web = { version = "0.1.0", path = "../piet-web" }


### PR DESCRIPTION
We don't need the direct2d and related crates, as we're calling winapi directly.