### PR TITLE
Do doc tests with the stable compiler.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,10 +265,10 @@ jobs:
           sudo apt install libgtk-3-dev
         if: contains(matrix.os, 'ubuntu')
 
-      - name: install nightly toolchain
+      - name: install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           target: wasm32-unknown-unknown
           profile: minimal
           override: true


### PR DESCRIPTION
The doc tests are marked as required, so they should be done with the stable compiler instead.