### PR TITLE
For convenience, use a shared reference to the Cairo context

### DIFF
--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -19,9 +19,9 @@ fn main() {
 
     let surface = ImageSurface::create(Format::ARgb32, size.width as i32, size.height as i32)
         .expect("Can't create surface");
-    let mut cr = Context::new(&surface);
+    let cr = Context::new(&surface);
     cr.scale(HIDPI, HIDPI);
-    let mut piet_context = CairoRenderContext::new(&mut cr);
+    let mut piet_context = CairoRenderContext::new(&cr);
     draw_test_picture(&mut piet_context, test_picture_number).unwrap();
     piet_context.finish().unwrap();
     surface.flush();

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -23,7 +23,7 @@ pub use crate::text::{
 pub struct CairoRenderContext<'a> {
     // Cairo has this as Clone and with &self methods, but we do this to avoid
     // concurrency problems.
-    ctx: &'a mut Context,
+    ctx: &'a Context,
     text: CairoText,
     // because of the relationship between GTK and cairo (where GTK applies a transform
     // to adjust for menus and window borders) we cannot trust the transform returned
@@ -38,7 +38,7 @@ impl<'a> CairoRenderContext<'a> {
     /// At the moment, it uses the "toy text API" for text layout, but when
     /// we change to a more sophisticated text layout approach, we'll probably
     /// need a factory for that as an additional argument.
-    pub fn new(ctx: &mut Context) -> CairoRenderContext {
+    pub fn new(ctx: &Context) -> CairoRenderContext {
         CairoRenderContext {
             ctx,
             text: CairoText::new(),

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -106,7 +106,7 @@ impl<'a> BitmapTarget<'a> {
     /// Note: caller is responsible for calling `finish` on the render
     /// context at the end of rendering.
     pub fn render_context(&mut self) -> CairoRenderContext {
-        CairoRenderContext::new(&mut self.cr)
+        CairoRenderContext::new(&self.cr)
     }
 
     /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were


### PR DESCRIPTION
The reference kept by `CairoRenderContext` should be shared. The Cairo context is internally reference-counted and, as far as I can tell, thread-safe.

The fact that it now keeps an exclusive reference is an inconvenience in combination with GTK. The callback of the [`draw` signal](https://docs.rs/gtk/0.8.1/gtk/trait.WidgetExt.html#tymethod.connect_draw) is only provided a shared reference to a context which means that you have to clone it first.