### PR TITLE
Add a BitmapTarget::copy_raw_pixels function

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["graphics", "2d"]
 
 [features]
 d2d = ["piet-direct2d"]
-cairo = ["piet-cairo", "cairo-rs"]
+cairo = ["piet-cairo", "cairo-rs", "cairo-sys-rs"]
 web = ["piet-web"]
 
 [dependencies]
@@ -22,11 +22,13 @@ piet-web = { version = "0.1.0", path = "../piet-web", optional = true }
 
 cfg-if = "0.1.10"
 cairo-rs = { version = "0.8.1", default_features = false, optional = true }
+cairo-sys-rs = { version = "0.9.2", optional = true }
 png = { version = "0.16.1", optional = true }
 
 [target.'cfg(target_os="linux")'.dependencies]
 piet-cairo = { version = "0.1.0", path = "../piet-cairo" }
 cairo-rs = { version = "0.8.1", default_features = false}
+cairo-sys-rs = { version = "0.9.2" }
 
 [target.'cfg(target_os="macos")'.dependencies]
 piet-coregraphics = { version = "0.1.1", path = "../piet-coregraphics" }

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -135,6 +135,14 @@ impl<'a> BitmapTarget<'a> {
                 }
                 std::slice::from_raw_parts(data_ptr, height.saturating_sub(1) * stride + width * 4)
             };
