### PR TITLE
[cg] Add line_number_for_utf8_offset (and fix logic error)

### DIFF
--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -242,10 +242,7 @@ impl TextLayout for CoreGraphicsTextLayout {
     }
 
     fn hit_test_text_position(&self, offset: usize) -> Option<HitTestTextPosition> {
-        let line_num = match self.line_offsets.binary_search(&offset) {
-            Ok(line) => line.saturating_sub(1),
-            Err(line) => line.saturating_sub(1),
-        };
+        let line_num = self.line_number_for_utf8_offset(offset);
         let line: Line = self.unwrap_frame().get_line(line_num)?.into();
         let text = self.line_text(line_num)?;
 
@@ -297,6 +294,13 @@ impl CoreGraphicsTextLayout {
     #[inline]
     fn unwrap_frame(&self) -> &Frame {
         self.frame.as_ref().expect("always inited in ::new")
+    }
+
+    fn line_number_for_utf8_offset(&self, offset: usize) -> usize {
+        match self.line_offsets.binary_search(&offset) {
+            Ok(line) => line,
+            Err(line) => line.saturating_sub(1),
+        }
     }
 
     /// for each line in a layout, determine its offset in utf8.


### PR DESCRIPTION
This didn't matter when we didn't really support multi-line layout,
but this calculation was wrong at the start of lines.