### PR TITLE
Make italic/underline text attributes take a boolean

### DIFF
--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -98,7 +98,7 @@ impl CoreGraphicsTextLayoutBuilder {
     fn add(&mut self, attr: TextAttribute<CoreGraphicsFont>, range: Range<usize>) {
         // Some attributes are 'standalone' and can just be added to the attributed string
         // immediately.
-        if matches!(&attr, TextAttribute::ForegroundColor(_) | TextAttribute::Underline) {
+        if matches!(&attr, TextAttribute::ForegroundColor(_) | TextAttribute::Underline(_)) {
             return self.add_immediately(attr, range);
         }
 
@@ -114,7 +114,7 @@ impl CoreGraphicsTextLayoutBuilder {
             TextAttribute::Font(font) => self.font = Span::new(font, range),
             TextAttribute::Weight(weight) => self.weight = Span::new(weight, range),
             TextAttribute::Size(size) => self.size = Span::new(size, range),
-            TextAttribute::Italic => self.italic = Span::new(true, range),
+            TextAttribute::Italic(flag) => self.italic = Span::new(flag, range),
             _ => unreachable!(),
         }
     }
@@ -134,12 +134,19 @@ impl CoreGraphicsTextLayoutBuilder {
                         color.as_CFType(),
                     )
                 }
-                TextAttribute::Underline => {
-                    #[allow(non_upper_case_globals)]
+                #[allow(non_upper_case_globals)]
+                TextAttribute::Underline(flag) => {
+                    const kCTUnderlineStyleNone: i32 = 0x00;
                     const kCTUnderlineStyleSingle: i32 = 0x01;
+
+                    let value = if flag {
+                        kCTUnderlineStyleSingle
+                    } else {
+                        kCTUnderlineStyleNone
+                    };
                     (
                         string_attributes::kCTUnderlineStyleAttributeName,
-                        CFNumber::from(kCTUnderlineStyleSingle).as_CFType(),
+                        CFNumber::from(value).as_CFType(),
                     )
                 }
                 _ => unreachable!(),

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -10,6 +10,7 @@ use std::mem::MaybeUninit;
 use std::ptr::null_mut;
 use std::sync::Arc;
 
+use winapi::shared::minwindef::{FALSE, TRUE};
 use winapi::shared::ntdef::LOCALE_NAME_MAX_LENGTH;
 use winapi::shared::winerror::{HRESULT, SUCCEEDED, S_OK};
 use winapi::um::dwrite::{
@@ -359,17 +360,23 @@ impl TextLayout {
         }
     }
 
-    pub(crate) fn set_italic(&mut self, start: usize, len: usize) {
+    pub(crate) fn set_italic(&mut self, start: usize, len: usize, ital: bool) {
         let range = make_text_range(start, len);
+        let val = if ital {
+            DWRITE_FONT_STYLE_ITALIC
+        } else {
+            DWRITE_FONT_STYLE_NORMAL
+        };
         unsafe {
-            self.0.SetFontStyle(DWRITE_FONT_STYLE_ITALIC, range);
+            self.0.SetFontStyle(val, range);
         }
     }
 
-    pub(crate) fn set_underline(&mut self, start: usize, len: usize) {
+    pub(crate) fn set_underline(&mut self, start: usize, len: usize, flag: bool) {
         let range = make_text_range(start, len);
+        let flag = if flag { TRUE } else { FALSE };
         unsafe {
-            self.0.SetUnderline(1, range);
+            self.0.SetUnderline(flag, range);
         }
     }
 

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -160,8 +160,8 @@ impl TextLayoutBuilder for D2DTextLayoutBuilder {
                 TextAttribute::Font(font) => layout.set_font_family(start, len, &font.family),
                 TextAttribute::Size(size) => layout.set_size(start, len, size as f32),
                 TextAttribute::Weight(weight) => layout.set_weight(start, len, weight),
-                TextAttribute::Italic => layout.set_italic(start, len),
-                TextAttribute::Underline => layout.set_underline(start, len),
+                TextAttribute::Italic(flag) => layout.set_italic(start, len, flag),
+                TextAttribute::Underline(flag) => layout.set_underline(start, len, flag),
                 TextAttribute::ForegroundColor(color) => {
                     if let Ok(brush) = self.device.create_solid_color(conv::color_to_colorf(color))
                     {

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -45,8 +45,8 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         )
         .add_attribute(200.., FontWeight::EXTRA_BLACK)
         .add_attribute(220.., TextAttribute::Size(18.0))
-        .add_attribute(240.., TextAttribute::Italic)
-        .add_attribute(280.., TextAttribute::Underline)
+        .add_attribute(240.., TextAttribute::Italic(true))
+        .add_attribute(280.., TextAttribute::Underline(true))
         .build()?;
 
     rc.draw_text(&en_leading, (0., 0.), &Color::BLACK);

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -101,9 +101,9 @@ pub enum TextAttribute<T> {
     ForegroundColor(crate::Color),
     //BackgroundColor(crate::Color),
     /// Italics.
-    Italic,
+    Italic(bool),
     /// Underline.
-    Underline,
+    Underline(bool),
 }
 
 pub trait FontBuilder {
@@ -155,7 +155,7 @@ pub trait TextLayoutBuilder {
     /// let font = text.system_font(12.0);
     /// let times = text.new_font_by_name("Times New Roman", 12.0).build().unwrap();
     /// let layout = text.new_text_layout(&font, "This API is okay, I guess?", 100.0)
-    ///     .add_attribute(.., TextAttribute::Italic)
+    ///     .add_attribute(.., TextAttribute::Italic(true))
     ///     .add_attribute(..5, FontWeight::BOLD)
     ///     .add_attribute(5..14, times)
     ///     .add_attribute(20.., TextAttribute::ForegroundColor(Color::rgb(1.0, 0., 0.,)))


### PR DESCRIPTION
This will be necessary when attributes for specific ranges can
override default attributes.