### PR TITLE
Add TextLayout::range convenience method

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -221,8 +221,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         for lm in &layout.line_metrics {
             self.ctx
                 .move_to(pos.x, pos.y + lm.cumulative_height - lm.height);
-            self.ctx
-                .show_text(&layout.text[lm.start_offset..lm.end_offset]);
+            self.ctx.show_text(&layout.text[lm.range()]);
         }
     }
 

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -96,11 +96,9 @@ impl Text for CairoText {
 
         let line_metrics = lines::calculate_line_metrics(text, &font.0, width);
 
-        let widths = line_metrics.iter().map(|lm| {
-            font.0
-                .text_extents(&text[lm.start_offset..lm.end_offset])
-                .x_advance
-        });
+        let widths = line_metrics
+            .iter()
+            .map(|lm| font.0.text_extents(&text[lm.range()]).x_advance);
 
         let width = widths.fold(0.0, |a: f64, b| a.max(b));
 
@@ -163,11 +161,10 @@ impl TextLayout for CairoTextLayout {
 
         self.line_metrics = lines::calculate_line_metrics(&self.text, &self.font, new_width);
 
-        let widths = self.line_metrics.iter().map(|lm| {
-            self.font
-                .text_extents(&self.text[lm.start_offset..lm.end_offset])
-                .x_advance
-        });
+        let widths = self
+            .line_metrics
+            .iter()
+            .map(|lm| self.font.text_extents(&self.text[lm.range()]).x_advance);
 
         self.width = widths.fold(0.0, |a: f64, b| a.max(b));
 
@@ -177,7 +174,7 @@ impl TextLayout for CairoTextLayout {
     fn line_text(&self, line_number: usize) -> Option<&str> {
         self.line_metrics
             .get(line_number)
-            .map(|lm| &self.text[lm.start_offset..(lm.end_offset)])
+            .map(|lm| &self.text[lm.range()])
     }
 
     fn line_metric(&self, line_number: usize) -> Option<LineMetric> {
@@ -229,7 +226,7 @@ impl TextLayout for CairoTextLayout {
 
         // Then for the line, do hit test point
         // Trailing whitespace is remove for the line
-        let line = &self.text[lm.start_offset..lm.end_offset];
+        let line = &self.text[lm.range()];
 
         let mut htp = hit_test_line_point(&self.font, line, point);
         htp.metrics.text_position += lm.start_offset;
@@ -267,7 +264,7 @@ impl TextLayout for CairoTextLayout {
 
         // Then for the line, do text position
         // Trailing whitespace is removed for the line
-        let line = &self.text[lm.start_offset..lm.end_offset];
+        let line = &self.text[lm.range()];
         let line_position = text_position - lm.start_offset;
 
         let mut http = hit_test_line_position(&self.font, line, line_position);

--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -197,8 +197,7 @@ mod test {
         for (i, (metric, exp)) in line_metrics.iter().zip(expected).enumerate() {
             println!("calculated: {:?}\nexpected: {:?}", metric, exp);
 
-            assert_eq!(metric.start_offset, exp.start_offset);
-            assert_eq!(metric.end_offset, exp.end_offset);
+            assert_eq!(metric.range(), exp.range());
             assert_eq!(metric.trailing_whitespace, exp.trailing_whitespace);
             assert!(
                 metric.cumulative_height < exp.cumulative_height + ((i as f64 + 1.0) * 3.0)
@@ -260,7 +259,7 @@ mod test {
             font.0.text_extents("piet text ").x_advance
         );
         for lm in &line_metrics {
-            let line_text = &input[lm.start_offset..lm.end_offset];
+            let line_text = &input[lm.range()];
             println!(
                 "{}: {:?}",
                 font.0.text_extents(line_text).x_advance,
@@ -287,7 +286,7 @@ mod test {
         println!("{}: \"piet\n\"", font.0.text_extents("piet\n").x_advance);
         println!("{}: \"text\"", font.0.text_extents("text").x_advance);
         for lm in &line_metrics {
-            let line_text = &input[lm.start_offset..lm.end_offset];
+            let line_text = &input[lm.range()];
             println!(
                 "{}: {:?}",
                 font.0.text_extents(line_text).x_advance,

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -629,14 +629,12 @@ mod tests {
                 .unwrap();
 
         let line1 = layout.line_metric(0).unwrap();
-        assert_eq!(line1.start_offset, 0);
-        assert_eq!(line1.end_offset, 6);
+        assert_eq!(line1.range(), 0..6);
         assert_eq!(line1.trailing_whitespace, 1);
         layout.line_metric(1);
 
         let line3 = layout.line_metric(2).unwrap();
-        assert_eq!(line3.start_offset, 15);
-        assert_eq!(line3.end_offset, 30);
+        assert_eq!(line3.range(), 15..30);
         assert_eq!(line3.trailing_whitespace, 2);
 
         let line4 = layout.line_metric(3).unwrap();

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -1,6 +1,6 @@
 //! Traits for fonts and text handling.
 
-use std::ops::RangeBounds;
+use std::ops::{Range, RangeBounds};
 
 use crate::kurbo::Point;
 use crate::Error;
@@ -297,13 +297,20 @@ pub trait TextLayout: Clone {
 /// Metadata about each line in a text layout.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LineMetric {
-    /// Index (in code units) of the start of the line, offset from the beginning of the text.
+    /// The start index of this line in the underlying `String` used to create the
+    /// [`TextLayout`] to which this line belongs.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
     pub start_offset: usize,
 
-    /// Line length (in UTF-8 code units), but offset from the beginning of the text. So it's the length
-    /// of this line summed with the lengths of all the lines before it.
+    /// The end index of this line in the underlying `String` used to create the
+    /// [`TextLayout`] to which this line belongs.
+    ///
+    /// This is the end of an exclusive range; this index is not part of the line.
     ///
     /// Includes trailing whitespace.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
     pub end_offset: usize,
 
     /// Length in (in UTF-8 code units) of current line's trailing whitespace.
@@ -317,6 +324,17 @@ pub struct LineMetric {
 
     /// Cumulative line height (includes previous line heights)
     pub cumulative_height: f64,
+}
+
+impl LineMetric {
+    /// The utf-8 range in the underlying `String` used to create the
+    /// [`TextLayout`] to which this line belongs.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
+    #[inline]
+    pub fn range(&self) -> Range<usize> {
+        self.start_offset..self.end_offset
+    }
 }
 
 /// return values for [`hit_test_point`](../piet/trait.TextLayout.html#tymethod.hit_test_point).


### PR DESCRIPTION
I had initially wanted to replace `start_offset` and `end_offset` with a single `range: Range<usize>` member, but this didn't end up feeling much more ergonomic, and was a fairly invasive change.

This also touches up the docs for `start_offset` and `end_offset`.