### PR TITLE
Make `Text` trait require `Clone` and implement for all backends

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -22,6 +22,7 @@ use self::grapheme::{get_grapheme_boundaries, point_x_in_grapheme};
 /// access to system font information as a global. This will change.
 // we use a phantom lifetime here to match the API of the d2d backend,
 // and the likely API of something with access to system font information.
+#[derive(Clone)]
 pub struct CairoText<'a>(PhantomData<&'a ()>);
 
 pub struct CairoFont(ScaledFont);

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -27,7 +27,7 @@ pub type Brush = piet_web::Brush;
 /// The associated text factory for this backend.
 ///
 /// This type matches `RenderContext::Text`
-pub type PietText<'a> = WebRenderContext<'a>;
+pub type PietText<'a> = WebText<'a>;
 
 /// The associated font type for this backend.
 ///

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -39,6 +39,7 @@ pub struct CoreGraphicsTextLayout {
 
 pub struct CoreGraphicsTextLayoutBuilder(CoreGraphicsTextLayout);
 
+#[derive(Clone)]
 pub struct CoreGraphicsText<'a>(PhantomData<&'a ()>);
 
 impl<'a> CoreGraphicsText<'a> {

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -18,6 +18,7 @@ use self::lines::fetch_line_metrics;
 use crate::d2d;
 use crate::dwrite::{self, TextFormat, TextFormatBuilder};
 
+#[derive(Clone)]
 pub struct D2DText<'a> {
     dwrite: &'a DwriteFactory,
 }

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -6,6 +6,7 @@ use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric};
 type Result<T> = std::result::Result<T, Error>;
 
 /// SVG text (unimplemented)
+#[derive(Clone)]
 pub struct Text(());
 
 impl Text {

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -29,6 +29,7 @@ pub struct WebRenderContext<'a> {
     ctx: CanvasRenderingContext2d,
     /// Used for creating image bitmaps and possibly other resources.
     window: Window,
+    text: WebText<'a>,
     err: Result<(), Error>,
     phantom: std::marker::PhantomData<&'a ()>,
 }
@@ -36,9 +37,25 @@ pub struct WebRenderContext<'a> {
 impl<'a> WebRenderContext<'a> {
     pub fn new(ctx: CanvasRenderingContext2d, window: Window) -> WebRenderContext<'a> {
         WebRenderContext {
-            ctx,
+            ctx: ctx.clone(),
             window,
+            text: WebText::new(ctx),
             err: Ok(()),
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct WebText<'a> {
+    ctx: CanvasRenderingContext2d,
+    phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> WebText<'a> {
+    pub fn new(ctx: CanvasRenderingContext2d) -> WebText<'a> {
+        WebText {
+            ctx,
             phantom: std::marker::PhantomData,
         }
     }
@@ -104,7 +121,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     /// wasm-bindgen doesn't have a native Point type, so use kurbo's.
     type Brush = Brush;
 
-    type Text = Self;
+    type Text = WebText<'a>;
     type TextLayout = WebTextLayout;
 
     type Image = WebImage;
@@ -197,7 +214,7 @@ impl<'a> RenderContext for WebRenderContext<'a> {
     }
 
     fn text(&mut self) -> &mut Self::Text {
-        self
+        &mut self.text
     }
 
     fn draw_text(

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -16,7 +16,7 @@ use piet::{
 use unicode_segmentation::UnicodeSegmentation;
 
 use self::grapheme::{get_grapheme_boundaries, point_x_in_grapheme};
-use crate::WebRenderContext;
+use crate::WebText;
 
 #[derive(Clone)]
 pub struct WebFont {
@@ -56,7 +56,7 @@ enum FontStyle {
     Oblique(Option<f64>),
 }
 
-impl<'a> Text for WebRenderContext<'a> {
+impl<'a> Text for WebText<'a> {
     type Font = WebFont;
     type FontBuilder = WebFontBuilder;
     type TextLayout = WebTextLayout;
@@ -449,9 +449,8 @@ pub(crate) mod test {
 
     #[wasm_bindgen_test]
     pub fn test_hit_test_text_position_basic() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         let input = "piet text!";
         let font = text_layout
@@ -542,9 +541,8 @@ pub(crate) mod test {
 
     #[wasm_bindgen_test]
     pub fn test_hit_test_text_position_complex_0() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         let input = "é";
         assert_eq!(input.len(), 2);
@@ -624,9 +622,8 @@ pub(crate) mod test {
 
     #[wasm_bindgen_test]
     pub fn test_hit_test_text_position_complex_1() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         // Notes on this input:
         // 6 code points
@@ -723,9 +720,8 @@ pub(crate) mod test {
     // NOTE brittle test
     #[wasm_bindgen_test]
     pub fn test_hit_test_point_basic_0() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         let font = text_layout
             .new_font_by_name("sans-serif", 16.0)
@@ -772,9 +768,8 @@ pub(crate) mod test {
     // NOTE brittle test
     #[wasm_bindgen_test]
     pub fn test_hit_test_point_basic_1() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         // base condition, one grapheme
         let font = text_layout
@@ -811,9 +806,8 @@ pub(crate) mod test {
     // NOTE brittle test
     #[wasm_bindgen_test]
     pub fn test_hit_test_point_complex_0() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         // Notes on this input:
         // 6 code points
@@ -866,9 +860,8 @@ pub(crate) mod test {
     // NOTE brittle test
     #[wasm_bindgen_test]
     pub fn test_hit_test_point_complex_1() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         // this input caused an infinite loop in the binary search when test position
         // > 21.0 && < 28.0
@@ -900,9 +893,8 @@ pub(crate) mod test {
 
     #[wasm_bindgen_test]
     fn test_multiline_hit_test_text_position_basic() {
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text_layout = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text_layout = WebText::new(context);
 
         let input = "piet  text!";
         let font = text_layout
@@ -1059,9 +1051,8 @@ pub(crate) mod test {
     fn test_multiline_hit_test_point_basic() {
         let input = "piet text most best";
 
-        let (window, context) = setup_ctx();
-        let ctx = WebRenderContext::new(context, window);
-        let mut text = ctx;
+        let (_window, context) = setup_ctx();
+        let mut text = WebText::new(context);
 
         let font = text.new_font_by_name("sans-serif", 14.0).build().unwrap();
         // this should break into four lines

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -23,6 +23,7 @@ pub struct NullBrush;
 #[doc(hidden)]
 pub struct NullImage;
 
+#[derive(Clone)]
 #[doc(hidden)]
 pub struct NullText;
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::Point;
 use crate::Error;
 
-pub trait Text {
+pub trait Text: Clone {
     type FontBuilder: FontBuilder<Out = Self::Font>;
     type Font: Font;
 


### PR DESCRIPTION
All implementations of `Text` should now be clonable thus clearing up the lifetime issues around threading as discussed on Zulip.

Required breaking `piet-web`'s `Text` implementation into it's own struct adjacent to its `RenderContext` struct. That is a breaking change which will require modification to druid's web shell. Once this seems to be passing CI (which I bet it will not initially pass) I will submit a hopefully minor druid PR to make the required changes.