### PR TITLE
Add TextLayout::image_bounds

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -7,8 +7,7 @@ use std::ops::RangeBounds;
 
 use cairo::{FontFace, FontOptions, FontSlant, FontWeight, Matrix, ScaledFont};
 
-use piet::kurbo::{Point, Size};
-
+use piet::kurbo::{Point, Rect, Size};
 use piet::{
     Error, Font, FontBuilder, HitTestMetrics, HitTestPoint, HitTestTextPosition, LineMetric,
     RoundInto, Text, TextAttribute, TextLayout, TextLayoutBuilder,
@@ -156,6 +155,10 @@ impl TextLayout for CairoTextLayout {
 
     fn size(&self) -> Size {
         self.size
+    }
+
+    fn image_bounds(&self) -> Rect {
+        self.size.to_rect()
     }
 
     // TODO refactor this to use same code as new_text_layout

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -15,19 +15,20 @@ use core_foundation::{
 use core_foundation_sys::base::CFRange;
 use core_graphics::{
     base::CGFloat,
-    geometry::{CGPoint, CGSize},
+    geometry::{CGPoint, CGRect, CGSize},
     path::CGPathRef,
 };
 use core_text::{
     font::{kCTFontSystemFontType, CTFont, CTFontRef, CTFontUIFontType},
     frame::{CTFrame, CTFrameRef},
     framesetter::CTFramesetter,
-    line::{CTLine, TypographicBounds},
+    line::{CTLine, CTLineRef, TypographicBounds},
     string_attributes,
 };
 
 use unic_bidi::bidi_class::{BidiClass, BidiClassCategory};
 
+use piet::kurbo::Rect;
 use piet::TextAlignment;
 
 #[derive(Clone)]
@@ -192,6 +193,13 @@ impl<'a> Line<'a> {
         self.0.get_typographic_bounds()
     }
 
+    pub(crate) fn get_image_bounds(&self) -> Rect {
+        unsafe {
+            let r = CTLineGetImageBounds(self.0.as_concrete_TypeRef(), std::ptr::null_mut());
+            Rect::from_origin_size((r.origin.x, r.origin.y), (r.size.width, r.size.height))
+        }
+    }
+
     pub(crate) fn get_string_index_for_position(&self, position: CGPoint) -> CFIndex {
         self.0.get_string_index_for_position(position)
     }
@@ -250,4 +258,5 @@ extern "C" {
         settings: *const CTParagraphStyleSetting,
         count: usize,
     ) -> CTParagraphStyleRef;
+    fn CTLineGetImageBounds(line: CTLineRef, ctx: *mut c_void) -> CGRect;
 }

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -17,9 +17,9 @@ use winapi::um::dwrite::{
     IDWriteLocalizedStrings, IDWriteTextFormat, IDWriteTextLayout, DWRITE_FACTORY_TYPE_SHARED,
     DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE, DWRITE_FONT_STYLE_ITALIC,
     DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT, DWRITE_FONT_WEIGHT_NORMAL,
-    DWRITE_HIT_TEST_METRICS, DWRITE_LINE_METRICS, DWRITE_TEXT_ALIGNMENT_CENTER,
-    DWRITE_TEXT_ALIGNMENT_JUSTIFIED, DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_TEXT_ALIGNMENT_TRAILING,
-    DWRITE_TEXT_METRICS, DWRITE_TEXT_RANGE,
+    DWRITE_HIT_TEST_METRICS, DWRITE_LINE_METRICS, DWRITE_OVERHANG_METRICS,
+    DWRITE_TEXT_ALIGNMENT_CENTER, DWRITE_TEXT_ALIGNMENT_JUSTIFIED, DWRITE_TEXT_ALIGNMENT_LEADING,
+    DWRITE_TEXT_ALIGNMENT_TRAILING, DWRITE_TEXT_METRICS, DWRITE_TEXT_RANGE,
 };
 use winapi::um::unknwnbase::IUnknown;
 use winapi::um::winnls::GetUserDefaultLocaleName;
@@ -28,6 +28,7 @@ use winapi::Interface;
 use wio::com::ComPtr;
 use wio::wide::{FromWide, ToWide};
 
+use piet::kurbo::Insets;
 use piet::{FontWeight, TextAlignment};
 
 use crate::Brush;
@@ -409,6 +410,26 @@ impl TextLayout {
             let mut result = std::mem::zeroed();
             self.0.GetMetrics(&mut result);
             result
+        }
+    }
+
+    /// Return the DWRITE_OVERHANG_METRICS, converted to an `Insets` struct.
+    ///
+    /// The 'right' and 'bottom' values of this struct are relative to the *layout*
+    /// width and height; that is, the width and height constraints used to create
+    /// the layout, not the actual size of the generated layout.
+    pub fn get_overhang_metrics(&self) -> Insets {
+        unsafe {
+            let mut result = std::mem::zeroed();
+            // returning all 0s on failure feels okay?
+            let _ = self.0.GetOverhangMetrics(&mut result);
+            let DWRITE_OVERHANG_METRICS {
+                left,
+                top,
+                right,
+                bottom,
+            } = result;
+            Insets::new(left as f64, top as f64, right as f64, bottom as f64)
         }
     }
 

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -2,7 +2,7 @@
 
 use std::ops::RangeBounds;
 
-use piet::kurbo::{Point, Size};
+use piet::kurbo::{Point, Rect, Size};
 use piet::{Error, HitTestPoint, HitTestTextPosition, LineMetric, TextAttribute};
 
 type Result<T> = std::result::Result<T, Error>;
@@ -92,6 +92,10 @@ impl piet::TextLayout for TextLayout {
     }
 
     fn size(&self) -> Size {
+        unimplemented!()
+    }
+
+    fn image_bounds(&self) -> Rect {
         unimplemented!()
     }
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -8,7 +8,7 @@ use std::ops::RangeBounds;
 
 use web_sys::CanvasRenderingContext2d;
 
-use piet::kurbo::{Point, Size};
+use piet::kurbo::{Point, Rect, Size};
 
 use piet::{
     Error, Font, FontBuilder, HitTestMetrics, HitTestPoint, HitTestTextPosition, LineMetric, Text,
@@ -170,6 +170,11 @@ impl TextLayout for WebTextLayout {
 
     fn size(&self) -> Size {
         self.size
+    }
+
+    fn image_bounds(&self) -> Rect {
+        //FIXME: figure out actual image bounds on web?
+        self.size.to_rect()
     }
 
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error> {

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -203,6 +203,10 @@ impl TextLayout for NullTextLayout {
         Size::ZERO
     }
 
+    fn image_bounds(&self) -> Rect {
+        Rect::ZERO
+    }
+
     fn update_width(&mut self, _new_width: impl Into<Option<f64>>) -> Result<(), Error> {
         Ok(())
     }

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -5,6 +5,7 @@ use crate::{Error, RenderContext};
 
 mod picture_0;
 mod picture_1;
+mod picture_10;
 mod picture_2;
 mod picture_3;
 mod picture_4;
@@ -16,6 +17,7 @@ mod picture_9;
 
 use picture_0::draw as draw_picture_0;
 use picture_1::draw as draw_picture_1;
+use picture_10::draw as draw_picture_10;
 use picture_2::draw as draw_picture_2;
 use picture_3::draw as draw_picture_3;
 use picture_4::draw as draw_picture_4;
@@ -41,6 +43,7 @@ pub fn draw_test_picture(rc: &mut impl RenderContext, number: usize) -> Result<(
         7 => draw_picture_7(rc),
         8 => draw_picture_8(rc),
         9 => draw_picture_9(rc),
+        10 => draw_picture_10(rc),
         _ => {
             eprintln!(
                 "Don't have test picture {} yet. Why don't you make it?",
@@ -63,6 +66,7 @@ pub fn size_for_test_picture(number: usize) -> Result<Size, Error> {
         7 => Ok(picture_7::SIZE),
         8 => Ok(picture_8::SIZE),
         9 => Ok(picture_9::SIZE),
+        10 => Ok(picture_10::SIZE),
         other => {
             eprintln!("test picture {} does not exist.", other);
             Err(Error::InvalidInput)

--- a/piet/src/samples/picture_10.rs
+++ b/piet/src/samples/picture_10.rs
@@ -1,0 +1,30 @@
+//! Show the relationship between the layout rect and the inking/image rect.
+
+use crate::kurbo::{Size, Vec2};
+use crate::{Color, Error, RenderContext, Text, TextLayout, TextLayoutBuilder};
+
+pub const SIZE: Size = Size::new(400., 400.);
+
+static SAMPLE_EN: &str = r#"ḧ́ͥm̾ͭpͭ̒ͦ̎ḧ̐̈̾̆͊
+ ch̯͈̙̯̼̠a͚͉o̺̮̳̮̩s̪͇.̥̩̹"#;
+
+const LIGHT_GREY: Color = Color::grey8(0xc0);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(LIGHT_GREY);
+    let text = rc.text();
+    let font = text.system_font(24.0);
+
+    let layout = text.new_text_layout(&font, SAMPLE_EN, None).build()?;
+
+    let text_pos = Vec2::new(50.0, 50.0);
+    let layout_rect = layout.size().to_rect() + text_pos;
+    let image_rect = layout.image_bounds() + text_pos;
+
+    rc.fill(layout_rect, &Color::WHITE);
+    rc.stroke(image_rect, &Color::BLACK, 0.5);
+
+    rc.draw_text(&layout, text_pos.to_point(), &Color::BLACK);
+
+    Ok(())
+}

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -42,7 +42,10 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
 
     let text_pos = Vec2::new(0.0, 50.0);
     let layout_rect = layout.size().to_rect() + text_pos;
+    let image_rect = layout.image_bounds() + text_pos;
+
     rc.fill(layout_rect, &Color::WHITE);
+    rc.stroke(image_rect, &Color::BLACK, 0.5);
 
     for idx in 0..layout.line_count() {
         let metrics = layout.line_metric(idx).unwrap();

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -2,7 +2,7 @@
 
 use std::ops::{Range, RangeBounds};
 
-use crate::kurbo::{Point, Size};
+use crate::kurbo::{Point, Rect, Size};
 use crate::Error;
 
 pub trait Text: Clone {
@@ -245,6 +245,12 @@ pub trait TextLayout: Clone {
     /// We would ultimately like to review and attempt to standardize this
     /// behaviour, but it is out of scope for the time being.
     fn size(&self) -> Size;
+
+    /// Returns a `Rect` representing the bounding box of the glyphs in this layout,
+    /// relative to the top-left of the layout object.
+    ///
+    /// This is sometimes called the bounding box or the inking rect.
+    fn image_bounds(&self) -> Rect;
 
     /// Change the width of this `TextLayout`.
     ///


### PR DESCRIPTION
This method returns the bounding rectangle of the glyphs in the
layout, relative to the layout's origin.

It also adds a new sample picture (`picture_10.rs`) that shows the
difference between this region and the layout's bounds in an
exaggerated case (zalgo).

![coregraphics-test-10](https://user-images.githubusercontent.com/3330916/88075057-4391cf80-cb46-11ea-808f-8d2ca4e2785b.png)
