### PR TITLE
Remove HitTestMetrics, simplify other hit testing types

### DIFF
--- a/piet-cairo/src/text/grapheme.rs
+++ b/piet-cairo/src/text/grapheme.rs
@@ -19,8 +19,8 @@ pub(crate) fn get_grapheme_boundaries(
     let next_edge = hit_test_line_position(font, text, next_text_position)?;
 
     let res = GraphemeBoundaries {
-        curr_idx: curr_edge.metrics.text_position,
-        next_idx: next_edge.metrics.text_position,
+        curr_idx: text_position,
+        next_idx: next_text_position,
         leading: curr_edge.point.x,
         trailing: next_edge.point.x,
     };
@@ -32,7 +32,6 @@ pub(crate) fn point_x_in_grapheme(
     point_x: f64,
     grapheme_boundaries: &GraphemeBoundaries,
 ) -> Option<HitTestPoint> {
-    let mut res = HitTestPoint::default();
     let leading = grapheme_boundaries.leading;
     let trailing = grapheme_boundaries.trailing;
     let curr_idx = grapheme_boundaries.curr_idx;
@@ -42,14 +41,13 @@ pub(crate) fn point_x_in_grapheme(
         // Check which boundary it's closer to.
         // Round up to next grapheme boundary if
         let midpoint = leading + ((trailing - leading) / 2.0);
-        if point_x >= midpoint {
-            res.metrics.text_position = next_idx;
+        let is_inside = true;
+        let idx = if point_x >= midpoint {
+            next_idx
         } else {
-            res.metrics.text_position = curr_idx;
-        }
-
-        res.is_inside = true;
-        Some(res)
+            curr_idx
+        };
+        Some(HitTestPoint { idx, is_inside })
     } else {
         None
     }
@@ -107,11 +105,11 @@ mod test {
         };
 
         let expected_curr = Some(HitTestPoint {
-            metrics: HitTestMetrics { text_position: 2 },
+            idx: 2,
             is_inside: true,
         });
         let expected_next = Some(HitTestPoint {
-            metrics: HitTestMetrics { text_position: 4 },
+            idx: 4,
             is_inside: true,
         });
 

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -3,7 +3,7 @@
 use std::ops::RangeBounds;
 
 use piet::kurbo::{Point, Rect, Size};
-use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric, TextAttribute};
+use piet::{Error, HitTestPoint, HitTestPosition, LineMetric, TextAttribute};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -123,7 +123,7 @@ impl piet::TextLayout for TextLayout {
         unimplemented!()
     }
 
-    fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestTextPosition> {
+    fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestPosition> {
         unimplemented!()
     }
 }

--- a/piet-web/src/text/grapheme.rs
+++ b/piet-web/src/text/grapheme.rs
@@ -24,8 +24,8 @@ pub(crate) fn get_grapheme_boundaries(
     let next_edge = hit_test_line_position(ctx, text, next_text_position)?;
 
     let res = GraphemeBoundaries {
-        curr_idx: curr_edge.metrics.text_position,
-        next_idx: next_edge.metrics.text_position,
+        curr_idx: text_position,
+        next_idx: next_text_position,
         leading: curr_edge.point.x,
         trailing: next_edge.point.x,
     };
@@ -37,7 +37,6 @@ pub(crate) fn point_x_in_grapheme(
     point_x: f64,
     grapheme_boundaries: &GraphemeBoundaries,
 ) -> Option<HitTestPoint> {
-    let mut res = HitTestPoint::default();
     let leading = grapheme_boundaries.leading;
     let trailing = grapheme_boundaries.trailing;
     let curr_idx = grapheme_boundaries.curr_idx;
@@ -47,14 +46,13 @@ pub(crate) fn point_x_in_grapheme(
         // Check which boundary it's closer to.
         // Round up to next grapheme boundary if
         let midpoint = leading + ((trailing - leading) / 2.0);
-        if point_x >= midpoint {
-            res.metrics.text_position = next_idx;
+        let is_inside = true;
+        let idx = if point_x >= midpoint {
+            next_idx
         } else {
-            res.metrics.text_position = curr_idx;
-        }
-
-        res.is_inside = true;
-        Some(res)
+            curr_idx
+        };
+        Some(HitTestPoint { idx, is_inside })
     } else {
         None
     }

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -6,7 +6,7 @@ use std::ops::RangeBounds;
 use kurbo::{Affine, Point, Rect, Shape, Size};
 
 use crate::{
-    Color, Error, FixedGradient, Font, FontBuilder, HitTestPoint, HitTestTextPosition, ImageFormat,
+    Color, Error, FixedGradient, Font, FontBuilder, HitTestPoint, HitTestPosition, ImageFormat,
     InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextAttribute,
     TextLayout, TextLayoutBuilder,
 };
@@ -227,7 +227,7 @@ impl TextLayout for NullTextLayout {
         HitTestPoint::default()
     }
 
-    fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestTextPosition> {
+    fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestPosition> {
         None
     }
 }

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -5,7 +5,6 @@ use crate::{Error, RenderContext};
 
 mod picture_0;
 mod picture_1;
-mod picture_10;
 mod picture_2;
 mod picture_3;
 mod picture_4;
@@ -15,9 +14,11 @@ mod picture_7;
 mod picture_8;
 mod picture_9;
 
+mod picture_10;
+mod picture_11;
+
 use picture_0::draw as draw_picture_0;
 use picture_1::draw as draw_picture_1;
-use picture_10::draw as draw_picture_10;
 use picture_2::draw as draw_picture_2;
 use picture_3::draw as draw_picture_3;
 use picture_4::draw as draw_picture_4;
@@ -26,6 +27,9 @@ use picture_6::draw as draw_picture_6;
 use picture_7::draw as draw_picture_7;
 use picture_8::draw as draw_picture_8;
 use picture_9::draw as draw_picture_9;
+
+use picture_10::draw as draw_picture_10;
+use picture_11::draw as draw_picture_11;
 
 /// Draw a test picture, by number.
 ///
@@ -44,6 +48,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         8 => draw_picture_8(rc),
         9 => draw_picture_9(rc),
         10 => draw_picture_10(rc),
+        11 => draw_picture_11(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",
@@ -67,6 +72,7 @@ pub fn size_for_test_picture(number: usize) -> Result<Size, Error> {
         8 => Ok(picture_8::SIZE),
         9 => Ok(picture_9::SIZE),
         10 => Ok(picture_10::SIZE),
+        11 => Ok(picture_11::SIZE),
         other => {
             eprintln!("test picture {} does not exist.", other);
             Err(Error::InvalidInput)

--- a/piet/src/samples/picture_11.rs
+++ b/piet/src/samples/picture_11.rs
@@ -1,0 +1,50 @@
+//! Visualize results of hit-testing
+
+use crate::kurbo::{Circle, Line, Point, Size, Vec2};
+use crate::{Color, Error, RenderContext, Text, TextLayout, TextLayoutBuilder};
+
+pub const SIZE: Size = Size::new(480., 800.);
+pub const DOT_RADIUS: f64 = 2.0;
+pub const TEST_ADVANCE: f64 = 23.4;
+
+static TEXT: &str = r#"Philosophers often behave like little children who scribble some marks on a piece of paper at random and then ask the grown-up "What's that?" — It happened like this: the grown-up had drawn pictures for the child several times and said "this is a man," "this is a house," etc. And then the child makes some marks too and asks: what's this then?"#;
+
+const LIGHT_GREY: Color = Color::grey8(0xc0);
+const RED: Color = Color::rgb8(255, 0, 0);
+const BLUE: Color = Color::rgb8(0, 0, 255);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(LIGHT_GREY);
+    let text = rc.text();
+    let font = text.system_font(12.0);
+    let layout = text.new_text_layout(&font, TEXT, 200.0).build()?;
+
+    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+
+    let text_pos = Vec2::new(16.0, y_pos);
+    let layout_rect = layout.size().to_rect() + text_pos;
+    rc.fill(layout_rect, &Color::WHITE);
+
+    let mut y = y_pos - 20.;
+    while y < (layout_rect.max_y() + TEST_ADVANCE) {
+        let mut x = 2.0;
+        while x < SIZE.width / 2.0 {
+            let point = Point::new(x, y);
+            let test_point = layout.hit_test_point(point - text_pos);
+            let test_pos = layout.hit_test_text_position(test_point.idx).unwrap();
+            let hit_point = test_pos.point + text_pos;
+
+            let color = if test_point.is_inside { &RED } else { &BLUE };
+
+            let line = Line::new(point, hit_point);
+            let dot = Circle::new(hit_point, DOT_RADIUS);
+            rc.stroke(line, color, 0.5);
+            rc.fill(dot, color);
+            x += TEST_ADVANCE;
+        }
+        y += TEST_ADVANCE;
+    }
+    rc.draw_text(&layout, text_pos.to_point(), &Color::BLACK);
+
+    Ok(())
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -313,7 +313,7 @@ pub trait TextLayout: Clone {
     ///
     /// [`HitTestTextPosition`]: struct.HitTestTextPosition.html
     /// [`HitTestMetrics`]: struct.HitTestMetrics.html
-    fn hit_test_text_position(&self, text_position: usize) -> Option<HitTestTextPosition>;
+    fn hit_test_text_position(&self, text_position: usize) -> Option<HitTestPosition>;
 }
 
 /// Metadata about each line in a text layout.
@@ -371,20 +371,33 @@ impl LineMetric {
     }
 }
 
-/// return values for [`hit_test_point`](../piet/trait.TextLayout.html#tymethod.hit_test_point).
+/// Result of hit testing a point in a [`TextLayout`].
+///
+/// This type is returned by [`TextLayout::hit_test_point`].
+///
+/// [`TextLayout`]: ../piet/trait.TextLayout.html
+/// [`TextLayout::hit_test_point`]: ../piet/trait.TextLayout.html#tymethod.hit_test_point
 #[derive(Debug, Default, PartialEq)]
 pub struct HitTestPoint {
-    /// `metrics.text_position` will give you the text position.
-    pub metrics: HitTestMetrics,
-    /// `is_inside` indicates whether the hit test point landed within the text.
+    /// The index representing the grapheme boundary closest to the `Point`.
+    pub idx: usize,
+    /// Whether or not the point was inside the bounds of the layout object.
+    ///
+    /// A click outside the layout object will still resolve to a position in the
+    /// text; for instance a click to the right edge of a line will resolve to the
+    /// end of that line, and a click below the last line will resolve to a
+    /// position in that line.
     pub is_inside: bool,
-    // removing until needed for BIDI or other.
-    //pub is_trailing_hit: bool,
 }
 
-/// return values for [`hit_test_text_position`](../piet/trait.TextLayout.html#tymethod.hit_test_text_position).
+/// Result of hit testing a text position in a [`TextLayout`].
+///
+/// This type is returned by [`TextLayout::hit_test_text_position`].
+///
+/// [`TextLayout`]: ../piet/trait.TextLayout.html
+/// [`TextLayout::hit_test_text_position`]: ../piet/trait.TextLayout.html#tymethod.hit_test_text_position
 #[derive(Debug, Default)]
-pub struct HitTestTextPosition {
+pub struct HitTestPosition {
     /// the `point`'s `x` value is the position of the leading edge of the
     /// grapheme cluster containing the text position. The `y` value corresponds
     /// to the baseline of the line containing that grapheme cluster.
@@ -392,18 +405,6 @@ pub struct HitTestTextPosition {
     //instead of returning an x/y point, we could return the x offset, the line's y_offset,
     //and the line height (everything tou would need to draw a cursor)
     pub point: Point,
-    /// `metrics.text_position` will give you the text position.
-    pub metrics: HitTestMetrics,
-}
-
-#[derive(Debug, Default, PartialEq)]
-/// Hit test metrics, returned as part of [`hit_test_text_position`](../piet/trait.TextLayout.html#tymethod.hit_test_text_position)
-/// and [`hit_test_point`](../piet/trait.TextLayout.html#tymethod.hit_test_point).
-pub struct HitTestMetrics {
-    pub text_position: usize,
-    // TODO:
-    // consider adding other metrics as needed, such as those provided in
-    // [DWRITE_HIT_TEST_METRICS](https://docs.microsoft.com/en-us/windows/win32/api/dwrite/ns-dwrite-dwrite_hit_test_metrics).
 }
 
 impl<T: Font> From<T> for TextAttribute<T> {

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -269,51 +269,58 @@ pub trait TextLayout: Clone {
 
     /// Given a `Point`, determine the corresponding text position.
     ///
+    /// This is used for things like mapping a mouse click to a cursor position.
+    ///
+    /// The point should be in the coordinate space of the layout object.
+    ///
     /// ## Return value:
     /// Returns a [`HitTestPoint`][] describing the results of the test.
     ///
-    /// [`HitTestPoint`][] field `is_inside` is true if the tested point falls within the bounds of the text, `false` otherwise.
+    /// The [`HitTestPoint`][] field `is_inside` is true if the tested point
+    /// falls within the bounds of the text, `false` otherwise.
     ///
-    /// [`HitTestPoint`][] field `metrics` is a [`HitTestMetrics`][] struct. [`HitTestMetrics`][] field `text_position` is the text
-    /// position closest to the tested point.
+    /// The [`HitTestPoint`][] field `idx` is the index, in the string used to
+    /// create this [`TextLayout`][], of the start of the grapheme cluster
+    /// closest to the tested point.
     ///
     /// ## Notes:
     ///
-    /// Some text position will always be returned; if the tested point is inside, it returns the appropriate text
-    /// position; if it's outside, it will return the nearest text position (either `0` or `text.len()`).
+    /// This will always return *some* text position. If the point is outside of
+    /// the bounds of the layout, it will return the nearest text position.
     ///
-    /// For more on text positions, see docs for the [`TextLayout`](../piet/trait.TextLayout.html)
-    /// trait.
+    /// For more on text positions, see docs for the [`TextLayout`] trait.
     ///
     /// [`HitTestPoint`]: struct.HitTestPoint.html
-    /// [`HitTestMetrics`]: struct.HitTestMetrics.html
+    /// [`TextLayout`]: ../piet/trait.TextLayout.html
     fn hit_test_point(&self, point: Point) -> HitTestPoint;
 
-    /// Given a text position, determine the corresponding pixel location.
-    /// (currently consider the text layout just one line)
+    /// Given a grapheme boundary in the string used to create this [`TextLayout`],
+    /// return information about the location of that boundary within the layout
+    /// object.
+    ///
     ///
     /// ## Return value:
-    /// Returns a [`HitTestTextPosition`][] describing the results of the test.
+    /// Returns a [`HitTestPosition`][] struct describing the results of the test.
     ///
-    /// [`HitTestTextPosition`][] field `point` is the point offset of the boundary of the
-    /// grapheme cluster that the text position is a part of.
+    /// The [`HitTestPosition`][] field `point` is a `Point`, on the baseline
+    /// of the line containing this grapheme cluster, of the grapheme's leading edge,
+    /// relative to the origin of the layout object.
     ///
-    /// [`HitTestTextPosition`][] field `metrics` is a [`HitTestMetrics`][] struct. [`HitTestMetrics`][] field `text_position` is the original text position (unless out of bounds).
+    /// ## Panics:
     ///
-    /// ## Notes:
-    /// In directwrite, if a text position is not at code point boundary, this method will panic.
-    /// Cairo and web are more lenient and may not panic.
+    // FIXME: behaviour currently differs between backends, but some backends panic.
+    // decide whether this panics or not, and standardize backend behaviour.
+    /// This method may panic if the text position is not a codepoint boundary,
+    /// or if it is greater than the length of the text.
     ///
-    /// For text position that is greater than `text.len()`, web/cairo will return the
-    /// [`HitTestTextPosition`][] as if `text_position == text.len()`. In directwrite, the method will
-    /// panic, as the text position is out of bounds.
+    /// For more on text positions, see docs for the [`TextLayout`] trait.
     ///
-    /// For more on text positions, see docs for the [`TextLayout`](../piet/trait.TextLayout.html)
-    /// trait.
-    ///
-    /// [`HitTestTextPosition`]: struct.HitTestTextPosition.html
-    /// [`HitTestMetrics`]: struct.HitTestMetrics.html
-    fn hit_test_text_position(&self, text_position: usize) -> Option<HitTestPosition>;
+    /// [`HitTestPosition`]: struct.HitTestPosition.html
+    /// [`TextLayout`]: ../piet/trait.TextLayout.html
+    //FIXME: under what circumstances should this return `None`? A reasonable
+    //case would be when trimming has caused an index to not be included in the
+    //layout's text?`
+    fn hit_test_text_position(&self, idx: usize) -> Option<HitTestPosition>;
 }
 
 /// Metadata about each line in a text layout.


### PR DESCRIPTION
This is intended to simplify this API a bit; the existing design
was based on DirectWrite's API, but we aren't going to implement
that API directly so I think this is a reasonable simplification.

- HitTestTextPosition is renamed HitTestPosition
- HitTestPosition loses the `metrics` field
- HitTestPoint has an `idx` field, instead of a `HitTestMetrics`
member

This also includes a new sample picture or visualizing the results of hit-testing, which looks something like:

![coregraphics-test-11](https://user-images.githubusercontent.com/3330916/88094064-f111dc80-cb60-11ea-977b-5a3885867d85.png)

this has revealed an inconsistency in dw, where we're returning the top of the line instead of the baseline in `HitTestPosition`; will open an issue for that shortly.

I'm also considering returning a line number along with the `Point` for `hit_test_text_position`, to make it easier to get the line metrics for the relevant line, but that can be future work.