### PR TITLE
Enable trivially_copy_pass_by_ref clippy lint.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+# The default clippy value for this is 8 bytes, which is chosen to improve performance on 32-bit.
+# Given that piet is being designed for the future and already even mobile phones have 64-bit CPUs,
+# it makes sense to optimize for 64-bit and accept the performance hits on 32-bit.
+# 16 bytes is the number of bytes that fits into two 64-bit CPU registers.
+trivial-copy-size-limit = 16

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -1,5 +1,7 @@
 //! The Cairo backend for the Piet 2D graphics abstraction.
 
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 mod text;
 
 use std::borrow::Cow;

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -203,7 +203,7 @@ impl TextLayout for CairoTextLayout {
         // Trailing whitespace is remove for the line
         let line = &self.text[lm.start_offset..lm.end_offset];
 
-        let mut htp = hit_test_line_point(&self.font, line, &point);
+        let mut htp = hit_test_line_point(&self.font, line, point);
         htp.metrics.text_position += lm.start_offset;
 
         if !is_y_inside {
@@ -253,7 +253,7 @@ impl TextLayout for CairoTextLayout {
 
 // NOTE this is the same as the old, non-line-aware version of hit_test_point
 // Future: instead of passing Font, should there be some other line-level text layout?
-fn hit_test_line_point(font: &ScaledFont, text: &str, point: &Point) -> HitTestPoint {
+fn hit_test_line_point(font: &ScaledFont, text: &str, point: Point) -> HitTestPoint {
     // null case
     if text.is_empty() {
         return HitTestPoint::default();

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -24,6 +24,8 @@
 //! [kurbo]: https://crates.io/crates/kurbo
 //! [piet-cairo]: https://crates.io/crates/piet-cairo
 
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 pub use piet::*;
 
 #[doc(hidden)]

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -1,5 +1,7 @@
 //! The CoreGraphics backend for the Piet 2D graphics abstraction.
 
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 mod ct_helpers;
 mod gradient;
 mod text;

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -453,6 +453,7 @@ impl DeviceContext {
         }
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(crate) fn create_linear_gradient(
         &mut self,
         props: &D2D1_LINEAR_GRADIENT_BRUSH_PROPERTIES,
@@ -541,6 +542,7 @@ impl DeviceContext {
         }
     }
 
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub(crate) fn draw_bitmap(
         &mut self,
         bitmap: &Bitmap,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg(windows)]
 // allows for nice formatting for e.g. new_buf[i * 4 + 0] = premul(buf[i * 4 + 0, a)
 #![allow(clippy::identity_op)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 //! The Direct2D backend for the Piet 2D graphics abstraction.
 

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Text and images are unimplemented and will always return errors.
 
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 mod text;
 
 use std::borrow::Cow;

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -1,5 +1,6 @@
 // allows e.g. raw_data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
 #![allow(clippy::identity_op)]
+#![deny(clippy::trivially_copy_pass_by_ref)]
 
 //! The Web Canvas backend for the Piet 2D graphics abstraction.
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -221,7 +221,7 @@ impl TextLayout for WebTextLayout {
         // Trailing whitespace is remove for the line
         let line = &self.text[lm.start_offset..lm.end_offset];
 
-        let mut htp = hit_test_line_point(&self.ctx, line, &point);
+        let mut htp = hit_test_line_point(&self.ctx, line, point);
         htp.metrics.text_position += lm.start_offset;
 
         if !is_y_inside {
@@ -271,7 +271,7 @@ impl TextLayout for WebTextLayout {
 
 // NOTE this is the same as the old, non-line-aware version of hit_test_point
 // Future: instead of passing ctx, should there be some other line-level text layout?
-fn hit_test_line_point(ctx: &CanvasRenderingContext2d, text: &str, point: &Point) -> HitTestPoint {
+fn hit_test_line_point(ctx: &CanvasRenderingContext2d, text: &str, point: Point) -> HitTestPoint {
     // null case
     if text.is_empty() {
         return HitTestPoint::default();

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -259,7 +259,7 @@ impl UnitPoint {
     }
 
     /// Given a rectangle, resolve the point within the rectangle.
-    pub fn resolve(&self, rect: Rect) -> Point {
+    pub fn resolve(self, rect: Rect) -> Point {
         Point::new(
             rect.x0 + self.u * (rect.x1 - rect.x0),
             rect.y0 + self.v * (rect.y1 - rect.y0),

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -1,5 +1,7 @@
 //! A 2D graphics abstraction.
 
+#![deny(clippy::trivially_copy_pass_by_ref)]
+
 pub use kurbo;
 
 /// utilities shared by various backends

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+max_width = 100
+use_field_init_shorthand = true
+newline_style = "Unix"


### PR DESCRIPTION
Rust 1.44 moved the `trivially_copy_pass_by_ref` clippy lint to pedantic. As discussed on [zulip](https://xi.zulipchat.com/#narrow/stream/147926-druid/topic/Scale.20clippy.20fail) let's turn it back on, at least for now.