### PR TITLE
[d2d] Use utf-8 for ranges in LineMetric

### DIFF
--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -173,7 +173,7 @@ impl TextLayoutBuilder for D2DTextLayoutBuilder {
 
     fn build(self) -> Result<Self::Out, Error> {
         let layout = self.layout?;
-        let line_metrics = lines::fetch_line_metrics(&layout);
+        let line_metrics = lines::fetch_line_metrics(&self.text, &layout);
         let text_metrics = layout.get_metrics();
         let width = text_metrics.width as f64;
         let height = text_metrics.height as f64;
@@ -202,7 +202,7 @@ impl TextLayout for D2DTextLayout {
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 
         self.layout.set_max_width(new_width)?;
-        self.line_metrics = lines::fetch_line_metrics(&self.layout);
+        self.line_metrics = lines::fetch_line_metrics(&self.text, &self.layout);
 
         Ok(())
     }

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -126,5 +126,7 @@ mod tests {
         assert_eq!(count_until_utf16(input, 3), Some(6));
         assert_eq!(count_until_utf16(input, 4), Some(9));
         assert_eq!(count_until_utf16(input, 5), None);
+
+        assert_eq!(count_until_utf16("", 0), None);
     }
 }


### PR DESCRIPTION
This was previously using utf-16, which was presumably an oversight.