### PR TITLE
two text api tweaks

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -219,8 +219,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         let pos = pos.into();
 
         for lm in &layout.line_metrics {
-            self.ctx
-                .move_to(pos.x, pos.y + lm.cumulative_height - lm.height);
+            self.ctx.move_to(pos.x, pos.y + lm.y_offset);
             self.ctx
                 .show_text(&layout.text[lm.start_offset..lm.end_offset]);
         }

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -220,8 +220,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
 
         for lm in &layout.line_metrics {
             self.ctx.move_to(pos.x, pos.y + lm.y_offset);
-            self.ctx
-                .show_text(&layout.text[lm.start_offset..lm.end_offset]);
+            self.ctx.show_text(&layout.text[lm.range()]);
         }
     }
 

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -96,11 +96,9 @@ impl Text for CairoText {
 
         let line_metrics = lines::calculate_line_metrics(text, &font.0, width);
 
-        let widths = line_metrics.iter().map(|lm| {
-            font.0
-                .text_extents(&text[lm.start_offset..lm.end_offset])
-                .x_advance
-        });
+        let widths = line_metrics
+            .iter()
+            .map(|lm| font.0.text_extents(&text[lm.range()]).x_advance);
 
         let width = widths.fold(0.0, |a: f64, b| a.max(b));
 
@@ -163,11 +161,10 @@ impl TextLayout for CairoTextLayout {
 
         self.line_metrics = lines::calculate_line_metrics(&self.text, &self.font, new_width);
 
-        let widths = self.line_metrics.iter().map(|lm| {
-            self.font
-                .text_extents(&self.text[lm.start_offset..lm.end_offset])
-                .x_advance
-        });
+        let widths = self
+            .line_metrics
+            .iter()
+            .map(|lm| self.font.text_extents(&self.text[lm.range()]).x_advance);
 
         self.width = widths.fold(0.0, |a: f64, b| a.max(b));
 
@@ -177,7 +174,7 @@ impl TextLayout for CairoTextLayout {
     fn line_text(&self, line_number: usize) -> Option<&str> {
         self.line_metrics
             .get(line_number)
-            .map(|lm| &self.text[lm.start_offset..(lm.end_offset)])
+            .map(|lm| &self.text[lm.range()])
     }
 
     fn line_metric(&self, line_number: usize) -> Option<LineMetric> {
@@ -229,7 +226,7 @@ impl TextLayout for CairoTextLayout {
 
         // Then for the line, do hit test point
         // Trailing whitespace is remove for the line
-        let line = &self.text[lm.start_offset..lm.end_offset];
+        let line = &self.text[lm.range()];
 
         let mut htp = hit_test_line_point(&self.font, line, point);
         htp.metrics.text_position += lm.start_offset;
@@ -267,7 +264,7 @@ impl TextLayout for CairoTextLayout {
 
         // Then for the line, do text position
         // Trailing whitespace is removed for the line
-        let line = &self.text[lm.start_offset..lm.end_offset];
+        let line = &self.text[lm.range()];
         let line_position = text_position - lm.start_offset;
 
         let mut http = hit_test_line_position(&self.font, line, line_position);

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -213,7 +213,7 @@ impl TextLayout for CairoTextLayout {
         let mut lm = self
             .line_metrics
             .iter()
-            .skip_while(|l| l.cumulative_height - first_baseline < point.y);
+            .skip_while(|l| l.y_offset + l.height < point.y);
         let lm = lm
             .next()
             .or_else(|| {

--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -158,17 +158,20 @@ fn add_line_metric(
     cumulative_height: &mut f64,
     line_metrics: &mut Vec<LineMetric>,
 ) {
+    let y_offset = *cumulative_height;
     *cumulative_height += height;
 
     let line = &text[start_offset..end_offset];
     let trailing_whitespace = count_trailing_whitespace(line);
 
+    #[allow(deprecated)]
     let line_metric = LineMetric {
         start_offset,
         end_offset,
         trailing_whitespace,
         baseline,
         height,
+        y_offset,
         cumulative_height: *cumulative_height,
     };
     line_metrics.push(line_metric);
@@ -201,8 +204,8 @@ mod test {
             assert_eq!(metric.end_offset, exp.end_offset);
             assert_eq!(metric.trailing_whitespace, exp.trailing_whitespace);
             assert!(
-                metric.cumulative_height < exp.cumulative_height + ((i as f64 + 1.0) * 3.0)
-                    && metric.cumulative_height > exp.cumulative_height - ((i as f64 + 1.0) * 3.0)
+                metric.y_offset < exp.y_offset + ((i as f64 + 1.0) * 3.0)
+                    && metric.y_offset > exp.y_offset - ((i as f64 + 1.0) * 3.0)
             );
             assert!(metric.baseline < exp.baseline + 3.0 && metric.baseline > exp.baseline - 3.0);
             assert!(metric.height < exp.height + 3.0 && metric.height > exp.height - 3.0);
@@ -312,6 +315,7 @@ mod test {
     // - large is no split.
     //
     // Also test empty string input
+    #[allow(deprecated)]
     #[test]
     fn test_basic_calculate_line_metrics() {
         // Setup input, width, and expected
@@ -328,6 +332,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 5,
                 trailing_whitespace: 1,
+                y_offset: 0.,
                 cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -336,6 +341,7 @@ mod test {
                 start_offset: 5,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 14.0,
                 cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -344,6 +350,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 15,
                 trailing_whitespace: 1,
+                y_offset: 28.0,
                 cumulative_height: 42.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -352,6 +359,7 @@ mod test {
                 start_offset: 15,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 42.0,
                 cumulative_height: 56.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -364,6 +372,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -372,6 +381,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 14.0,
                 cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -383,6 +393,7 @@ mod test {
             start_offset: 0,
             end_offset: 19,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 14.0,
             baseline: 12.0,
             height: 14.0,
@@ -393,6 +404,7 @@ mod test {
             start_offset: 0,
             end_offset: 0,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 14.0,
             baseline: 12.0,
             height: 14.0,
@@ -422,6 +434,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     #[cfg(target_os = "linux")]
     // TODO determine if we need to test macos too for this. I don't think it's a big deal right
     // now, just wanted to make sure hard breaks work.
@@ -440,6 +453,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 5,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -448,6 +462,7 @@ mod test {
                 start_offset: 5,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 14.0,
                 cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -456,6 +471,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 15,
                 trailing_whitespace: 1,
+                y_offset: 28.0,
                 cumulative_height: 42.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -464,6 +480,7 @@ mod test {
                 start_offset: 15,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 42.0,
                 cumulative_height: 56.0,
                 baseline: 12.0,
                 height: 14.0,

--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -200,8 +200,7 @@ mod test {
         for (i, (metric, exp)) in line_metrics.iter().zip(expected).enumerate() {
             println!("calculated: {:?}\nexpected: {:?}", metric, exp);
 
-            assert_eq!(metric.start_offset, exp.start_offset);
-            assert_eq!(metric.end_offset, exp.end_offset);
+            assert_eq!(metric.range(), exp.range());
             assert_eq!(metric.trailing_whitespace, exp.trailing_whitespace);
             assert!(
                 metric.y_offset < exp.y_offset + ((i as f64 + 1.0) * 3.0)
@@ -263,7 +262,7 @@ mod test {
             font.0.text_extents("piet text ").x_advance
         );
         for lm in &line_metrics {
-            let line_text = &input[lm.start_offset..lm.end_offset];
+            let line_text = &input[lm.range()];
             println!(
                 "{}: {:?}",
                 font.0.text_extents(line_text).x_advance,
@@ -290,7 +289,7 @@ mod test {
         println!("{}: \"piet\n\"", font.0.text_extents("piet\n").x_advance);
         println!("{}: \"text\"", font.0.text_extents("text").x_advance);
         for lm in &line_metrics {
-            let line_text = &input[lm.start_offset..lm.end_offset];
+            let line_text = &input[lm.range()];
             println!(
                 "{}: {:?}",
                 font.0.text_extents(line_text).x_advance,

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -633,14 +633,12 @@ mod tests {
                 .unwrap();
 
         let line1 = layout.line_metric(0).unwrap();
-        assert_eq!(line1.start_offset, 0);
-        assert_eq!(line1.end_offset, 6);
+        assert_eq!(line1.range(), 0..6);
         assert_eq!(line1.trailing_whitespace, 1);
         layout.line_metric(1);
 
         let line3 = layout.line_metric(2).unwrap();
-        assert_eq!(line3.start_offset, 15);
-        assert_eq!(line3.end_offset, 30);
+        assert_eq!(line3.range(), 15..30);
         assert_eq!(line3.trailing_whitespace, 2);
 
         let line4 = layout.line_metric(3).unwrap();

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -14,11 +14,13 @@ pub(crate) fn fetch_line_metrics(layout: &dwrite::TextLayout) -> Vec<LineMetric>
 
             let cumulative_height = *height_agg + line_metric.height as f64;
 
+            #[allow(deprecated)]
             let res = LineMetric {
                 start_offset,
                 end_offset,
                 trailing_whitespace,
                 height: line_metric.height as f64,
+                y_offset: *height_agg,
                 cumulative_height,
                 baseline: line_metric.baseline as f64,
             };
@@ -68,6 +70,7 @@ mod test {
     //
     // TODO figure out how to deal with height floats
     #[test]
+    #[allow(deprecated)]
     fn test_fetch_line_metrics() {
         // Setup input, width, and expected
         let input = "piet text most best";
@@ -78,6 +81,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 5,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 15.960_937_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -86,6 +90,7 @@ mod test {
                 start_offset: 5,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 15.960_937_5,
                 cumulative_height: 31.921_875,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -94,6 +99,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 15,
                 trailing_whitespace: 1,
+                y_offset: 31.921_875,
                 cumulative_height: 47.882_812_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -102,6 +108,7 @@ mod test {
                 start_offset: 15,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 47.882_812_5,
                 cumulative_height: 63.843_75,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -114,6 +121,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 15.960_937_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -122,6 +130,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 15.960_937_5,
                 cumulative_height: 31.921_875,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -133,6 +142,7 @@ mod test {
             start_offset: 0,
             end_offset: 19,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 15.960_937_5,
             baseline: 12.949_218_75,
             height: 15.960_937_5,
@@ -143,6 +153,7 @@ mod test {
             start_offset: 0,
             end_offset: 0,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 15.960_937_5,
             baseline: 12.949_218_75,
             height: 15.960_937_5,

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -229,7 +229,7 @@ impl RenderContext for WebRenderContext {
                 .fill_text(
                     &layout.text[lm.start_offset..lm.end_offset],
                     pos.x,
-                    pos.y + lm.cumulative_height - lm.height,
+                    pos.y + lm.y_offset,
                 )
                 .wrap();
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -229,7 +229,7 @@ impl TextLayout for WebTextLayout {
         let mut lm = self
             .line_metrics
             .iter()
-            .skip_while(|l| l.cumulative_height - first_baseline < point.y);
+            .skip_while(|l| l.y_offset + l.height < point.y);
         let lm = lm
             .next()
             .or_else(|| {

--- a/piet-web/src/text/lines.rs
+++ b/piet-web/src/text/lines.rs
@@ -172,11 +172,13 @@ fn add_line_metric(
     cumulative_height: &mut f64,
     line_metrics: &mut Vec<LineMetric>,
 ) {
+    let y_offset = *cumulative_height;
     *cumulative_height += height;
 
     let line = &text[start_offset..end_offset];
     let trailing_whitespace = count_trailing_whitespace(line);
 
+    #[allow(deprecated)]
     let line_metric = LineMetric {
         start_offset,
         end_offset,
@@ -184,6 +186,7 @@ fn add_line_metric(
         baseline,
         height,
         cumulative_height: *cumulative_height,
+        y_offset,
     };
     line_metrics.push(line_metric);
 }

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -12,6 +12,7 @@ mod picture_5;
 mod picture_6;
 mod picture_7;
 mod picture_8;
+mod picture_9;
 
 use picture_0::draw as draw_picture_0;
 use picture_1::draw as draw_picture_1;
@@ -22,6 +23,7 @@ use picture_5::draw as draw_picture_5;
 use picture_6::draw as draw_picture_6;
 use picture_7::draw as draw_picture_7;
 use picture_8::draw as draw_picture_8;
+use picture_9::draw as draw_picture_9;
 
 /// Draw a test picture, by number.
 ///
@@ -38,6 +40,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         6 => draw_picture_6(rc),
         7 => draw_picture_7(rc),
         8 => draw_picture_8(rc),
+        9 => draw_picture_9(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",
@@ -59,6 +62,7 @@ pub fn size_for_test_picture(number: usize) -> Result<Size, Error> {
         6 => Ok(picture_6::SIZE),
         7 => Ok(picture_7::SIZE),
         8 => Ok(picture_8::SIZE),
+        9 => Ok(picture_9::SIZE),
         other => {
             eprintln!("test picture {} does not exist.", other);
             Err(Error::InvalidInput)

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -1,0 +1,65 @@
+//! Verifying line metrics and text layout geometry behave as intended.
+
+use crate::kurbo::{Line, Size, Vec2};
+use crate::{
+    Color, Error, FontBuilder, RenderContext, Text, TextAlignment, TextAttribute, TextLayout,
+    TextLayoutBuilder,
+};
+
+pub const SIZE: Size = Size::new(400., 800.);
+
+static SAMPLE_EN: &str = r#"1nnyyÊbbbb soft break
+2nnyyÊbbbb
+3nnyyÊbbbb
+4nnyyÊbbbb
+5nnyyÊbbbb
+6nnyyÊbbbb
+7nnyyÊbbbb
+"#;
+
+const RED: Color = Color::rgb8(255, 0, 0);
+const BLUE: Color = Color::rgb8(0, 0, 255);
+const YELLOW: Color = Color::rgb8(255, 255, 0);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(Color::WHITE);
+    let text = rc.text();
+    let font = text.system_font(24.0);
+    let mono = text
+        .new_font_by_name("Courier New", 18.0)
+        .build()
+        .expect("missing Courier New");
+
+    let layout = text
+        .new_text_layout(&font, SAMPLE_EN, 200.0)
+        .alignment(TextAlignment::Start)
+        .add_attribute(23..35, mono.clone())
+        .add_attribute(23..35, TextAttribute::Size(18.0))
+        .add_attribute(47..52, mono)
+        .add_attribute(47..52, TextAttribute::Size(36.0))
+        .build()?;
+
+    let text_pos = Vec2::new(0.0, 50.0);
+
+    for idx in 0..layout.line_count() {
+        let metrics = layout.line_metric(idx).unwrap();
+        let line_width = 200.0;
+
+        let top = text_pos.y + metrics.y_offset;
+        let line_top = Line::new((0.0, top), (line_width, top));
+
+        let baseline = metrics.y_offset + metrics.baseline + text_pos.y;
+        let baseline_line = Line::new((0., baseline), (line_width, baseline));
+
+        let bottom = metrics.y_offset + metrics.height + text_pos.y;
+        let bottom_line = Line::new((0., bottom), (line_width, bottom));
+
+        rc.stroke(line_top, &RED, 1.0);
+        rc.stroke(baseline_line, &YELLOW, 1.0);
+        rc.stroke(bottom_line, &BLUE, 1.0);
+    }
+
+    rc.draw_text(&layout, text_pos.to_point(), &Color::BLACK);
+
+    Ok(())
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -306,17 +306,24 @@ pub struct LineMetric {
     /// Includes trailing whitespace.
     pub end_offset: usize,
 
-    /// Length in (in UTF-8 code units) of current line's trailing whitespace.
+    /// The length of the trailing whitespace at the end of this line, in utf-8 code units.
     pub trailing_whitespace: usize,
 
-    /// Distance of the baseline from the top of the line
+    /// The distance from the top of the line (`y_offset`) to the baseline.
     pub baseline: f64,
 
-    /// Line height
+    /// The height of the line.
     pub height: f64,
 
     /// Cumulative line height (includes previous line heights)
+    #[deprecated(since = "0.2.0", note = "use y_offset instead")]
     pub cumulative_height: f64,
+
+    /// The y position of the top of this line, relative to the top of the layout.
+    ///
+    /// It should be possible to use this position, in conjunction with `height`,
+    /// to determine the region that would be used for things like text selection.
+    pub y_offset: f64,
 }
 
 /// return values for [`hit_test_point`](../piet/trait.TextLayout.html#tymethod.hit_test_point).

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -1,6 +1,6 @@
 //! Traits for fonts and text handling.
 
-use std::ops::RangeBounds;
+use std::ops::{Range, RangeBounds};
 
 use crate::kurbo::Point;
 use crate::Error;
@@ -297,13 +297,20 @@ pub trait TextLayout: Clone {
 /// Metadata about each line in a text layout.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LineMetric {
-    /// Index (in code units) of the start of the line, offset from the beginning of the text.
+    /// The start index of this line in the underlying `String` used to create the
+    /// [`TextLayout`] to which this line belongs.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
     pub start_offset: usize,
 
-    /// Line length (in UTF-8 code units), but offset from the beginning of the text. So it's the length
-    /// of this line summed with the lengths of all the lines before it.
+    /// The end index of this line in the underlying `String` used to create the
+    /// [`TextLayout`] to which this line belongs.
+    ///
+    /// This is the end of an exclusive range; this index is not part of the line.
     ///
     /// Includes trailing whitespace.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
     pub end_offset: usize,
 
     /// The length of the trailing whitespace at the end of this line, in utf-8 code units.
@@ -324,6 +331,17 @@ pub struct LineMetric {
     /// It should be possible to use this position, in conjunction with `height`,
     /// to determine the region that would be used for things like text selection.
     pub y_offset: f64,
+}
+
+impl LineMetric {
+    /// The utf-8 range in the underlying `String` used to create the
+    /// [`TextLayout`] to which this line belongs.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
+    #[inline]
+    pub fn range(&self) -> Range<usize> {
+        self.start_offset..self.end_offset
+    }
 }
 
 /// return values for [`hit_test_point`](../piet/trait.TextLayout.html#tymethod.hit_test_point).


### PR DESCRIPTION
This is based off of #229, and makes a few changes and additions to the text API.

In 88f3a02, `LineMetric::cumulative_height` is replaced with `LineMetric::y_offset`, which (I think) better communicates the intent of this value, which is to determine the position of the line relative to the origin of the layout.

in 683033f, I just add a `range()` method to `LineMetric`. I had initially wanted to replace `start_offset` and `end_offset` with a single `range: Range<usize>` member, but this didn't end up feeling much more ergonomic, and was a fairly invasive change.