### PR TITLE
WebRender clear uses canvas pixel dimensions instead of DOM layout di…

### DIFF
--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -115,7 +115,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
 
     fn clear(&mut self, color: Color) {
         let (width, height) = match self.ctx.canvas() {
-            Some(canvas) => (canvas.offset_width(), canvas.offset_height()),
+            Some(canvas) => (canvas.width(), canvas.height()),
             None => return,
             /* Canvas might be null if the dom node is not in
              * the document; do nothing. */


### PR DESCRIPTION
On a display with device pixel density > 2, the offset dimensions for a 1024x1024 pixel canvas element with layout dimensions 512x512 will be 512x512, meaning context.clear() would only clear the top left quadrant.

this just uses the width/height properties instead of offset_width/offset_height.