### PR TITLE
Update new_text_layout API

### DIFF
--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -348,14 +348,10 @@ impl Text for CoreGraphicsText {
         CoreGraphicsFont(crate::ct_helpers::system_font(size))
     }
 
-    fn new_text_layout(
-        &mut self,
-        font: &Self::Font,
-        text: &str,
-        width: impl Into<Option<f64>>,
-    ) -> Self::TextLayoutBuilder {
-        let width = width.into().unwrap_or(f64::INFINITY);
-        CoreGraphicsTextLayoutBuilder::new(font, text, width)
+    fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder {
+        let width = f64::INFINITY;
+        let font = crate::ct_helpers::system_font(0.0);
+        CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(font), text, width)
     }
 }
 
@@ -370,10 +366,10 @@ impl FontBuilder for CoreGraphicsFontBuilder {
 }
 
 impl CoreGraphicsTextLayoutBuilder {
-    fn new(font: &CoreGraphicsFont, text: &str, width: f64) -> Self {
+    fn new(font: CoreGraphicsFont, text: &str, width: f64) -> Self {
         let attr_string = AttributedString::new(text);
         let attrs = Attributes {
-            defaults: util::LayoutDefaults::new(font.clone()),
+            defaults: util::LayoutDefaults::new(font),
             ..Default::default()
         };
 
@@ -393,6 +389,11 @@ impl CoreGraphicsTextLayoutBuilder {
 impl TextLayoutBuilder for CoreGraphicsTextLayoutBuilder {
     type Out = CoreGraphicsTextLayout;
     type Font = CoreGraphicsFont;
+
+    fn max_width(mut self, width: f64) -> Self {
+        self.width = width;
+        self
+    }
 
     fn alignment(mut self, alignment: piet::TextAlignment) -> Self {
         self.alignment = alignment;
@@ -692,7 +693,7 @@ mod tests {
         let text = "hi\ni'm\n😀 four\nlines";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .build()
                 .unwrap();
         assert_eq!(layout.line_text(0), Some("hi\n"));
@@ -706,7 +707,7 @@ mod tests {
         let text = "🤡:\na string\nwith a number \n of lines";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .build()
                 .unwrap();
 
@@ -735,7 +736,7 @@ mod tests {
         let text = "1\n😀\n8\nA";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .default_attribute(TextAttribute::Size(16.0))
                 .build()
                 .unwrap();
@@ -772,7 +773,7 @@ mod tests {
         let text = "hello";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .default_attribute(TextAttribute::Size(16.0))
                 .build()
                 .unwrap();
@@ -793,7 +794,7 @@ mod tests {
         let text = "";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .build()
                 .unwrap();
         let pt = layout.hit_test_point(Point::new(0.0, 0.0));
@@ -805,7 +806,7 @@ mod tests {
         let text = "aaaaa\nbbbbb";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .default_attribute(TextAttribute::Size(16.0))
                 .build()
                 .unwrap();
@@ -823,7 +824,7 @@ mod tests {
         let text = "👾🤠\n🤖🎃👾";
         let a_font = font::new_from_name("Helvetica", 16.0).unwrap();
         let layout =
-            CoreGraphicsTextLayoutBuilder::new(&CoreGraphicsFont(a_font), text, f64::INFINITY)
+            CoreGraphicsTextLayoutBuilder::new(CoreGraphicsFont(a_font), text, f64::INFINITY)
                 .default_attribute(TextAttribute::Size(16.0))
                 .build()
                 .unwrap();

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -60,9 +60,12 @@ mod test {
         input: &str,
         text_layout: &mut D2DText,
         font: &D2DFont,
+        font_size: f64,
     ) {
         let layout = text_layout
-            .new_text_layout(&font, input, width)
+            .new_text_layout(input)
+            .max_width(width)
+            .font(font.clone(), font_size)
             .build()
             .unwrap();
         let line_metrics = fetch_line_metrics(input, &layout.layout);
@@ -176,10 +179,17 @@ mod test {
         let mut text = D2DText::new_for_test();
         let font = text.new_font_by_name("Segoe UI", 12.0).build().unwrap();
 
-        test_metrics_with_width(width_small, expected_small, input, &mut text, &font);
-        test_metrics_with_width(width_medium, expected_medium, input, &mut text, &font);
-        test_metrics_with_width(width_large, expected_large, input, &mut text, &font);
-        test_metrics_with_width(width_small, expected_empty, empty_input, &mut text, &font);
+        test_metrics_with_width(width_small, expected_small, input, &mut text, &font, 12.0);
+        test_metrics_with_width(width_medium, expected_medium, input, &mut text, &font, 12.0);
+        test_metrics_with_width(width_large, expected_large, input, &mut text, &font, 12.0);
+        test_metrics_with_width(
+            width_small,
+            expected_empty,
+            empty_input,
+            &mut text,
+            &font,
+            12.0,
+        );
     }
 
     #[test]
@@ -187,8 +197,7 @@ mod test {
         let input = "€tf\n16";
 
         let mut text = D2DText::new_for_test();
-        let font = text.new_font_by_name("Segoe UI", 12.0).build().unwrap();
-        let layout = text.new_text_layout(&font, input, 100.0).build().unwrap();
+        let layout = text.new_text_layout(input).build().unwrap();
         let metric = layout.line_metric(0).unwrap();
         assert_eq!(&input[metric.range()], "€tf\n");
         let metric = layout.line_metric(1).unwrap();

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -32,12 +32,7 @@ impl piet::Text for Text {
         Font
     }
 
-    fn new_text_layout(
-        &mut self,
-        _font: &Self::Font,
-        _text: &str,
-        _width: impl Into<Option<f64>>,
-    ) -> TextLayoutBuilder {
+    fn new_text_layout(&mut self, _text: &str) -> TextLayoutBuilder {
         TextLayoutBuilder
     }
 }
@@ -64,6 +59,10 @@ pub struct TextLayoutBuilder;
 impl piet::TextLayoutBuilder for TextLayoutBuilder {
     type Out = TextLayout;
     type Font = Font;
+
+    fn max_width(self, _width: f64) -> Self {
+        self
+    }
 
     fn alignment(self, _alignment: piet::TextAlignment) -> Self {
         self

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -147,12 +147,7 @@ impl Text for NullText {
         NullFont
     }
 
-    fn new_text_layout(
-        &mut self,
-        _font: &Self::Font,
-        _text: &str,
-        _width: impl Into<Option<f64>>,
-    ) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, _text: &str) -> Self::TextLayoutBuilder {
         NullTextLayoutBuilder
     }
 }
@@ -170,6 +165,10 @@ impl FontBuilder for NullFontBuilder {
 impl TextLayoutBuilder for NullTextLayoutBuilder {
     type Out = NullTextLayout;
     type Font = NullFont;
+
+    fn max_width(self, _width: f64) -> Self {
+        self
+    }
 
     fn alignment(self, _alignment: crate::TextAlignment) -> Self {
         self

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -35,7 +35,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let layout = rc
         .text()
-        .new_text_layout(&segoe, "Hello piet!", None)
+        .new_text_layout("Hello piet!")
         .default_attribute(segoe)
         .default_attribute(TextAttribute::Size(12.0))
         .default_attribute(TextAttribute::ForegroundColor(RED_ALPHA))
@@ -84,7 +84,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
 
     let layout = rc
         .text()
-        .new_text_layout(&georgia, "CLIPPED", None)
+        .new_text_layout("CLIPPED")
         .default_attribute(georgia)
         .default_attribute(TextAttribute::Size(8.0))
         .default_attribute(TextAttribute::ForegroundColor(RED_ALPHA))

--- a/piet/src/samples/picture_10.rs
+++ b/piet/src/samples/picture_10.rs
@@ -13,10 +13,9 @@ const LIGHT_GREY: Color = Color::grey8(0xc0);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
     let text = rc.text();
-    let font = text.system_font(24.0);
 
     let layout = text
-        .new_text_layout(&font, SAMPLE_EN, None)
+        .new_text_layout(SAMPLE_EN)
         .default_attribute(TextAttribute::Size(24.0))
         .build()?;
 

--- a/piet/src/samples/picture_11.rs
+++ b/piet/src/samples/picture_11.rs
@@ -16,8 +16,7 @@ const BLUE: Color = Color::rgb8(0, 0, 255);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
     let text = rc.text();
-    let font = text.system_font(12.0);
-    let layout = text.new_text_layout(&font, TEXT, 200.0).build()?;
+    let layout = text.new_text_layout(TEXT).max_width(200.0).build()?;
 
     let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
 

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -19,7 +19,8 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let font = text.system_font(12.0);
     let font2 = text.new_font_by_name("Courier New", 12.0).build().unwrap();
     let layout = text
-        .new_text_layout(&font, TEXT, 200.0)
+        .new_text_layout(TEXT)
+        .max_width(200.0)
         .default_attribute(font2)
         .default_attribute(TextAttribute::Underline(true))
         .default_attribute(TextAttribute::Italic(true))

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -1,13 +1,14 @@
 //! Text layouts
 
-use crate::kurbo::Size;
+use crate::kurbo::{Rect, Size};
 use crate::{Color, Error, RenderContext, Text, TextAlignment, TextAttribute, TextLayoutBuilder};
 
 pub const SIZE: Size = Size::new(800., 800.);
 static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
-static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.
-"#;
+static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي."#;
+
+const LIGHT_GREY: Color = Color::grey8(0xF0);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
@@ -68,6 +69,11 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
+
+    for pt in &[(0f64, 0f64), (200.0, 0.), (100., 200.), (300., 200.)] {
+        let rect = Rect::from_origin_size(*pt, (100., 200.));
+        rc.fill(rect, &LIGHT_GREY);
+    }
 
     rc.draw_text(&en_leading, (0., 0.));
     rc.draw_text(&en_trailing, (100., 0.));

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -4,8 +4,7 @@ use crate::kurbo::Size;
 use crate::{Color, Error, RenderContext, Text, TextAlignment, TextAttribute, TextLayoutBuilder};
 
 pub const SIZE: Size = Size::new(800., 800.);
-static SAMPLE_EN: &str = r#"
-This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
+static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
 static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي.
 "#;
@@ -13,53 +12,60 @@ static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
-    let font = text.system_font(8.0);
 
     let en_leading = text
-        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .new_text_layout(SAMPLE_EN)
         .alignment(TextAlignment::Start)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let en_trailing = text
-        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .new_text_layout(SAMPLE_EN)
         .alignment(TextAlignment::End)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let en_center = text
-        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .new_text_layout(SAMPLE_EN)
         .alignment(TextAlignment::Center)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let en_justify = text
-        .new_text_layout(&font, SAMPLE_EN, 100.0)
+        .new_text_layout(SAMPLE_EN)
         .alignment(TextAlignment::Justified)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let ar_leading = text
-        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .new_text_layout(SAMPLE_AR)
         .alignment(TextAlignment::Start)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let ar_trailing = text
-        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .new_text_layout(SAMPLE_AR)
         .alignment(TextAlignment::End)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let ar_center = text
-        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .new_text_layout(SAMPLE_AR)
         .alignment(TextAlignment::Center)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 
     let ar_justify = text
-        .new_text_layout(&font, SAMPLE_AR, 100.0)
+        .new_text_layout(SAMPLE_AR)
         .alignment(TextAlignment::Justified)
+        .max_width(100.0)
         .default_attribute(TextAttribute::Size(8.0))
         .build()?;
 

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -24,7 +24,9 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let mono = text.new_font_by_name(MONO, 12.0).build().unwrap();
 
     let en_leading = text
-        .new_text_layout(&font, SAMPLE_EN, 200.0)
+        .new_text_layout(SAMPLE_EN)
+        .max_width(200.0)
+        .default_attribute(font)
         .alignment(TextAlignment::Start)
         .range_attribute(10..80, TextAttribute::Size(8.0))
         .range_attribute(20..120, serif)

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -32,7 +32,10 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .expect("missing Courier New");
 
     let layout = text
-        .new_text_layout(&font, SAMPLE_EN, 200.0)
+        .new_text_layout(SAMPLE_EN)
+        .default_attribute(font)
+        .default_attribute(TextAttribute::Size(24.0))
+        .max_width(200.0)
         .alignment(TextAlignment::Start)
         .default_attribute(TextAttribute::Size(24.0))
         .range_attribute(23..35, mono.clone())


### PR DESCRIPTION
This now shifts almost everything to the builder.

It also adds a new TextLayoutBuilder::font(Font, f64) method for
easily setting the layout's default family and size.

This looks a bit funny right now because we haven't removed size from the font object yet; that will be the next patch.