+
+            // A sanity check for all the unsafe indexing that follows.
+            let src_off_max = (height - 1) * stride;
+            let dst_off_max = (height - 1) * width * 4;
+            let x_max = width - 1;
+            buf.get(dst_off_max + x_max * 4 + 3).unwrap();
+            data.get(src_off_max + x_max * 4 + 3).unwrap();
+
             for y in 0..height {
                 let src_off = y * stride;
                 let dst_off = y * width * 4;

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -127,6 +127,9 @@ impl<'a> BitmapTarget<'a> {
             // don't seem to think that's a problem, as long as we call flush (which we already
             // did), and promise not to mutate anything.
             // https://www.cairographics.org/manual/cairo-Image-Surfaces.html#cairo-image-surface-get-data
+            //
+            // TODO: we can simplify this once cairo makes a release containing
+            // https://github.com/gtk-rs/cairo/pull/330
             let data_len = height.saturating_sub(1) * stride + width * 4;
             let data = {
                 let data_ptr = cairo_sys::cairo_image_surface_get_data(self.surface.to_raw_none());

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -101,33 +101,60 @@ impl<'a> BitmapTarget<'a> {
         CairoRenderContext::new(&mut self.cr)
     }
 
-    /// Get raw RGBA pixels from the bitmap.
-    pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were
+    /// copied, returns the number of bytes written. If `buf` wasn't big enough, returns an error
+    /// and doesn't write anything.
+    pub fn copy_raw_pixels(
+        &mut self,
+        fmt: ImageFormat,
+        buf: &mut [u8],
+    ) -> Result<usize, piet::Error> {
         // TODO: convert other formats.
         if fmt != ImageFormat::RgbaPremul {
             return Err(piet::Error::NotSupported);
         }
-        std::mem::drop(self.cr);
         self.surface.flush();
         let stride = self.surface.get_stride() as usize;
         let width = self.surface.get_width() as usize;
         let height = self.surface.get_height() as usize;
-        let mut raw_data = vec![0; width * height * 4];
-        let buf = self
-            .surface
-            .get_data()
-            .map_err(Into::<Box<dyn std::error::Error>>::into)?;
-        for y in 0..height {
-            let src_off = y * stride;
-            let dst_off = y * width * 4;
-            for x in 0..width {
-                raw_data[dst_off + x * 4 + 0] = buf[src_off + x * 4 + 2];
-                raw_data[dst_off + x * 4 + 1] = buf[src_off + x * 4 + 1];
-                raw_data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
-                raw_data[dst_off + x * 4 + 3] = buf[src_off + x * 4 + 3];
-            }
+        let size = width * height * 4;
+        if buf.len() < size {
+            return Err(piet::Error::InvalidInput);
         }
-        Ok(raw_data)
+        unsafe {
+            // Cairo's rust wrapper has extra safety checks that we want to avoid: it won't let us
+            // get the data from an ImageSurface that's still referenced by a context. The C docs
+            // don't seem to think that's a problem, as long as we call flush (which we already
+            // did), and promise not to mutate anything.
+            let data = {
+                let data_ptr = cairo_sys::cairo_image_surface_get_data(self.surface.to_raw_none());
+                if data_ptr.is_null() {
+                    let err = cairo::BorrowError::from(cairo::Status::SurfaceFinished);
+                    return Err((Box::new(err) as Box<dyn std::error::Error>).into());
+                }
+                std::slice::from_raw_parts(data_ptr, size)
+            };
+            for y in 0..height {
+                let src_off = y * stride;
+                let dst_off = y * width * 4;
+                for x in 0..width {
+                    buf[dst_off + x * 4 + 0] = data[src_off + x * 4 + 2];
+                    buf[dst_off + x * 4 + 1] = data[src_off + x * 4 + 1];
+                    buf[dst_off + x * 4 + 2] = data[src_off + x * 4 + 0];
+                    buf[dst_off + x * 4 + 3] = data[src_off + x * 4 + 3];
+                }
+            }
+        };
+        Ok(size)
+    }
+
+    /// Get raw RGBA pixels from the bitmap.
+    pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+        let width = self.surface.get_width() as usize;
+        let height = self.surface.get_height() as usize;
+        let mut buf = vec![0; width * height * 4];
+        self.copy_raw_pixels(fmt, &mut buf)?;
+        Ok(buf)
     }
 
     /// Save bitmap to RGBA PNG file

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -159,7 +159,7 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    pub fn to_raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    pub fn raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         let width = self.surface.get_width() as usize;
         let height = self.surface.get_height() as usize;
         let mut buf = vec![0; width * height * 4];
@@ -168,17 +168,17 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
+    #[deprecated(since = "0.2.0", note = "use raw_pixels")]
     pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
-        self.to_raw_pixels(fmt)
+        self.raw_pixels(fmt)
     }
 
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
-    pub fn save_to_file<P: AsRef<Path>>(self, path: P) -> Result<(), piet::Error> {
+    pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
         let height = self.surface.get_height();
         let width = self.surface.get_width();
-        let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
+        let image = self.raw_pixels(ImageFormat::RgbaPremul)?;
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -137,7 +137,7 @@ impl<'a> BitmapTarget<'a> {
                     let err = cairo::BorrowError::from(cairo::Status::SurfaceFinished);
                     return Err((Box::new(err) as Box<dyn std::error::Error>).into());
                 }
-                std::slice::from_raw_parts(data_ptr, data_len);
+                std::slice::from_raw_parts(data_ptr, data_len)
             };
 
             // A sanity check for all the unsafe indexing that follows.

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -106,7 +106,13 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
+    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
     pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+        self.to_raw_pixels(fmt)
+    }
+
+    /// Get raw RGBA pixels from the bitmap.
+    pub fn to_raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         let width = self.ctx.width() as usize;
         let height = self.ctx.height() as usize;
         let mut buf = vec![0; width * height * 4];

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -106,13 +106,13 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
+    #[deprecated(since = "0.2.0", note = "use raw_pixels")]
     pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
-        self.to_raw_pixels(fmt)
+        self.raw_pixels(fmt)
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    pub fn to_raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    pub fn raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         let width = self.ctx.width() as usize;
         let height = self.ctx.height() as usize;
         let mut buf = vec![0; width * height * 4];
@@ -160,10 +160,10 @@ impl<'a> BitmapTarget<'a> {
 
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
-    pub fn save_to_file<P: AsRef<Path>>(self, path: P) -> Result<(), piet::Error> {
+    pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
         let width = self.ctx.width() as usize;
         let height = self.ctx.height() as usize;
-        let mut data = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
+        let mut data = self.raw_pixels(ImageFormat::RgbaPremul)?;
         piet_coregraphics::unpremultiply_rgba(&mut data);
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -155,13 +155,13 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
+    #[deprecated(since = "0.2.0", note = "use to__pixels")]
     pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
-        self.to_raw_pixels(fmt)
+        self.raw_pixels(fmt)
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    pub fn to_raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    pub fn raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         let mut buf = vec![0; self.width * self.height * 4];
         self.copy_raw_pixels(fmt, &mut buf)?;
         Ok(buf)
@@ -215,10 +215,10 @@ impl<'a> BitmapTarget<'a> {
 
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
-    pub fn save_to_file<P: AsRef<Path>>(self, path: P) -> Result<(), piet::Error> {
+    pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
         let height = self.height;
         let width = self.width;
-        let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
+        let image = self.raw_pixels(ImageFormat::RgbaPremul)?;
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);
@@ -257,13 +257,13 @@ mod tests {
     }
 
     #[test]
-    fn into_raw_pixels() {
+    fn raw_pixels() {
         let mut device = Device::new().unwrap();
         let mut target = device.bitmap_target(640, 480, 1.0).unwrap();
         let mut piet = target.render_context();
         piet.clip(Rect::ZERO);
         piet.finish().unwrap();
         std::mem::drop(piet);
-        target.into_raw_pixels(ImageFormat::RgbaPremul).unwrap();
+        target.raw_pixels(ImageFormat::RgbaPremul).unwrap();
     }
 }

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -155,7 +155,13 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
+    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
     pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+        self.to_raw_pixels(fmt)
+    }
+
+    /// Get raw RGBA pixels from the bitmap.
+    pub fn to_raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         let mut buf = vec![0; self.width * self.height * 4];
         self.copy_raw_pixels(fmt, &mut buf)?;
         Ok(buf)

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -108,7 +108,8 @@ impl<'a> BitmapTarget<'a> {
         WebRenderContext::new(self.context.clone(), web_sys::window().unwrap())
     }
 
-    fn raw_pixels(&self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    /// Get raw RGBA pixels from the bitmap.
+    fn to_raw_pixels(&self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         // TODO: This code is just a snippet. A thorough review and testing should be done before
         // this is used. It is here for compatibility with druid.
 
@@ -129,8 +130,9 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
+    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
     pub fn into_raw_pixels(self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
-        self.raw_pixels(fmt)
+        self.to_raw_pixels(fmt)
     }
 
     /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were
@@ -141,7 +143,7 @@ impl<'a> BitmapTarget<'a> {
         fmt: ImageFormat,
         buf: &mut [u8],
     ) -> Result<usize, piet::Error> {
-        let data = self.raw_pixels(fmt)?;
+        let data = self.to_raw_pixels(fmt)?;
         if data.len() > buf.len() {
             return Err(piet::Error::InvalidInput);
         }

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -109,7 +109,7 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    fn raw_pixels(&self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    fn raw_pixels(&mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         // TODO: This code is just a snippet. A thorough review and testing should be done before
         // this is used. It is here for compatibility with druid.
 
@@ -131,7 +131,7 @@ impl<'a> BitmapTarget<'a> {
 
     /// Get raw RGBA pixels from the bitmap.
     #[deprecated(since = "0.2.0", note = "use raw_pixels")]
-    pub fn into_raw_pixels(self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    pub fn into_raw_pixels(mut self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         self.raw_pixels(fmt)
     }
 

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -109,7 +109,7 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    fn to_raw_pixels(&self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
+    fn raw_pixels(&self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
         // TODO: This code is just a snippet. A thorough review and testing should be done before
         // this is used. It is here for compatibility with druid.
 
@@ -130,9 +130,9 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get raw RGBA pixels from the bitmap.
-    #[deprecated(since = "0.2.0", note = "use to_raw_pixels")]
+    #[deprecated(since = "0.2.0", note = "use raw_pixels")]
     pub fn into_raw_pixels(self, fmt: ImageFormat) -> Result<Vec<u8>, piet::Error> {
-        self.to_raw_pixels(fmt)
+        self.raw_pixels(fmt)
     }
 
     /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were
@@ -143,7 +143,7 @@ impl<'a> BitmapTarget<'a> {
         fmt: ImageFormat,
         buf: &mut [u8],
     ) -> Result<usize, piet::Error> {
-        let data = self.to_raw_pixels(fmt)?;
+        let data = self.raw_pixels(fmt)?;
         if data.len() > buf.len() {
             return Err(piet::Error::InvalidInput);
         }
@@ -153,10 +153,10 @@ impl<'a> BitmapTarget<'a> {
 
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
-    pub fn save_to_file<P: AsRef<Path>>(self, path: P) -> Result<(), piet::Error> {
+    pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
         let height = self.canvas.height();
         let width = self.canvas.width();
-        let image = self.into_raw_pixels(ImageFormat::RgbaPremul)?;
+        let image = self.raw_pixels(ImageFormat::RgbaPremul)?;
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::RGBA);


### PR DESCRIPTION
This adds the functions that I suggested in #212. There are two sad things about this PR that I couldn't figure out how to improve:

- on web, I couldn't find a way to access the borrowed pixels, so `copy_raw_pixels` has to copy them twice :|
- cairo-rs has some safety checks that made it a pain to get the data out without destroying the context first. I ended up needing to use unsafe.