### PR TITLE
Add TextLayout::size method

### DIFF
--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -370,6 +370,10 @@ impl TextLayout for CoreGraphicsTextLayout {
         self.frame_size.width
     }
 
+    fn size(&self) -> Size {
+        self.frame_size
+    }
+
     #[allow(clippy::float_cmp)]
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error> {
         let width = new_width.into().unwrap_or(f64::INFINITY);

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -2,7 +2,7 @@
 
 use std::ops::RangeBounds;
 
-use piet::kurbo::Point;
+use piet::kurbo::{Point, Size};
 use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric, TextAttribute};
 
 type Result<T> = std::result::Result<T, Error>;
@@ -88,6 +88,10 @@ pub struct TextLayout;
 
 impl piet::TextLayout for TextLayout {
     fn width(&self) -> f64 {
+        unimplemented!()
+    }
+
+    fn size(&self) -> Size {
         unimplemented!()
     }
 

--- a/piet-web/src/text/lines.rs
+++ b/piet-web/src/text/lines.rs
@@ -4,6 +4,7 @@
 // However, not cleaning up because cairo and web implementations should diverge soon; and putting this
 // code in `piet` core doesn't really make sense as it's implementation specific.
 //
+
 use web_sys::CanvasRenderingContext2d;
 use xi_unicode::LineBreakIterator;
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::ops::RangeBounds;
 
-use kurbo::{Affine, Point, Rect, Shape};
+use kurbo::{Affine, Point, Rect, Shape, Size};
 
 use crate::{
     Color, Error, FixedGradient, Font, FontBuilder, HitTestPoint, HitTestTextPosition, ImageFormat,
@@ -197,6 +197,10 @@ impl TextLayoutBuilder for NullTextLayoutBuilder {
 impl TextLayout for NullTextLayout {
     fn width(&self) -> f64 {
         42.0
+    }
+
+    fn size(&self) -> Size {
+        Size::ZERO
     }
 
     fn update_width(&mut self, _new_width: impl Into<Option<f64>>) -> Result<(), Error> {

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -31,7 +31,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     );
 
     let layout = make_text(rc.text(), "Segoe UI", 12., "Hello piet!");
-    let w: f64 = layout.width();
+    let w: f64 = layout.size().width;
     rc.draw_text(&layout, (80.0, 10.0), &RED_ALPHA);
 
     rc.stroke(Line::new((80.0, 12.0), (80.0 + w, 12.0)), &RED_ALPHA, 1.0);

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -22,7 +22,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
         .new_text_layout(&font, "piet text is the best text!", 50.0)
         .build()?;
 
-    let width = layout.width();
+    let width = layout.size().width;
 
     let brush = rc.solid_brush(Color::rgba8(0x00, 0x80, 0x80, 0xF0));
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Range, RangeBounds};
 
-use crate::kurbo::Point;
+use crate::kurbo::{Point, Size};
 use crate::Error;
 
 pub trait Text: Clone {
@@ -228,7 +228,23 @@ pub enum TextAlignment {
 ///
 pub trait TextLayout: Clone {
     /// Measure the advance width of the text.
+    #[deprecated(since = "0.2.0", note = "Use size().width insead")]
     fn width(&self) -> f64;
+
+    /// The total size of this `TextLayout`.
+    ///
+    /// This is the size required to draw this `TextLayout`, as provided by the
+    /// platform text system.
+    ///
+    /// # Note
+    ///
+    /// This is not currently defined very rigorously; in particular we do not
+    /// specify whether this should include half-leading or paragraph spacing
+    /// above or below the text.
+    ///
+    /// We would ultimately like to review and attempt to standardize this
+    /// behaviour, but it is out of scope for the time being.
+    fn size(&self) -> Size;
 
     /// Change the width of this `TextLayout`.
     ///


### PR DESCRIPTION
This replaces TextLayout::width; it is reasonable that the caller
would want to know the size of the entire layout, for things like
drawing a background or similar.