### PR TITLE
Text alignment

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -129,6 +129,11 @@ impl Font for CairoFont {}
 impl TextLayoutBuilder for CairoTextLayoutBuilder {
     type Out = CairoTextLayout;
 
+    fn alignment(self, _alignment: piet::TextAlignment) -> Self {
+        eprintln!("TextAlignment not supported by cairo toy text");
+        self
+    }
+
     fn build(self) -> Result<Self::Out, Error> {
         Ok(self.0)
     }

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -15,6 +15,7 @@ core-graphics = "0.21.0"
 core-text = "18.0.1"
 core-foundation = "0.9"
 core-foundation-sys = "0.8"
+unic-bidi = "0.9"
 
 [dev-dependencies]
 piet = { version = "0.2.0", path = "../piet", features = ["samples"] }

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -11,7 +11,7 @@ use piet::kurbo::Point;
 use piet::util;
 use piet::{
     Error, Font, FontBuilder, HitTestMetrics, HitTestPoint, HitTestTextPosition, LineMetric, Text,
-    TextLayout, TextLayoutBuilder,
+    TextAlignment, TextLayout, TextLayoutBuilder,
 };
 
 use self::lines::fetch_line_metrics;
@@ -117,6 +117,11 @@ impl Font for D2DFont {}
 
 impl TextLayoutBuilder for D2DTextLayoutBuilder {
     type Out = D2DTextLayout;
+
+    fn alignment(mut self, alignment: TextAlignment) -> Self {
+        self.builder = self.builder.alignment(alignment);
+        self
+    }
 
     fn build(self) -> Result<Self::Out, Error> {
         let layout = self.builder.build()?;

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -61,6 +61,10 @@ pub struct TextLayoutBuilder;
 impl piet::TextLayoutBuilder for TextLayoutBuilder {
     type Out = TextLayout;
 
+    fn alignment(self, _alignment: piet::TextAlignment) -> Self {
+        self
+    }
+
     fn build(self) -> Result<TextLayout> {
         Err(Error::NotSupported)
     }

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -130,6 +130,11 @@ impl WebFont {
 impl TextLayoutBuilder for WebTextLayoutBuilder {
     type Out = WebTextLayout;
 
+    fn alignment(self, _alignment: piet::TextAlignment) -> Self {
+        web_sys::console::log_1(&"TextLayout alignment unsupported on web".into());
+        self
+    }
+
     fn build(self) -> Result<Self::Out, Error> {
         self.ctx.set_font(&self.font.get_font_string());
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -174,6 +174,10 @@ impl FontBuilder for NullFontBuilder {
 impl TextLayoutBuilder for NullTextLayoutBuilder {
     type Out = NullTextLayout;
 
+    fn alignment(self, _alignment: crate::TextAlignment) -> Self {
+        self
+    }
+
     fn build(self) -> Result<Self::Out, Error> {
         Ok(NullTextLayout)
     }

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -10,6 +10,7 @@ mod picture_3;
 mod picture_4;
 mod picture_5;
 mod picture_6;
+mod picture_7;
 
 use picture_0::draw as draw_picture_0;
 use picture_1::draw as draw_picture_1;
@@ -18,6 +19,7 @@ use picture_3::draw as draw_picture_3;
 use picture_4::draw as draw_picture_4;
 use picture_5::draw as draw_picture_5;
 use picture_6::draw as draw_picture_6;
+use picture_7::draw as draw_picture_7;
 
 /// Draw a test picture, by number.
 ///
@@ -32,6 +34,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         4 => draw_picture_4(rc),
         5 => draw_picture_5(rc),
         6 => draw_picture_6(rc),
+        7 => draw_picture_7(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",
@@ -51,6 +54,7 @@ pub fn size_for_test_picture(number: usize) -> Result<Size, Error> {
         4 => Ok(picture_4::SIZE),
         5 => Ok(picture_5::SIZE),
         6 => Ok(picture_6::SIZE),
+        7 => Ok(picture_7::SIZE),
         other => {
             eprintln!("test picture {} does not exist.", other);
             Err(Error::InvalidInput)

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -1,0 +1,69 @@
+//! Text layouts
+
+use crate::kurbo::Size;
+use crate::{Color, Error, RenderContext, Text, TextAlignment, TextLayoutBuilder};
+
+pub const SIZE: Size = Size::new(800., 800.);
+static SAMPLE_EN: &str = r#"
+This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
+
+static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.
+"#;
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(Color::WHITE);
+    let text = rc.text();
+    let font = text.system_font(8.0);
+
+    let en_leading = text
+        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .alignment(TextAlignment::Start)
+        .build()?;
+
+    let en_trailing = text
+        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .alignment(TextAlignment::End)
+        .build()?;
+
+    let en_center = text
+        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .alignment(TextAlignment::Center)
+        .build()?;
+
+    let en_justify = text
+        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .alignment(TextAlignment::Justified)
+        .build()?;
+
+    let ar_leading = text
+        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .alignment(TextAlignment::Start)
+        .build()?;
+
+    let ar_trailing = text
+        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .alignment(TextAlignment::End)
+        .build()?;
+
+    let ar_center = text
+        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .alignment(TextAlignment::Center)
+        .build()?;
+
+    let ar_justify = text
+        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .alignment(TextAlignment::Justified)
+        .build()?;
+
+    rc.draw_text(&en_leading, (0., 0.), &Color::BLACK);
+    rc.draw_text(&en_trailing, (100., 0.), &Color::BLACK);
+    rc.draw_text(&en_center, (200., 0.), &Color::BLACK);
+    rc.draw_text(&en_justify, (300., 0.), &Color::BLACK);
+
+    rc.draw_text(&ar_leading, (0., 200.), &Color::BLACK);
+    rc.draw_text(&ar_trailing, (100., 200.), &Color::BLACK);
+    rc.draw_text(&ar_center, (200., 200.), &Color::BLACK);
+    rc.draw_text(&ar_justify, (300., 200.), &Color::BLACK);
+
+    Ok(())
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -34,7 +34,32 @@ pub trait Font {}
 pub trait TextLayoutBuilder {
     type Out: TextLayout;
 
+    /// Set the [`TextAlignment`] to be used for this layout.
+    ///
+    /// [`TextAlignment`]: enum.TextAlignment.html
+    fn alignment(self, alignment: TextAlignment) -> Self;
     fn build(self) -> Result<Self::Out, Error>;
+}
+
+/// The alignment of text in a [`TextLayout`].
+///
+/// [`TextLayout`]: trait.TextLayout.html
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextAlignment {
+    /// Text is aligned to the left edge in left-to-right scripts, and the
+    /// right edge in right-to-left scripts.
+    Start,
+    /// Text is aligned to the right edge in left-to-right scripts, and the
+    /// left edge in right-to-left scripts.
+    End,
+    Center,
+    Justified,
+}
+
+impl Default for TextAlignment {
+    fn default() -> Self {
+        TextAlignment::Start
+    }
 }
 
 /// # Text Layout


### PR DESCRIPTION
This adds a `TextAlignment` enum, which can be used with `TextLayoutBuilder`.

It also uses this on mac and windows (windows impl was written blind, will fix it up shortly).

This is based off of #225, because it includes a test drawing that exercises these layouts, and which on macOS looks like,

![coregraphics-test-7](https://user-images.githubusercontent.com/3330916/86486485-60966800-bd29-11ea-9959-f399228c8c01.png)

Also looking at that sample is making me think that we're not doing hidpi correctly when writing out the PNGs or something? I'll have to look into that.
