### PR TITLE
Add system_font method to Text trait

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -71,16 +71,11 @@ impl Text for CairoText {
         }
     }
 
-    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
-        let weight = if bold {
-            FontWeight::Bold
-        } else {
-            FontWeight::Normal
-        };
+    fn system_font(&mut self, size: f64) -> Self::Font {
         CairoFontBuilder {
             family: "sans-serif".into(),
             size: size.round_into(),
-            weight,
+            weight: FontWeight::Normal,
             slant: FontSlant::Normal,
         }
         .build()

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -71,6 +71,22 @@ impl Text for CairoText {
         }
     }
 
+    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
+        let weight = if bold {
+            FontWeight::Bold
+        } else {
+            FontWeight::Normal
+        };
+        CairoFontBuilder {
+            family: "sans-serif".into(),
+            size: size.round_into(),
+            weight,
+            slant: FontSlant::Normal,
+        }
+        .build()
+        .unwrap()
+    }
+
     fn new_text_layout(
         &mut self,
         font: &Self::Font,

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -19,9 +19,7 @@ use core_graphics::{
     path::CGPathRef,
 };
 use core_text::{
-    font::{
-        kCTFontEmphasizedSystemFontType, kCTFontSystemFontType, CTFont, CTFontRef, CTFontUIFontType,
-    },
+    font::{kCTFontSystemFontType, CTFont, CTFontRef, CTFontUIFontType},
     frame::{CTFrame, CTFrameRef},
     framesetter::{CTFramesetter, CTFramesetterRef},
     line::{CTLine, CTLineRef},
@@ -174,15 +172,9 @@ impl<'a> From<CTLine> for Line<'a> {
     }
 }
 
-pub fn system_font(size: CGFloat, bold: bool) -> CTFont {
-    let font_type = if bold {
-        kCTFontEmphasizedSystemFontType
-    } else {
-        kCTFontSystemFontType
-    };
-
+pub(crate) fn system_font(size: CGFloat) -> CTFont {
     unsafe {
-        let font = CTFontCreateUIFontForLanguage(font_type, size, std::ptr::null());
+        let font = CTFontCreateUIFontForLanguage(kCTFontSystemFontType, size, std::ptr::null());
         CTFont::wrap_under_create_rule(font)
     }
 }

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -10,7 +10,7 @@ use core_foundation::{
     base::TCFType,
     boolean::CFBoolean,
     dictionary::CFDictionaryRef,
-    string::CFString,
+    string::{CFString, CFStringRef},
 };
 use core_foundation_sys::base::CFRange;
 use core_graphics::{
@@ -19,7 +19,9 @@ use core_graphics::{
     path::CGPathRef,
 };
 use core_text::{
-    font::CTFont,
+    font::{
+        kCTFontEmphasizedSystemFontType, kCTFontSystemFontType, CTFont, CTFontRef, CTFontUIFontType,
+    },
     frame::{CTFrame, CTFrameRef},
     framesetter::{CTFramesetter, CTFramesetterRef},
     line::{CTLine, CTLineRef},
@@ -172,6 +174,19 @@ impl<'a> From<CTLine> for Line<'a> {
     }
 }
 
+pub fn system_font(size: CGFloat, bold: bool) -> CTFont {
+    let font_type = if bold {
+        kCTFontEmphasizedSystemFontType
+    } else {
+        kCTFontSystemFontType
+    };
+
+    unsafe {
+        let font = CTFontCreateUIFontForLanguage(font_type, size, std::ptr::null());
+        CTFont::wrap_under_create_rule(font)
+    }
+}
+
 #[link(name = "CoreText", kind = "framework")]
 extern "C" {
     fn CTFramesetterSuggestFrameSizeWithConstraints(
@@ -200,4 +215,9 @@ extern "C" {
         charIndex: CFIndex,
         secondaryOffset: *mut CGFloat,
     ) -> CGFloat;
+    fn CTFontCreateUIFontForLanguage(
+        font_type: CTFontUIFontType,
+        size: CGFloat,
+        language: CFStringRef,
+    ) -> CTFontRef;
 }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -58,8 +58,8 @@ impl Text for CoreGraphicsText {
         CoreGraphicsFontBuilder(font::new_from_name(name, size).ok())
     }
 
-    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
-        CoreGraphicsFont(crate::ct_helpers::system_font(size, bold))
+    fn system_font(&mut self, size: f64) -> Self::Font {
+        CoreGraphicsFont(crate::ct_helpers::system_font(size))
     }
 
     fn new_text_layout(

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -58,6 +58,10 @@ impl Text for CoreGraphicsText {
         CoreGraphicsFontBuilder(font::new_from_name(name, size).ok())
     }
 
+    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
+        CoreGraphicsFont(crate::ct_helpers::system_font(size, bold))
+    }
+
     fn new_text_layout(
         &mut self,
         font: &Self::Font,

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -18,8 +18,6 @@ use winapi::Interface;
 use wio::com::ComPtr;
 use wio::wide::ToWide;
 
-use piet::FontWeight;
-
 // TODO: minimize cut'n'paste; probably the best way to do this is
 // unify with the crate error type
 pub enum Error {
@@ -45,7 +43,6 @@ pub struct TextFormatBuilder {
     factory: DwriteFactory,
     size: Option<f32>,
     family: Option<String>,
-    weight: FontWeight,
 }
 
 pub struct TextLayoutBuilder {
@@ -137,7 +134,6 @@ impl TextFormatBuilder {
             factory,
             size: None,
             family: None,
-            weight: FontWeight::default(),
         }
     }
 
@@ -151,11 +147,6 @@ impl TextFormatBuilder {
         self
     }
 
-    pub fn weight(mut self, weight: FontWeight) -> TextFormatBuilder {
-        self.weight = weight;
-        self
-    }
-
     pub fn build(self) -> Result<TextFormat, Error> {
         let family = self
             .family
@@ -163,13 +154,12 @@ impl TextFormatBuilder {
             .to_wide_null();
         let size = self.size.expect("`size` must be specified");
         let locale = "en-US".to_wide_null();
-        let weight = self.weight.to_raw();
         unsafe {
             let mut ptr = null_mut();
             let hr = self.factory.0.CreateTextFormat(
                 family.as_ptr(),
                 null_mut(), // collection
-                weight,
+                DWRITE_FONT_WEIGHT_NORMAL,
                 DWRITE_FONT_STYLE_NORMAL,
                 DWRITE_FONT_STRETCH_NORMAL,
                 size,

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -18,6 +18,8 @@ use winapi::Interface;
 use wio::com::ComPtr;
 use wio::wide::ToWide;
 
+use piet::FontWeight;
+
 // TODO: minimize cut'n'paste; probably the best way to do this is
 // unify with the crate error type
 pub enum Error {
@@ -43,6 +45,7 @@ pub struct TextFormatBuilder {
     factory: DwriteFactory,
     size: Option<f32>,
     family: Option<String>,
+    weight: FontWeight,
 }
 
 pub struct TextLayoutBuilder {
@@ -134,6 +137,7 @@ impl TextFormatBuilder {
             factory,
             size: None,
             family: None,
+            weight: FontWeight::default(),
         }
     }
 
@@ -147,6 +151,11 @@ impl TextFormatBuilder {
         self
     }
 
+    pub fn weight(mut self, weight: FontWeight) -> TextFormatBuilder {
+        self.weight = weight;
+        self
+    }
+
     pub fn build(self) -> Result<TextFormat, Error> {
         let family = self
             .family
@@ -154,12 +163,13 @@ impl TextFormatBuilder {
             .to_wide_null();
         let size = self.size.expect("`size` must be specified");
         let locale = "en-US".to_wide_null();
+        let weight = self.weight.to_raw();
         unsafe {
             let mut ptr = null_mut();
             let hr = self.factory.0.CreateTextFormat(
                 family.as_ptr(),
                 null_mut(), // collection
-                DWRITE_FONT_WEIGHT_NORMAL,
+                weight,
                 DWRITE_FONT_STYLE_NORMAL,
                 DWRITE_FONT_STRETCH_NORMAL,
                 size,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -67,6 +67,30 @@ impl Text for D2DText {
         }
     }
 
+    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
+        let weight = if bold {
+            FontWeight::Bold
+        } else {
+            FontWeight::Normal
+        };
+        // this is... lazy. We try Segoe UI, and if it's missing we try Arial,
+        // and if that's missing we crash. :shrug_emoji:
+        // FIXME: something like this might be better? https://stackoverflow.com/questions/41505151/how-to-draw-text-with-the-default-ui-font-in-directwrite
+        TextFormatBuilder::new(self.dwrite.clone())
+            .size(size as f32)
+            .family("Segoe UI".into())
+            .weight(weight)
+            .build()
+            .unwrap_or_else(|| {
+                TextFormatBuilder::new(self.dwrite.clone())
+                    .size(size as f32)
+                    .family("Arial".into())
+                    .weight(weight)
+                    .build()
+            })
+            .unwrap()
+    }
+
     fn new_text_layout(
         &mut self,
         font: &Self::Font,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -67,28 +67,23 @@ impl Text for D2DText {
         }
     }
 
-    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
-        let weight = if bold {
-            FontWeight::Bold
-        } else {
-            FontWeight::Normal
-        };
+    fn system_font(&mut self, size: f64) -> Self::Font {
         // this is... lazy. We try Segoe UI, and if it's missing we try Arial,
         // and if that's missing we crash. :shrug_emoji:
         // FIXME: something like this might be better? https://stackoverflow.com/questions/41505151/how-to-draw-text-with-the-default-ui-font-in-directwrite
-        TextFormatBuilder::new(self.dwrite.clone())
-            .size(size as f32)
-            .family("Segoe UI".into())
-            .weight(weight)
-            .build()
-            .unwrap_or_else(|| {
-                TextFormatBuilder::new(self.dwrite.clone())
-                    .size(size as f32)
-                    .family("Arial".into())
-                    .weight(weight)
-                    .build()
-            })
-            .unwrap()
+        D2DFont(
+            TextFormatBuilder::new(self.dwrite.clone())
+                .size(size as f32)
+                .family("Segoe UI".into())
+                .build()
+                .or_else(|_| {
+                    TextFormatBuilder::new(self.dwrite.clone())
+                        .size(size as f32)
+                        .family("Arial".into())
+                        .build()
+                })
+                .unwrap(),
+        )
     }
 
     fn new_text_layout(

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -26,6 +26,10 @@ impl piet::Text for Text {
         FontBuilder
     }
 
+    fn system_font(&mut self, _size: f64, _bold: bool) -> Self::Font {
+        Font
+    }
+
     fn new_text_layout(
         &mut self,
         _font: &Self::Font,

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -26,7 +26,7 @@ impl piet::Text for Text {
         FontBuilder
     }
 
-    fn system_font(&mut self, _size: f64, _bold: bool) -> Self::Font {
+    fn system_font(&mut self, _size: f64) -> Self::Font {
         Font
     }
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -72,6 +72,16 @@ impl Text for WebText {
         WebFontBuilder(font)
     }
 
+    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
+        let font = WebFont {
+            family: "san-serif".to_owned(),
+            size,
+            weight: if bold { 700 } else { 500 },
+            style: FontStyle::Normal,
+        };
+        WebFontBuilder(font).build().unwrap()
+    }
+
     fn new_text_layout(
         &mut self,
         font: &Self::Font,

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -72,11 +72,11 @@ impl Text for WebText {
         WebFontBuilder(font)
     }
 
-    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font {
+    fn system_font(&mut self, size: f64) -> Self::Font {
         let font = WebFont {
             family: "san-serif".to_owned(),
             size,
-            weight: if bold { 700 } else { 500 },
+            weight: 400,
             style: FontStyle::Normal,
         };
         WebFontBuilder(font).build().unwrap()

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -147,7 +147,7 @@ impl Text for NullText {
         NullFontBuilder
     }
 
-    fn system_font(&mut self, _size: f64, _bold: bool) -> Self::Font {
+    fn system_font(&mut self, _size: f64) -> Self::Font {
         NullFont
     }
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -147,6 +147,10 @@ impl Text for NullText {
         NullFontBuilder
     }
 
+    fn system_font(&mut self, _size: f64, _bold: bool) -> Self::Font {
+        NullFont
+    }
+
     fn new_text_layout(
         &mut self,
         _font: &Self::Font,

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -13,7 +13,7 @@ pub trait Text: Clone {
     fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder;
 
     /// Returns a font suitable for use in UI on this platform.
-    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font;
+    fn system_font(&mut self, size: f64) -> Self::Font;
 
     fn new_text_layout(
         &mut self,
@@ -35,21 +35,6 @@ pub trait TextLayoutBuilder {
     type Out: TextLayout;
 
     fn build(self) -> Result<Self::Out, Error>;
-}
-
-//TODO: this isn't currently part of public API, but we expect it to be at
-//some point; it's here now because it is used by certain backends.
-/// Standard font weights.
-pub enum FontWeight {
-    Thin,
-    ExtraLight,
-    Light,
-    Normal,
-    Medium,
-    SemiBold,
-    Bold,
-    ExtraBold,
-    Black,
 }
 
 /// # Text Layout
@@ -211,32 +196,4 @@ pub struct HitTestMetrics {
     // TODO:
     // consider adding other metrics as needed, such as those provided in
     // [DWRITE_HIT_TEST_METRICS](https://docs.microsoft.com/en-us/windows/win32/api/dwrite/ns-dwrite-dwrite_hit_test_metrics).
-}
-
-impl FontWeight {
-    /// The numerical value for this weight.
-    ///
-    /// This follows the convention from [OpenType], which is also used in CSS
-    /// and elsewhere.
-    ///
-    /// [OpenType]: https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass
-    pub fn to_raw(self) -> u32 {
-        match self {
-            FontWeight::Thin => 100,
-            FontWeight::ExtraLight => 200,
-            FontWeight::Light => 300,
-            FontWeight::Normal => 400,
-            FontWeight::Medium => 500,
-            FontWeight::SemiBold => 600,
-            FontWeight::Bold => 700,
-            FontWeight::ExtraBold => 800,
-            FontWeight::Black => 900,
-        }
-    }
-}
-
-impl Default for FontWeight {
-    fn default() -> Self {
-        FontWeight::Normal
-    }
 }

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -12,6 +12,9 @@ pub trait Text: Clone {
 
     fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder;
 
+    /// Returns a font suitable for use in UI on this platform.
+    fn system_font(&mut self, size: f64, bold: bool) -> Self::Font;
+
     fn new_text_layout(
         &mut self,
         font: &Self::Font,
@@ -32,6 +35,21 @@ pub trait TextLayoutBuilder {
     type Out: TextLayout;
 
     fn build(self) -> Result<Self::Out, Error>;
+}
+
+//TODO: this isn't currently part of public API, but we expect it to be at
+//some point; it's here now because it is used by certain backends.
+/// Standard font weights.
+pub enum FontWeight {
+    Thin,
+    ExtraLight,
+    Light,
+    Normal,
+    Medium,
+    SemiBold,
+    Bold,
+    ExtraBold,
+    Black,
 }
 
 /// # Text Layout
@@ -193,4 +211,32 @@ pub struct HitTestMetrics {
     // TODO:
     // consider adding other metrics as needed, such as those provided in
     // [DWRITE_HIT_TEST_METRICS](https://docs.microsoft.com/en-us/windows/win32/api/dwrite/ns-dwrite-dwrite_hit_test_metrics).
+}
+
+impl FontWeight {
+    /// The numerical value for this weight.
+    ///
+    /// This follows the convention from [OpenType], which is also used in CSS
+    /// and elsewhere.
+    ///
+    /// [OpenType]: https://docs.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass
+    pub fn to_raw(self) -> u32 {
+        match self {
+            FontWeight::Thin => 100,
+            FontWeight::ExtraLight => 200,
+            FontWeight::Light => 300,
+            FontWeight::Normal => 400,
+            FontWeight::Medium => 500,
+            FontWeight::SemiBold => 600,
+            FontWeight::Bold => 700,
+            FontWeight::ExtraBold => 800,
+            FontWeight::Black => 900,
+        }
+    }
+}
+
+impl Default for FontWeight {
+    fn default() -> Self {
+        FontWeight::Normal
+    }
 }


### PR DESCRIPTION
This is intended as a very simple, non-falible way of getting
a font suitable for UI.

I'd initially imagined a slightly more complex API, that included support for a few different fonts and styles, but I backed away and just went with the simplest thing I could picture.

This has only been tested on macOS. cairo should work, but windows is a bit hacky.

Question: should this at least support italics?