### PR TITLE
svg: split opacity and color for increased compatibility

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -309,8 +309,8 @@ impl Attrs<'_> {
             node.assign("clip-path", format!("url(#{})", id.to_string()));
         }
         if let Some((ref brush, rule)) = self.fill {
-            node.assign("fill", brush.val_color());
-            if let Some(opacity) = brush.val_opacity() {
+            node.assign("fill", brush.color());
+            if let Some(opacity) = brush.opacity() {
                 node.assign("fill-opacity", opacity);
             }
             if let Some(rule) = rule {
@@ -320,8 +320,8 @@ impl Attrs<'_> {
             node.assign("fill", "none");
         }
         if let Some((ref stroke, width, style)) = self.stroke {
-            node.assign("stroke", stroke.val_color());
-            if let Some(opacity) = stroke.val_opacity() {
+            node.assign("stroke", stroke.color());
+            if let Some(opacity) = stroke.opacity() {
                 node.assign("stroke-opacity", opacity);
             }
             if width != 1.0 {
@@ -419,14 +419,14 @@ enum BrushKind {
 }
 
 impl Brush {
-    fn val_color(&self) -> svg::node::Value {
+    fn color(&self) -> svg::node::Value {
         match self.kind {
             BrushKind::Solid(ref color) => fmt_color(color).into(),
             BrushKind::Ref(id) => format!("url(#{})", id.to_string()).into(),
         }
     }
 
-    fn val_opacity(&self) -> Option<svg::node::Value> {
+    fn opacity(&self) -> Option<svg::node::Value> {
         match self.kind {
             BrushKind::Solid(ref color) => Some(fmt_opacity(color).into()),
             BrushKind::Ref(_) => None,


### PR DESCRIPTION
The `<color>` value for the `fill` and `stroke` attributes for example, typically, refers to a solid color (sRGB).
Applications like Inkscape or Affinity don't support the additional alpha channel which is currently added.

This PR splits the color value into the RGB and A channels and sets the corresponding attributes.

Example output:
```
<svg xmlns="http://www.w3.org/2000/svg">
<path d="M20 250C48.00262530267052 250 62.00393795400579 250 72.69952498697732 244.5503262094184C77.37444060334367 242.1683377286408 81.6453050202178 239.06537309843694 85.35533905932736 235.35533905932738C89.06537309843692 231.64530502021782 92.16833772864078 227.3744406033437 94.55032620941837 222.69952498697734C100 212.00393795400578 100 198.00262530267054 100 170" fill="none" stroke="#cc331a" stroke-opacity="0.7019608" stroke-width="2" transform="matrix(1 0 0 1 0 0)"/>
<path d="M85.35533905932738 45.35533905932737C84.06970695965603 44.06970695965604 83.42689090982037 43.42689090982037 82.78745892001557 42.643132827266626C78.13546716493401 36.941140752813965 76.99054286224477 29.145089266025106 79.80668059723617 22.3463313526982C82.62281833222757 15.547573439371295 88.9450429433923 10.844516304960267 96.2664151215518 10.10205395888492C97.2727624726339 10 98.18184164842259 10 100 10" fill="none" stroke="#cc331a" stroke-opacity="0.7019608" stroke-width="2" transform="matrix(1 0 0 1 0 0)"/>
<path d="M160 50C153.7476165076737 43.74761650767371 150.62142476151055 40.62142476151057 149.16232286146453 35.86098028688478C147.80053733447264 31.41803878472556 148.02836798021366 26.639557790853086 149.80668059723615 22.3463313526982C151.58499321425865 18.053104914543315 154.8027889342313 14.513108005439435 158.9073507794809 12.334401721505177C163.30523419691556 10 167.7263369629183 10 176.5685424949238 10" fill="none" stroke="#cc331a" stroke-opacity="0.7019608" stroke-width="2" transform="matrix(1 0 0 1 0 0)"/>
<path d="M111.5889360201312 132.009219983224C116.41289877191969 127.98925102340026 118.82488014781393 125.9792665434884 120.33718311137332 122.6992253971081C122.09997135473265 118.87590552675266 122.28478100103457 114.51186164820622 120.85154628002849 110.55319577995172C119.4183115590224 106.59452991169722 116.4825440455617 103.36029079157117 112.68070286966021 101.55164464176724C109.41908837968545 100 106.27939225312363 100 100 100" fill="none" stroke="#cc331a" stroke-opacity="0.7019608" stroke-width="2" transform="matrix(1 0 0 1 0 0)"/>
</svg>
```

cc @Ralith 
