### PR TITLE
Initial rich text support

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -3,13 +3,15 @@
 mod grapheme;
 mod lines;
 
+use std::ops::RangeBounds;
+
 use cairo::{FontFace, FontOptions, FontSlant, FontWeight, Matrix, ScaledFont};
 
 use piet::kurbo::Point;
 
 use piet::{
     Error, Font, FontBuilder, HitTestMetrics, HitTestPoint, HitTestTextPosition, LineMetric,
-    RoundInto, Text, TextLayout, TextLayoutBuilder,
+    RoundInto, Text, TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
 use unicode_segmentation::UnicodeSegmentation;
@@ -23,6 +25,7 @@ use self::grapheme::{get_grapheme_boundaries, point_x_in_grapheme};
 #[derive(Clone)]
 pub struct CairoText;
 
+#[derive(Clone)]
 pub struct CairoFont(ScaledFont);
 
 pub struct CairoFontBuilder {
@@ -128,9 +131,18 @@ impl Font for CairoFont {}
 
 impl TextLayoutBuilder for CairoTextLayoutBuilder {
     type Out = CairoTextLayout;
+    type Font = CairoFont;
 
     fn alignment(self, _alignment: piet::TextAlignment) -> Self {
         eprintln!("TextAlignment not supported by cairo toy text");
+        self
+    }
+
+    fn add_attribute(
+        self,
+        _range: impl RangeBounds<usize>,
+        _attribute: impl Into<TextAttribute<Self::Font>>,
+    ) -> Self {
         self
     }
 

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -116,12 +116,6 @@ impl AttributedString {
         AttributedString { inner, rtl }
     }
 
-    //string.set_attribute::<CFBoolean>(
-    //char_range,
-    //string_attributes::kCTForegroundColorFromContextAttributeName,
-    //&CFBoolean::true_value(),
-    //);
-
     pub(crate) fn set_alignment(&mut self, alignment: TextAlignment) {
         let alignment = CTParagraphStyleSetting::alignment(alignment, self.rtl);
         let settings = [alignment];

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -252,6 +252,7 @@ impl CoreGraphicsTextLayoutBuilder {
 /// to css-style weights. This is a fudge, adapted from QT:
 ///
 /// https://git.sailfishos.org/mer-core/qtbase/commit/9ba296cc4cefaeb9d6c5abc2e0c0b272f2288733#1b84d1913347bd20dd0a134247f8cd012a646261_44_55
+//TODO: a better solution would be piecewise linear interpolation between these values
 fn convert_to_coretext(weight: FontWeight) -> CFNumber {
     match weight.to_raw() {
         0..=199 => -0.8,

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "0.2.0", path = "../piet" }
+utf16_lit = "1.0"
 
 wio = "0.2.2"
 

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -16,7 +16,7 @@ wio = "0.2.2"
 
 [dependencies.winapi]
 version = "0.3.8"
-features = ["d2d1", "d2d1_1", "d2d1effects", "d3d11", "dxgi"]
+features = ["d2d1", "d2d1_1", "d2d1effects", "d3d11", "dxgi", "winnls"]
 
 [dev-dependencies]
 piet = { version = "0.2.0", path = "../piet", features = ["samples"] }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -75,6 +75,7 @@ unsafe impl Send for D2DDevice {}
 ///
 /// This struct is public only to use for system integration in piet_common and druid-shell. It is not intended
 /// that end-users directly use this struct.
+#[derive(Clone)]
 pub struct DeviceContext(ComPtr<ID2D1DeviceContext>);
 
 pub struct PathGeometry(ComPtr<ID2D1PathGeometry>);

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -3,6 +3,7 @@
 // TODO: get rid of this when we actually do use everything
 #![allow(unused)]
 
+use std::convert::TryInto;
 use std::ffi::OsString;
 use std::fmt::{Debug, Display, Formatter};
 use std::mem::MaybeUninit;
@@ -32,7 +33,7 @@ use piet::{FontWeight, TextAlignment};
 use crate::Brush;
 
 /// "en-US" as null-terminated utf16.
-const DEFAULT_LOCALE: [u16; 6] = [101, 110, 45, 85, 83, 0];
+const DEFAULT_LOCALE: &[u16] = utf16_lit::utf16_null!("en-US");
 
 // TODO: minimize cut'n'paste; probably the best way to do this is
 // unify with the crate error type
@@ -286,8 +287,8 @@ const E_NOT_SUFFICIENT_BUFFER: HRESULT = 0x8007007A;
 
 fn make_text_range(start: usize, len: usize) -> DWRITE_TEXT_RANGE {
     DWRITE_TEXT_RANGE {
-        startPosition: start as u32,
-        length: len as u32,
+        startPosition: start.try_into().unwrap(),
+        length: len.try_into().unwrap(),
     }
 }
 
@@ -299,8 +300,7 @@ impl TextLayout {
         text: &[u16],
     ) -> Result<Self, Error> {
         const QUITE_TALL_HEIGHT: f32 = 1e6;
-        let len = text.len();
-        assert!(len <= 0xffff_ffff);
+        let len: u32 = text.len().try_into().unwrap();
 
         unsafe {
             let mut ptr = null_mut();
@@ -554,6 +554,6 @@ mod tests {
 
     #[test]
     fn default_locale() {
-        assert_eq!("en-US".to_wide_null().as_slice(), &DEFAULT_LOCALE);
+        assert_eq!("en-US".to_wide_null().as_slice(), DEFAULT_LOCALE);
     }
 }

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -52,6 +52,11 @@ pub struct TextFormat(pub(crate) ComPtr<IDWriteTextFormat>);
 #[derive(Clone)]
 struct FontFamily(ComPtr<IDWriteFontFamily>);
 
+/// A cheap to clone reference to an existing family name.
+///
+/// We hold onto both the wide string and the rust string.
+///
+/// This type AsRefs to both `str` and `[u16]`.
 #[derive(Clone, Debug)]
 pub(crate) struct FamilyName {
     wide_name: Arc<[u16]>,
@@ -310,6 +315,7 @@ impl TextLayout {
         }
     }
 
+    /// Set the alignment for this entire layout.
     pub(crate) fn set_alignment(&mut self, alignment: TextAlignment) {
         let alignment = match alignment {
             TextAlignment::Start => DWRITE_TEXT_ALIGNMENT_LEADING,
@@ -323,6 +329,7 @@ impl TextLayout {
         }
     }
 
+    /// Set the weight for a range of this layout. `start` and `len` are in utf16.
     pub(crate) fn set_weight(&mut self, start: usize, len: usize, weight: FontWeight) {
         let range = make_text_range(start, len);
         let weight = weight.to_raw() as DWRITE_FONT_WEIGHT;

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -31,6 +31,9 @@ use piet::{FontWeight, TextAlignment};
 
 use crate::Brush;
 
+/// "en-US" as null-terminated utf16.
+const DEFAULT_LOCALE: [u16; 6] = [101, 110, 45, 85, 83, 0];
+
 // TODO: minimize cut'n'paste; probably the best way to do this is
 // unify with the crate error type
 pub enum Error {
@@ -200,8 +203,7 @@ impl FontFamily {
                 hr
             };
             if !SUCCEEDED(hr) || exists == 0 {
-                let us_en = "en-us".to_wide_null();
-                hr = names.FindLocaleName(us_en.as_ptr(), &mut index, &mut exists);
+                hr = names.FindLocaleName(DEFAULT_LOCALE.as_ptr(), &mut index, &mut exists);
             }
 
             if !SUCCEEDED(hr) {
@@ -245,8 +247,6 @@ impl TextFormat {
         size: f32,
     ) -> Result<TextFormat, Error> {
         let family = family.as_ref();
-        //TODO: this should be the user's locale? It will influence font fallback behaviour?
-        let locale = "en-US".to_wide_null();
 
         unsafe {
             let mut ptr = null_mut();
@@ -257,7 +257,8 @@ impl TextFormat {
                 DWRITE_FONT_STYLE_NORMAL,
                 DWRITE_FONT_STRETCH_NORMAL,
                 size,
-                locale.as_ptr(),
+                //TODO: this should be the user's locale? It will influence font fallback behaviour?
+                DEFAULT_LOCALE.as_ptr(),
                 &mut ptr,
             );
 
@@ -549,5 +550,10 @@ mod tests {
         assert!(fonts.font_family("arial").is_some());
         assert!(fonts.font_family("Arial").is_some());
         assert!(fonts.font_family("Times New Roman").is_some());
+    }
+
+    #[test]
+    fn default_locale() {
+        assert_eq!("en-US".to_wide_null().as_slice(), &DEFAULT_LOCALE);
     }
 }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -69,7 +69,7 @@ impl<'b, 'a: 'b> D2DRenderContext<'a> {
         dwrite: DwriteFactory,
         rt: &'b mut DeviceContext,
     ) -> D2DRenderContext<'b> {
-        let inner_text = D2DText::new(dwrite);
+        let inner_text = D2DText::new(dwrite, rt.clone());
         D2DRenderContext {
             factory,
             inner_text,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -92,6 +92,9 @@ impl Text for D2DText {
 
     fn system_font(&mut self, size: f64) -> Self::Font {
         let collection = self.dwrite.system_font_collection().unwrap();
+        //TODO: this is maybe not the best thing? I _think_ if we pass an empty string
+        //when creating a layout it will pick a fallback font for us, which would
+        //let us skip this unwrap.
         let family = collection
             .font_family("Segoe UI")
             .or_else(|| collection.font_family("Arial"))

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -149,9 +149,8 @@ mod test {
         }];
 
         // setup dwrite layout
-        let dwrite = dwrite::DwriteFactory::new().unwrap();
-        let mut text = D2DText::new(dwrite);
-        let font = text.new_font_by_name("sans-serif", 12.0).build().unwrap();
+        let mut text = D2DText::new_for_test();
+        let font = text.new_font_by_name("Segoe UI", 12.0).build().unwrap();
 
         test_metrics_with_width(width_small, expected_small, input, &mut text, &font);
         test_metrics_with_width(width_medium, expected_medium, input, &mut text, &font);

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -1,7 +1,9 @@
 //! Text functionality for Piet svg backend
 
+use std::ops::RangeBounds;
+
 use piet::kurbo::Point;
-use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric};
+use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric, TextAttribute};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -52,6 +54,7 @@ impl piet::FontBuilder for FontBuilder {
 }
 
 /// SVG font (unimplemented)
+#[derive(Clone)]
 pub struct Font;
 
 impl piet::Font for Font {}
@@ -60,8 +63,17 @@ pub struct TextLayoutBuilder;
 
 impl piet::TextLayoutBuilder for TextLayoutBuilder {
     type Out = TextLayout;
+    type Font = Font;
 
     fn alignment(self, _alignment: piet::TextAlignment) -> Self {
+        self
+    }
+
+    fn add_attribute(
+        self,
+        _range: impl RangeBounds<usize>,
+        _attribute: impl Into<TextAttribute<Self::Font>>,
+    ) -> Self {
         self
     }
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -4,6 +4,7 @@ mod grapheme;
 mod lines;
 
 use std::borrow::Cow;
+use std::ops::RangeBounds;
 
 use web_sys::CanvasRenderingContext2d;
 
@@ -11,7 +12,7 @@ use piet::kurbo::Point;
 
 use piet::{
     Error, Font, FontBuilder, HitTestMetrics, HitTestPoint, HitTestTextPosition, LineMetric, Text,
-    TextLayout, TextLayoutBuilder,
+    TextAttribute, TextLayout, TextLayoutBuilder,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -129,9 +130,19 @@ impl WebFont {
 
 impl TextLayoutBuilder for WebTextLayoutBuilder {
     type Out = WebTextLayout;
+    type Font = WebFont;
 
     fn alignment(self, _alignment: piet::TextAlignment) -> Self {
         web_sys::console::log_1(&"TextLayout alignment unsupported on web".into());
+        self
+    }
+
+    fn add_attribute(
+        self,
+        _range: impl RangeBounds<usize>,
+        _attribute: impl Into<TextAttribute<Self::Font>>,
+    ) -> Self {
+        web_sys::console::log_1(&"Text attributes not yet implemented for web".into());
         self
     }
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -1,13 +1,14 @@
 //! A render context that does nothing.
 
 use std::borrow::Cow;
+use std::ops::RangeBounds;
 
 use kurbo::{Affine, Point, Rect, Shape};
 
 use crate::{
     Color, Error, FixedGradient, Font, FontBuilder, HitTestPoint, HitTestTextPosition, ImageFormat,
-    InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextLayout,
-    TextLayoutBuilder,
+    InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextAttribute,
+    TextLayout, TextLayoutBuilder,
 };
 
 /// A render context that doesn't render.
@@ -28,6 +29,7 @@ pub struct NullImage;
 pub struct NullText;
 
 #[doc(hidden)]
+#[derive(Clone)]
 pub struct NullFont;
 #[doc(hidden)]
 pub struct NullFontBuilder;
@@ -173,8 +175,17 @@ impl FontBuilder for NullFontBuilder {
 
 impl TextLayoutBuilder for NullTextLayoutBuilder {
     type Out = NullTextLayout;
+    type Font = NullFont;
 
     fn alignment(self, _alignment: crate::TextAlignment) -> Self {
+        self
+    }
+
+    fn add_attribute(
+        self,
+        _range: impl RangeBounds<usize>,
+        _attribute: impl Into<TextAttribute<Self::Font>>,
+    ) -> Self {
         self
     }
 

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -11,6 +11,7 @@ mod picture_4;
 mod picture_5;
 mod picture_6;
 mod picture_7;
+mod picture_8;
 
 use picture_0::draw as draw_picture_0;
 use picture_1::draw as draw_picture_1;
@@ -20,6 +21,7 @@ use picture_4::draw as draw_picture_4;
 use picture_5::draw as draw_picture_5;
 use picture_6::draw as draw_picture_6;
 use picture_7::draw as draw_picture_7;
+use picture_8::draw as draw_picture_8;
 
 /// Draw a test picture, by number.
 ///
@@ -35,6 +37,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         5 => draw_picture_5(rc),
         6 => draw_picture_6(rc),
         7 => draw_picture_7(rc),
+        8 => draw_picture_8(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",
@@ -55,6 +58,7 @@ pub fn size_for_test_picture(number: usize) -> Result<Size, Error> {
         5 => Ok(picture_5::SIZE),
         6 => Ok(picture_6::SIZE),
         7 => Ok(picture_7::SIZE),
+        8 => Ok(picture_8::SIZE),
         other => {
             eprintln!("test picture {} does not exist.", other);
             Err(Error::InvalidInput)

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -1,7 +1,7 @@
 //! Text layouts
 
 use crate::kurbo::Size;
-use crate::{Color, Error, RenderContext, Text, TextAlignment, TextLayoutBuilder};
+use crate::{Color, Error, RenderContext, Text, TextAlignment, TextAttribute, TextLayoutBuilder};
 
 pub const SIZE: Size = Size::new(800., 800.);
 static SAMPLE_EN: &str = r#"
@@ -18,7 +18,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let en_leading = text
         .new_text_layout(&font, SAMPLE_EN, 100.0)
         .alignment(TextAlignment::Start)
-        .add_attribute(.., 8.0)
+        .add_attribute(.., TextAttribute::Size(8.0))
         .build()?;
 
     let en_trailing = text

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -18,6 +18,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let en_leading = text
         .new_text_layout(&font, SAMPLE_EN, 100.0)
         .alignment(TextAlignment::Start)
+        .add_attribute(.., 8.0)
         .build()?;
 
     let en_trailing = text

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -27,7 +27,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let en_leading = text
         .new_text_layout(&font, SAMPLE_EN, 200.0)
         .alignment(TextAlignment::Start)
-        .add_attribute(10..80, 8.0)
+        .add_attribute(10..80, TextAttribute::Size(8.0))
         .add_attribute(20..120, serif)
         .add_attribute(40..60, FontWeight::BOLD)
         .add_attribute(60..140, FontWeight::THIN)
@@ -45,7 +45,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
             TextAttribute::ForegroundColor(Color::rgb(0., 0., 0.6)),
         )
         .add_attribute(200.., FontWeight::EXTRA_BLACK)
-        .add_attribute(220.., 18.0)
+        .add_attribute(220.., TextAttribute::Size(18.0))
         .add_attribute(240.., TextAttribute::Italic)
         .add_attribute(280.., TextAttribute::Underline)
         .build()?;

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -11,17 +11,23 @@ pub const SIZE: Size = Size::new(400., 800.);
 static SAMPLE_EN: &str = r#"
 This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
+const SERIF: &str = "Times New Roman";
+#[cfg(target_os = "windows")]
+const MONO: &str = "Courier New";
+#[cfg(not(target_os = "windows"))]
+const MONO: &str = "Courier";
+
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
     let font = text.system_font(12.0);
-    let serif = text.new_font_by_name("Times", 20.0).build().unwrap();
-    let mono = text.new_font_by_name("Courier", 12.0).build().unwrap();
+    let serif = text.new_font_by_name(SERIF, 20.0).build().unwrap();
+    let mono = text.new_font_by_name(MONO, 12.0).build().unwrap();
 
     let en_leading = text
         .new_text_layout(&font, SAMPLE_EN, 200.0)
         .alignment(TextAlignment::Start)
-        .add_attribute(10..40, 8.0)
+        .add_attribute(10..80, 8.0)
         .add_attribute(20..120, serif)
         .add_attribute(40..60, FontWeight::BOLD)
         .add_attribute(60..140, FontWeight::THIN)

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -1,0 +1,50 @@
+//! Styled text
+
+use crate::kurbo::Size;
+use crate::{
+    Color, Error, FontBuilder, FontWeight, RenderContext, Text, TextAlignment, TextAttribute,
+    TextLayoutBuilder,
+};
+
+pub const SIZE: Size = Size::new(400., 800.);
+
+static SAMPLE_EN: &str = r#"
+This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(Color::WHITE);
+    let text = rc.text();
+    let font = text.system_font(12.0);
+    let serif = text.new_font_by_name("Times", 20.0).build().unwrap();
+    let mono = text.new_font_by_name("Courier", 12.0).build().unwrap();
+
+    let en_leading = text
+        .new_text_layout(&font, SAMPLE_EN, 200.0)
+        .alignment(TextAlignment::Start)
+        .add_attribute(10..40, 8.0)
+        .add_attribute(20..120, serif)
+        .add_attribute(40..60, FontWeight::BOLD)
+        .add_attribute(60..140, FontWeight::THIN)
+        .add_attribute(90..300, mono)
+        .add_attribute(
+            120..150,
+            TextAttribute::ForegroundColor(Color::rgb(0.6, 0., 0.)),
+        )
+        .add_attribute(
+            160..190,
+            TextAttribute::ForegroundColor(Color::rgb(0., 0.6, 0.)),
+        )
+        .add_attribute(
+            200..240,
+            TextAttribute::ForegroundColor(Color::rgb(0., 0., 0.6)),
+        )
+        .add_attribute(200.., FontWeight::EXTRA_BLACK)
+        .add_attribute(220.., 18.0)
+        .add_attribute(240.., TextAttribute::Italic)
+        .add_attribute(280.., TextAttribute::Underline)
+        .build()?;
+
+    rc.draw_text(&en_leading, (0., 0.), &Color::BLACK);
+
+    Ok(())
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -31,6 +31,60 @@ pub trait FontBuilder {
 
 pub trait Font {}
 
+/// A font weight, represented as a value in the range 1..=1000.
+///
+/// This is based on the [CSS `font-weight`] property. In general, you should
+/// prefer the constants defined on this type, such as `FontWeight::REGULAR` or
+/// `FontWeight::BOLD`.
+///
+/// [CSS `font-weeight`]: https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FontWeight(u16);
+
+impl FontWeight {
+    pub const THIN: FontWeight = FontWeight(100);
+    pub const HAIRLINE: FontWeight = FontWeight::THIN;
+
+    pub const EXTRA_LIGHT: FontWeight = FontWeight(200);
+
+    pub const LIGHT: FontWeight = FontWeight(300);
+
+    pub const REGULAR: FontWeight = FontWeight(400);
+    pub const NORMAL: FontWeight = FontWeight::REGULAR;
+
+    pub const MEDIUM: FontWeight = FontWeight(500);
+
+    pub const SEMI_BOLD: FontWeight = FontWeight(600);
+
+    pub const BOLD: FontWeight = FontWeight(700);
+
+    pub const EXTRA_BOLD: FontWeight = FontWeight(800);
+
+    pub const BLACK: FontWeight = FontWeight(900);
+    pub const HEAVY: FontWeight = FontWeight::BLACK;
+
+    pub const EXTRA_BLACK: FontWeight = FontWeight(950);
+
+    /// Create a new `FontWeight` with a custom value.
+    ///
+    /// Values will be clamped to the range 1..=1000.
+    pub fn new(raw: u16) -> FontWeight {
+        let raw = raw.min(1000).max(1);
+        FontWeight(raw)
+    }
+
+    /// Return the raw value as a u16.
+    pub const fn to_raw(self) -> u16 {
+        self.0
+    }
+}
+
+impl Default for FontWeight {
+    fn default() -> Self {
+        FontWeight::REGULAR
+    }
+}
+
 pub trait TextLayoutBuilder {
     type Out: TextLayout;
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -1,6 +1,7 @@
 //! Code useful for multiple backends
 
 use crate::kurbo::{Rect, Size};
+use std::ops::{Bound, Range, RangeBounds};
 
 /// Counts the number of utf-16 code units in the given string.
 /// from xi-editor
@@ -38,6 +39,23 @@ pub fn count_until_utf16(s: &str, utf16_text_position: usize) -> Option<usize> {
     }
 
     None
+}
+
+/// Resolves a `RangeBounds` into a range in the range 0..len.
+pub fn resolve_range(range: impl RangeBounds<usize>, len: usize) -> Range<usize> {
+    let start = match range.start_bound() {
+        Bound::Unbounded => 0,
+        Bound::Included(n) => *n,
+        Bound::Excluded(n) => *n + 1,
+    };
+
+    let end = match range.end_bound() {
+        Bound::Unbounded => len,
+        Bound::Included(n) => *n + 1,
+        Bound::Excluded(n) => *n,
+    };
+
+    start.min(len)..end.min(len)
 }
 
 /// Extent to which to expand the blur.


### PR DESCRIPTION
This adds support for rich text, with implementations for mac and windows.

A few things are in a funny state as a result of this work:

***font construction***: currently to construct a font you pass a name and a size, and get back a `FontBuilder`; the idea at the time was likely that you would set properties like weight/style on this builder, and then build your font object. We're moving closer to a world like CSS, where you don't generally use font objects directly, but instead specify familes/sizes/weights individually on the layout. This has some API implications:
- `FontBuilder` can go, and methods that construct fonts can return `Option<Font>`.
- The `Text::font` method is semantically less about *creating* a font than it is about validating the existence of a font family.
- `TextLayoutBuilder` should get methods for setting the default attributes for the layout.
- `Text::new_text_layout` might also take an explicit size, if size is no longer included in the `Font` object.

***brushes and text drawing***: currently we pass a brush when drawing text. With this work we've moved to allowing text color to be set when constructing the layout. I think we should remove the brush argument when drawing text, but this _is_ a regression in the case of wanting to draw text with a gradient or similar. Making these things work well together is tricky, especially in a platform independent way; I haven't looked into it too seriously, but one option might be to make the `brush` argument optional, in which case it would override attributes on the layout when it was passed. Another option would be to let a 'default brush' be set on the layout, which would have the same behaviour. At least on macOS it is going to be difficult to support mixing of colored regions with things like gradient drawing, so I think it should be an either/or thing.