### PR TITLE
Work around core-foundation changes.

### DIFF
--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -13,7 +13,7 @@ piet = { version = "0.2.0", path = "../piet" }
 
 core-graphics = "0.19.1"
 core-text = "16.0"
-core-foundation = "0.7.1"
+core-foundation = "=0.7.1"
 core-foundation-sys = "0.7"
 
 [dev-dependencies]

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -13,7 +13,7 @@ piet = { version = "0.2.0", path = "../piet" }
 
 core-graphics = "0.19.1"
 core-text = "16.0"
-core-foundation = "0.7"
+core-foundation = "0.7.1"
 core-foundation-sys = "0.7"
 
 [dev-dependencies]

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -56,12 +56,12 @@ impl AttributedString {
             string.set_attribute(
                 char_range,
                 string_attributes::kCTFontAttributeName,
-                font.clone(),
+                &font.clone(),
             );
             string.set_attribute::<CFBoolean>(
                 char_range,
                 string_attributes::kCTForegroundColorFromContextAttributeName,
-                CFBoolean::true_value(),
+                &CFBoolean::true_value(),
             );
         }
         AttributedString(string)


### PR DESCRIPTION
Looks like core-foundation broke semver [here](https://github.com/servo/core-foundation-rs/commit/b68e9c782af87534d50596d7c2a7b965e067eaef), leading to CI failures in druid.