### PR TITLE
Make Device Send and !Sync on all backends.

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -45,3 +45,6 @@ wasm-bindgen = "0.2.59"
 version = "0.3.36"
 features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData", "TextMetrics"]
+
+[dev-dependencies]
+static_assertions = "1.1.0"

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -58,7 +58,13 @@ pub type Image = ImageSurface;
 /// A struct that can be used to create bitmap render contexts.
 ///
 /// In the case of Cairo, being a software renderer, no state is needed.
-pub struct Device;
+pub struct Device {
+    // Since not all backends can support `Device: Sync`, make it non-Sync here to, for fewer
+    // portability surprises.
+    marker: std::marker::PhantomData<*const ()>,
+}
+
+unsafe impl Send for Device {}
 
 /// A struct provides a `RenderContext` and then can have its bitmap extracted.
 pub struct BitmapTarget<'a> {
@@ -70,7 +76,9 @@ pub struct BitmapTarget<'a> {
 impl Device {
     /// Create a new device.
     pub fn new() -> Result<Device, piet::Error> {
-        Ok(Device)
+        Ok(Device {
+            marker: std::marker::PhantomData,
+        })
     }
 
     /// Create a new bitmap target.

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -55,7 +55,13 @@ pub type PietTextLayoutBuilder = CoreGraphicsTextLayout;
 pub type Image = CGImage;
 
 /// A struct that can be used to create bitmap render contexts.
-pub struct Device;
+pub struct Device {
+    // Since not all backends can support `Device: Sync`, make it non-Sync here to, for fewer
+    // portability surprises.
+    marker: std::marker::PhantomData<*const ()>,
+}
+
+unsafe impl Send for Device {}
 
 /// A struct provides a `RenderContext` and then can have its bitmap extracted.
 pub struct BitmapTarget<'a> {
@@ -67,7 +73,9 @@ pub struct BitmapTarget<'a> {
 impl Device {
     /// Create a new device.
     pub fn new() -> Result<Device, piet::Error> {
-        Ok(Device)
+        Ok(Device {
+            marker: std::marker::PhantomData,
+        })
     }
 
     /// Create a new bitmap target.

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -57,6 +57,8 @@ mod test {
     use super::*;
     use std::marker::PhantomData;
 
+    use static_assertions as sa;
+
     // Make sure all the common types exist and don't get accidentally removed
     #[allow(dead_code)]
     struct Types<'a> {
@@ -70,4 +72,7 @@ mod test {
         image: Image,
         _phantom: PhantomData<&'a ()>,
     }
+
+    sa::assert_impl_all!(Device: Send);
+    sa::assert_not_impl_any!(Device: Sync);
 }

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -55,7 +55,13 @@ pub type PietTextLayoutBuilder = WebTextLayoutBuilder;
 pub type Image = WebImage;
 
 /// A struct that can be used to create bitmap render contexts.
-pub struct Device;
+pub struct Device {
+    // Since not all backends can support `Device: Sync`, make it non-Sync here to, for fewer
+    // portability surprises.
+    marker: std::marker::PhantomData<*const ()>,
+}
+
+unsafe impl Send for Device {}
 
 /// A struct provides a `RenderContext` and then can have its bitmap extracted.
 pub struct BitmapTarget<'a> {
@@ -67,7 +73,9 @@ pub struct BitmapTarget<'a> {
 impl Device {
     /// Create a new device.
     pub fn new() -> Result<Device, piet::Error> {
-        Ok(Device)
+        Ok(Device {
+            marker: std::marker::PhantomData,
+        })
     }
 
     /// Create a new bitmap target.

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -62,6 +62,12 @@ pub struct D2DFactory(ComPtr<ID2D1Factory1>);
 /// A Direct2D device.
 pub struct D2DDevice(ComPtr<ID2D1Device>);
 
+// Microsoft's API docs suggest that it's safe to access D2D factories, and anything coming out of
+// them, from multiple threads. (In fact, if there's no underlying D3D resources, they're even
+// `Sync`.) https://docs.microsoft.com/en-us/windows/win32/direct2d/multi-threaded-direct2d-apps
+unsafe impl Send for D2DFactory {}
+unsafe impl Send for D2DDevice {}
+
 /// The main context that takes drawing operations.
 ///
 /// This type is a thin wrapper for

--- a/piet-direct2d/src/d3d.rs
+++ b/piet-direct2d/src/d3d.rs
@@ -26,6 +26,15 @@ pub struct D3D11DeviceContext(ComPtr<ID3D11DeviceContext>);
 pub struct D3D11Texture2D(ComPtr<ID3D11Texture2D>);
 pub struct DxgiDevice(ComPtr<IDXGIDevice>);
 
+// According to Microsoft's docs, D3D11Device does its own synchronization. It also says that "only
+// one thread can call a ID3D11DeviceContext at a time", so D3D11DeviceContext is definitely not
+// Sync, but probably Send (or else they would have said something).
+//
+// https://docs.microsoft.com/en-us/windows/win32/direct3d11/overviews-direct3d-11-render-multi-thread-intro
+unsafe impl Send for D3D11Device {}
+unsafe impl Sync for D3D11Device {}
+unsafe impl Send for D3D11DeviceContext {}
+
 pub enum TextureMode {
     Target,
     Read,

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -29,6 +29,10 @@ pub enum Error {
 #[derive(Clone)]
 pub struct DwriteFactory(ComPtr<IDWriteFactory>);
 
+// I couldn't find any documentation about using IDWriteFactory in a multi-threaded context.
+// Hopefully, `Send` is a conservative enough assumption.
+unsafe impl Send for DwriteFactory {}
+
 #[derive(Clone)]
 pub struct TextFormat(ComPtr<IDWriteTextFormat>);
 


### PR DESCRIPTION
Fixes #211, and also makes Device !Sync, jut to reduce portability friction.

Note that there are currently no checks for this. If you're willing to add `static-assertions` as a dev-dep, I could add tests...