### PR TITLE
Use top-left as text origin

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -219,8 +219,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         let pos = pos.into();
 
         for lm in &layout.line_metrics {
-            self.ctx
-                .move_to(pos.x, pos.y + lm.cumulative_height - lm.height);
+            self.ctx.move_to(pos.x, pos.y + lm.y_offset);
             self.ctx.show_text(&layout.text[lm.range()]);
         }
     }

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -219,7 +219,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         let pos = pos.into();
 
         for lm in &layout.line_metrics {
-            self.ctx.move_to(pos.x, pos.y + lm.y_offset);
+            self.ctx.move_to(pos.x, pos.y + lm.y_offset + lm.baseline);
             self.ctx.show_text(&layout.text[lm.range()]);
         }
     }

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -173,7 +173,7 @@ impl TextLayout for CairoTextLayout {
         let height = self
             .line_metrics
             .last()
-            .map(|l| l.cumulative_height)
+            .map(|l| l.y_offset + l.height)
             .unwrap_or_default();
         self.size = Size::new(width, height);
 
@@ -219,7 +219,7 @@ impl TextLayout for CairoTextLayout {
         let mut lm = self
             .line_metrics
             .iter()
-            .skip_while(|l| l.cumulative_height - first_baseline < point.y);
+            .skip_while(|l| l.y_offset + l.height - l.baseline < point.y);
         let lm = lm
             .next()
             .or_else(|| {

--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -158,17 +158,20 @@ fn add_line_metric(
     cumulative_height: &mut f64,
     line_metrics: &mut Vec<LineMetric>,
 ) {
+    let y_offset = *cumulative_height;
     *cumulative_height += height;
 
     let line = &text[start_offset..end_offset];
     let trailing_whitespace = count_trailing_whitespace(line);
 
+    #[allow(deprecated)]
     let line_metric = LineMetric {
         start_offset,
         end_offset,
         trailing_whitespace,
         baseline,
         height,
+        y_offset,
         cumulative_height: *cumulative_height,
     };
     line_metrics.push(line_metric);
@@ -200,8 +203,8 @@ mod test {
             assert_eq!(metric.range(), exp.range());
             assert_eq!(metric.trailing_whitespace, exp.trailing_whitespace);
             assert!(
-                metric.cumulative_height < exp.cumulative_height + ((i as f64 + 1.0) * 3.0)
-                    && metric.cumulative_height > exp.cumulative_height - ((i as f64 + 1.0) * 3.0)
+                metric.y_offset < exp.y_offset + ((i as f64 + 1.0) * 3.0)
+                    && metric.y_offset > exp.y_offset - ((i as f64 + 1.0) * 3.0)
             );
             assert!(metric.baseline < exp.baseline + 3.0 && metric.baseline > exp.baseline - 3.0);
             assert!(metric.height < exp.height + 3.0 && metric.height > exp.height - 3.0);
@@ -311,6 +314,7 @@ mod test {
     // - large is no split.
     //
     // Also test empty string input
+    #[allow(deprecated)]
     #[test]
     fn test_basic_calculate_line_metrics() {
         // Setup input, width, and expected
@@ -327,6 +331,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 5,
                 trailing_whitespace: 1,
+                y_offset: 0.,
                 cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -335,6 +340,7 @@ mod test {
                 start_offset: 5,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 14.0,
                 cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -343,6 +349,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 15,
                 trailing_whitespace: 1,
+                y_offset: 28.0,
                 cumulative_height: 42.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -351,6 +358,7 @@ mod test {
                 start_offset: 15,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 42.0,
                 cumulative_height: 56.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -363,6 +371,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -371,6 +380,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 14.0,
                 cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -382,6 +392,7 @@ mod test {
             start_offset: 0,
             end_offset: 19,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 14.0,
             baseline: 12.0,
             height: 14.0,
@@ -392,6 +403,7 @@ mod test {
             start_offset: 0,
             end_offset: 0,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 14.0,
             baseline: 12.0,
             height: 14.0,
@@ -421,6 +433,7 @@ mod test {
     }
 
     #[test]
+    #[allow(deprecated)]
     #[cfg(target_os = "linux")]
     // TODO determine if we need to test macos too for this. I don't think it's a big deal right
     // now, just wanted to make sure hard breaks work.
@@ -439,6 +452,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 5,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -447,6 +461,7 @@ mod test {
                 start_offset: 5,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 14.0,
                 cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -455,6 +470,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 15,
                 trailing_whitespace: 1,
+                y_offset: 28.0,
                 cumulative_height: 42.0,
                 baseline: 12.0,
                 height: 14.0,
@@ -463,6 +479,7 @@ mod test {
                 start_offset: 15,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 42.0,
                 cumulative_height: 56.0,
                 baseline: 12.0,
                 height: 14.0,

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -420,11 +420,15 @@ impl TextLayout for CoreGraphicsTextLayout {
                 _ => false,
             })
             .count();
-        let height = typo_bounds.ascent + typo_bounds.descent + typo_bounds.leading;
         // this may not be exactly right, but i'm also not sure we ever use this?
         //  see https://stackoverflow.com/questions/5511830/how-does-line-spacing-work-in-core-text-and-why-is-it-different-from-nslayoutm
-        let cumulative_height =
-            (self.line_y_positions[line_number] + typo_bounds.descent + typo_bounds.leading).ceil();
+        let ascent = (typo_bounds.ascent + 0.5).floor();
+        let descent = (typo_bounds.descent + 0.5).floor();
+        let leading = (typo_bounds.leading + 0.5).floor();
+        let height = ascent + descent + leading;
+        let y_offset = self.line_y_positions[line_number] - ascent;
+        let cumulative_height = self.line_y_positions[line_number] + descent + leading;
+        #[allow(deprecated)]
         Some(LineMetric {
             start_offset,
             end_offset,
@@ -432,6 +436,7 @@ impl TextLayout for CoreGraphicsTextLayout {
             baseline: typo_bounds.ascent,
             height,
             cumulative_height,
+            y_offset,
         })
     }
 
@@ -646,7 +651,7 @@ mod tests {
         assert_eq!(line4.trailing_whitespace, 0);
 
         let total_height = layout.frame_size.height;
-        assert_eq!(line4.cumulative_height, total_height);
+        assert_eq!(line4.y_offset + line4.height, total_height);
 
         assert!(layout.line_metric(4).is_none());
     }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -288,9 +288,8 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             // Layout is empty, don't bother drawing.
             return;
         }
-        // Direct2D takes upper-left, so adjust for baseline.
-        let mut pos = to_point2f(pos.into());
-        pos.y -= line_metrics[0].baseline;
+
+        let pos = to_point2f(pos.into());
         let text_options = D2D1_DRAW_TEXT_OPTIONS_NONE;
 
         self.rt

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -14,11 +14,13 @@ pub(crate) fn fetch_line_metrics(layout: &dwrite::TextLayout) -> Vec<LineMetric>
 
             let cumulative_height = *height_agg + line_metric.height as f64;
 
+            #[allow(deprecated)]
             let res = LineMetric {
                 start_offset,
                 end_offset,
                 trailing_whitespace,
                 height: line_metric.height as f64,
+                y_offset: *height_agg,
                 cumulative_height,
                 baseline: line_metric.baseline as f64,
             };
@@ -68,6 +70,7 @@ mod test {
     //
     // TODO figure out how to deal with height floats
     #[test]
+    #[allow(deprecated)]
     fn test_fetch_line_metrics() {
         // Setup input, width, and expected
         let input = "piet text most best";
@@ -78,6 +81,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 5,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 15.960_937_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -86,6 +90,7 @@ mod test {
                 start_offset: 5,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 15.960_937_5,
                 cumulative_height: 31.921_875,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -94,6 +99,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 15,
                 trailing_whitespace: 1,
+                y_offset: 31.921_875,
                 cumulative_height: 47.882_812_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -102,6 +108,7 @@ mod test {
                 start_offset: 15,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 47.882_812_5,
                 cumulative_height: 63.843_75,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -114,6 +121,7 @@ mod test {
                 start_offset: 0,
                 end_offset: 10,
                 trailing_whitespace: 1,
+                y_offset: 0.0,
                 cumulative_height: 15.960_937_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -122,6 +130,7 @@ mod test {
                 start_offset: 10,
                 end_offset: 19,
                 trailing_whitespace: 0,
+                y_offset: 15.960_937_5,
                 cumulative_height: 31.921_875,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
@@ -133,6 +142,7 @@ mod test {
             start_offset: 0,
             end_offset: 19,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 15.960_937_5,
             baseline: 12.949_218_75,
             height: 15.960_937_5,
@@ -143,6 +153,7 @@ mod test {
             start_offset: 0,
             end_offset: 0,
             trailing_whitespace: 0,
+            y_offset: 0.0,
             cumulative_height: 15.960_937_5,
             baseline: 12.949_218_75,
             height: 15.960_937_5,

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -226,11 +226,7 @@ impl RenderContext for WebRenderContext {
         for lm in &layout.line_metrics {
             let draw_line = self
                 .ctx
-                .fill_text(
-                    &layout.text[lm.start_offset..lm.end_offset],
-                    pos.x,
-                    pos.y + lm.y_offset,
-                )
+                .fill_text(&layout.text[lm.start_offset..lm.end_offset], pos.x, pos.y)
                 .wrap();
 
             if let Err(e) = draw_line {

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -229,7 +229,7 @@ impl RenderContext for WebRenderContext {
                 .fill_text(
                     &layout.text[lm.start_offset..lm.end_offset],
                     pos.x,
-                    pos.y + lm.cumulative_height - lm.height,
+                    pos.y + lm.y_offset,
                 )
                 .wrap();
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -184,7 +184,7 @@ impl TextLayout for WebTextLayout {
             .fold(0., f64::max);
         let height = line_metrics
             .last()
-            .map(|l| l.cumulative_height)
+            .map(|l| l.y_offset + l.height)
             .unwrap_or_default();
         self.line_metrics = line_metrics;
         self.size = Size::new(max_width, height);
@@ -229,7 +229,7 @@ impl TextLayout for WebTextLayout {
         let mut lm = self
             .line_metrics
             .iter()
-            .skip_while(|l| l.cumulative_height - first_baseline < point.y);
+            .skip_while(|l| l.y_offset + l.height < point.y);
         let lm = lm
             .next()
             .or_else(|| {

--- a/piet-web/src/text/lines.rs
+++ b/piet-web/src/text/lines.rs
@@ -173,11 +173,13 @@ fn add_line_metric(
     cumulative_height: &mut f64,
     line_metrics: &mut Vec<LineMetric>,
 ) {
+    let y_offset = *cumulative_height;
     *cumulative_height += height;
 
     let line = &text[start_offset..end_offset];
     let trailing_whitespace = count_trailing_whitespace(line);
 
+    #[allow(deprecated)]
     let line_metric = LineMetric {
         start_offset,
         end_offset,
@@ -185,6 +187,7 @@ fn add_line_metric(
         baseline,
         height,
         cumulative_height: *cumulative_height,
+        y_offset,
     };
     line_metrics.push(line_metric);
 }

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -12,6 +12,7 @@ mod picture_5;
 mod picture_6;
 mod picture_7;
 mod picture_8;
+mod picture_9;
 
 use picture_0::draw as draw_picture_0;
 use picture_1::draw as draw_picture_1;
@@ -22,6 +23,7 @@ use picture_5::draw as draw_picture_5;
 use picture_6::draw as draw_picture_6;
 use picture_7::draw as draw_picture_7;
 use picture_8::draw as draw_picture_8;
+use picture_9::draw as draw_picture_9;
 
 /// Draw a test picture, by number.
 ///
@@ -38,6 +40,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         6 => draw_picture_6(rc),
         7 => draw_picture_7(rc),
         8 => draw_picture_8(rc),
+        9 => draw_picture_9(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",
@@ -59,6 +62,7 @@ pub fn size_for_test_picture(number: usize) -> Result<Size, Error> {
         6 => Ok(picture_6::SIZE),
         7 => Ok(picture_7::SIZE),
         8 => Ok(picture_8::SIZE),
+        9 => Ok(picture_9::SIZE),
         other => {
             eprintln!("test picture {} does not exist.", other);
             Err(Error::InvalidInput)

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -8,8 +8,7 @@ use crate::{
 
 pub const SIZE: Size = Size::new(400., 800.);
 
-static SAMPLE_EN: &str = r#"
-This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
+static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
 const SERIF: &str = "Times New Roman";
 #[cfg(target_os = "windows")]

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -1,0 +1,68 @@
+//! Verifying line metrics and text layout geometry behave as intended.
+
+use crate::kurbo::{Line, Size, Vec2};
+use crate::{
+    Color, Error, FontBuilder, RenderContext, Text, TextAlignment, TextAttribute, TextLayout,
+    TextLayoutBuilder,
+};
+
+pub const SIZE: Size = Size::new(464., 800.);
+
+static SAMPLE_EN: &str = r#"1nnyyÊbbbb soft break
+2nnyyÊbbbb
+3nnyyÊbbbb
+4nnyyÊbbbb
+5nnyyÊbbbb
+6nnyyÊbbbb
+7nnyyÊbbbb
+"#;
+
+const LIGHT_GREY: Color = Color::grey8(0xc0);
+const RED: Color = Color::rgb8(255, 0, 0);
+const BLUE: Color = Color::rgb8(0, 0, 255);
+const YELLOW: Color = Color::rgb8(255, 255, 0);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(LIGHT_GREY);
+    let text = rc.text();
+    let font = text.system_font(24.0);
+    let mono = text
+        .new_font_by_name("Courier New", 18.0)
+        .build()
+        .expect("missing Courier New");
+
+    let layout = text
+        .new_text_layout(&font, SAMPLE_EN, 200.0)
+        .alignment(TextAlignment::Start)
+        .add_attribute(23..35, mono.clone())
+        .add_attribute(23..35, TextAttribute::Size(18.0))
+        .add_attribute(47..52, mono)
+        .add_attribute(47..52, TextAttribute::Size(36.0))
+        .build()?;
+
+    let text_pos = Vec2::new(0.0, 50.0);
+    let layout_rect = layout.size().to_rect() + text_pos;
+    rc.fill(layout_rect, &Color::WHITE);
+
+    for idx in 0..layout.line_count() {
+        let metrics = layout.line_metric(idx).unwrap();
+        let line_width = 200.0;
+
+        let top = text_pos.y + metrics.y_offset;
+        let line_top = Line::new((0.0, top), (line_width, top));
+
+        let baseline = metrics.y_offset + metrics.baseline + text_pos.y;
+        let baseline_line = Line::new((0., baseline), (line_width, baseline));
+
+        let bottom = metrics.y_offset + metrics.height + text_pos.y;
+        let bottom_line = Line::new((0., bottom), (line_width, bottom));
+
+        rc.stroke(line_top, &RED, 1.0);
+        rc.stroke(baseline_line, &YELLOW, 1.0);
+        rc.stroke(bottom_line, &BLUE, 1.0);
+    }
+
+    rc.draw_text(&layout, text_pos.to_point(), &Color::BLACK);
+
+    Ok(())
+}

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -20,7 +20,7 @@ static SAMPLE_EN: &str = r#"1nnyyÊbbbb soft break
 const LIGHT_GREY: Color = Color::grey8(0xc0);
 const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);
-const YELLOW: Color = Color::rgb8(255, 255, 0);
+const GREEN: Color = Color::rgb8(105, 255, 0);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
@@ -58,7 +58,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         let bottom_line = Line::new((0., bottom), (line_width, bottom));
 
         rc.stroke(line_top, &RED, 1.0);
-        rc.stroke(baseline_line, &YELLOW, 1.0);
+        rc.stroke(baseline_line, &GREEN, 1.0);
         rc.stroke(bottom_line, &BLUE, 1.0);
     }
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -379,7 +379,12 @@ pub struct HitTestPoint {
 /// return values for [`hit_test_text_position`](../piet/trait.TextLayout.html#tymethod.hit_test_text_position).
 #[derive(Debug, Default)]
 pub struct HitTestTextPosition {
-    /// the `point`'s `x` value is the position of the leading edge of the grapheme cluster containing the text position.
+    /// the `point`'s `x` value is the position of the leading edge of the
+    /// grapheme cluster containing the text position. The `y` value corresponds
+    /// to the baseline of the line containing that grapheme cluster.
+    //FIXME: maybe we should communicate more about this position? for instance
+    //instead of returning an x/y point, we could return the x offset, the line's y_offset,
+    //and the line height (everything tou would need to draw a cursor)
     pub point: Point,
     /// `metrics.text_position` will give you the text position.
     pub metrics: HitTestMetrics,

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -329,17 +329,29 @@ pub struct LineMetric {
     /// [`TextLayout`]: trait.TextLayout.html
     pub end_offset: usize,
 
-    /// Length in (in UTF-8 code units) of current line's trailing whitespace.
+    /// The length of the trailing whitespace at the end of this line, in utf-8 code units.
     pub trailing_whitespace: usize,
 
-    /// Distance of the baseline from the top of the line
+    /// The distance from the top of the line (`y_offset`) to the baseline.
     pub baseline: f64,
 
-    /// Line height
+    /// The height of the line.
+    ///
+    /// This value is intended to be used to determine the height of features
+    /// such as cursors and selection regions. Although it is generally the case
+    /// that `y_offset + height` for line `n` is equal to the `y_offset` of
+    /// line `n + 1`, this is not strictly enforced, and should not be counted on.
     pub height: f64,
 
     /// Cumulative line height (includes previous line heights)
+    #[deprecated(since = "0.2.0", note = "use y_offset instead")]
     pub cumulative_height: f64,
+
+    /// The y position of the top of this line, relative to the top of the layout.
+    ///
+    /// It should be possible to use this position, in conjunction with `height`,
+    /// to determine the region that would be used for things like text selection.
+    pub y_offset: f64,
 }
 
 impl LineMetric {


### PR DESCRIPTION
This changes behaviour and will likely break text in druid, but that's future work.

in addition, LineMetric::cumulative_height is replaced with LineMetric::y_offset, which (I think) better communicates the intent of this value, which is to determine the position of the line relative to the origin of the layout.

(draft so I can run CI)