### PR TITLE
Standardize sample painting examples and output

### DIFF
--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -25,7 +25,7 @@ fn main() {
     draw_test_picture(&mut piet_context, test_picture_number).unwrap();
     piet_context.finish().unwrap();
     surface.flush();
-    let mut file = File::create("temp-cairo.png").expect("Couldn't create 'file.png'");
+    let mut file = File::create(format!("cairo-test-{}.png", test_picture_number)).unwrap();
     surface
         .write_to_png(&mut file)
         .expect("Error writing image file");

--- a/piet-direct2d/examples/test-picture.rs
+++ b/piet-direct2d/examples/test-picture.rs
@@ -87,8 +87,9 @@ fn main() {
         raw_pixels.set_len(pixel_count);
     }
 
+    let path = format!("d2d-test-{}.png", test_picture_number);
     image::save_buffer(
-        "temp-image.png",
+        &path,
         &raw_pixels,
         size.width as u32,
         size.height as u32,


### PR DESCRIPTION
The example binary that draws sample pictures are now
all called `test-picture`, and they now all output files
in the format, "$BACKEND-test-$SAMPLE_NUMBER".