### PR TITLE
Refactor sample image code

### DIFF
--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -1,32 +1,37 @@
 //! Basic example of rendering on Cairo.
 
 use std::fs::File;
+use std::path::Path;
 
 use cairo::{Context, Format, ImageSurface};
 
-use piet::draw_test_picture;
-use piet::RenderContext;
+use piet::{samples, RenderContext};
 use piet_cairo::CairoRenderContext;
 
 const HIDPI: f64 = 2.0;
+const FILE_PREFIX: &str = "cairo-test-";
 
-fn main() {
-    let test_picture_number = std::env::args()
-        .nth(1)
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(0);
-    let size = piet::size_for_test_picture(test_picture_number).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    samples::samples_main(run_sample)
+}
+
+fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let sample = samples::get(idx);
+    let size = sample.size();
+
+    let file_name = format!("{}{}.png", FILE_PREFIX, idx);
+    let path = base_dir.join(file_name);
 
     let surface = ImageSurface::create(Format::ARgb32, size.width as i32, size.height as i32)
         .expect("Can't create surface");
     let cr = Context::new(&surface);
     cr.scale(HIDPI, HIDPI);
     let mut piet_context = CairoRenderContext::new(&cr);
-    draw_test_picture(&mut piet_context, test_picture_number).unwrap();
-    piet_context.finish().unwrap();
+    sample.draw(&mut piet_context)?;
+    piet_context.finish()?;
     surface.flush();
-    let mut file = File::create(format!("cairo-test-{}.png", test_picture_number)).unwrap();
-    surface
-        .write_to_png(&mut file)
-        .expect("Error writing image file");
+
+    let mut file = File::create(path)?;
+
+    surface.write_to_png(&mut file).map_err(Into::into)
 }

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -19,5 +19,4 @@ unic-bidi = "0.9"
 
 [dev-dependencies]
 piet = { version = "0.2.0", path = "../piet", features = ["samples"] }
-
 png = "0.16.2"

--- a/piet-direct2d/src/d3d.rs
+++ b/piet-direct2d/src/d3d.rs
@@ -157,3 +157,11 @@ impl DxgiDevice {
         self.0.as_raw()
     }
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "HRESULT error {}", self.0)
+    }
+}
+
+impl std::error::Error for Error {}

--- a/piet-svg/examples/basic-svg.rs
+++ b/piet-svg/examples/basic-svg.rs
@@ -2,8 +2,7 @@
 
 use std::io;
 
-use piet::draw_test_picture;
-use piet::RenderContext;
+use piet::{samples, RenderContext};
 
 fn main() {
     let test_picture_number = std::env::args()
@@ -11,7 +10,7 @@ fn main() {
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(0);
     let mut piet = piet_svg::RenderContext::new();
-    draw_test_picture(&mut piet, test_picture_number).unwrap();
+    samples::get(test_picture_number).draw(&mut piet).unwrap();
     piet.finish().unwrap();
     piet.write(io::stdout()).unwrap();
 }

--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{window, HtmlCanvasElement};
 
-use piet::RenderContext;
+use piet::{samples, RenderContext};
 use piet_web::WebRenderContext;
 
 #[wasm_bindgen]
@@ -35,6 +35,6 @@ pub fn run() {
     let mut piet_context = WebRenderContext::new(context, window);
 
     // TODO: make the test picture selectable
-    piet::draw_test_picture(&mut piet_context, 0).unwrap();
+    samples::get(0).draw(&mut piet_context).unwrap();
     piet_context.finish().unwrap();
 }

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 kurbo = "0.6.2"
+pico-args =  { version = "0.3.3", optional = true }
 
 [features]
-samples = []
+samples = ["pico-args"]

--- a/piet/src/error.rs
+++ b/piet/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     BackendError(Box<dyn std::error::Error>),
     MissingFeature,
     MissingFont,
+    #[cfg(feature = "samples")]
+    InvalidSampleArgs,
 }
 
 impl fmt::Display for Error {
@@ -26,6 +28,8 @@ impl fmt::Display for Error {
                 write!(f, "Backend error: ")?;
                 e.fmt(f)
             }
+            #[cfg(feature = "samples")]
+            Error::InvalidSampleArgs => write!(f, "Must pass either --all or a number"),
         }
     }
 }

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -27,6 +27,3 @@ pub use crate::null_renderer::*;
 pub use crate::render_context::*;
 pub use crate::shapes::*;
 pub use crate::text::*;
-
-#[cfg(feature = "samples")]
-pub use samples::{draw_test_picture, size_for_test_picture};


### PR DESCRIPTION
This sets up doing snapshot testing over sample images. The actual
testing code isn't written yet, but this makes it easy to run all
of the samples, and to write them to a specific target directory.