### PR TITLE
Font API changes

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -16,9 +16,7 @@ use piet::{
     RenderContext, StrokeStyle, TextLayout,
 };
 
-pub use crate::text::{
-    CairoFont, CairoFontBuilder, CairoText, CairoTextLayout, CairoTextLayoutBuilder,
-};
+pub use crate::text::{CairoText, CairoTextLayout, CairoTextLayoutBuilder};
 
 pub struct CairoRenderContext<'a> {
     // Cairo has this as Clone and with &self methods, but we do this to avoid

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -63,7 +63,7 @@ impl Text for CairoText {
     type TextLayout = CairoTextLayout;
     type TextLayoutBuilder = CairoTextLayoutBuilder;
 
-    fn font(&mut self, family_name: &str) -> Option<FontFamily> {
+    fn font_family(&mut self, family_name: &str) -> Option<FontFamily> {
         Some(FontFamily::new_unchecked(family_name))
     }
 
@@ -88,7 +88,7 @@ impl CairoFont {
 
     /// Create a ScaledFont for this family.
     pub(crate) fn resolve(&self, size: f64, slant: FontSlant, weight: FontWeight) -> ScaledFont {
-        let font_face = FontFace::toy_create(self.family.as_str(), slant, weight);
+        let font_face = FontFace::toy_create(self.family.name(), slant, weight);
         let font_matrix = scale_matrix(size);
         let ctm = scale_matrix(1.0);
         let options = FontOptions::default();
@@ -1035,7 +1035,7 @@ mod test {
 
         let input = "piet  text!";
         let font = text_layout
-            .font("Helvetica") // change this for osx
+            .font_family("Helvetica") // change this for osx
             .unwrap();
 
         let layout = text_layout
@@ -1271,7 +1271,7 @@ mod test {
         let input = "piet text most best";
         let mut text = CairoText::new();
 
-        let font = text.font("Helvetica").unwrap();
+        let font = text.font_family("Helvetica").unwrap();
         // this should break into four lines
         let layout = text
             .new_text_layout(input)

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -75,6 +75,12 @@ impl Text for CairoText {
         }
     }
 
+    fn font(&mut self, family_name: &str) -> Option<Self::Font> {
+        Some(CairoFont {
+            family: family_name.to_owned(),
+        })
+    }
+
     fn system_font(&mut self, _size: f64) -> Self::Font {
         CairoFontBuilder {
             family: "sans-serif".into(),
@@ -191,7 +197,7 @@ impl TextLayoutBuilder for CairoTextLayoutBuilder {
 
 impl TextLayout for CairoTextLayout {
     fn width(&self) -> f64 {
-        // calculated by max x_advance, on TextLayout build
+        // calculated by max x_advance, in update_width
         self.size.width
     }
 
@@ -203,7 +209,6 @@ impl TextLayout for CairoTextLayout {
         self.size.to_rect()
     }
 
-    // TODO refactor this to use same code as new_text_layout
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error> {
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 

--- a/piet-cairo/src/text/grapheme.rs
+++ b/piet-cairo/src/text/grapheme.rs
@@ -70,7 +70,7 @@ mod test {
     fn test_grapheme_boundaries() {
         let text = "piet";
 
-        let font = CairoFont::new("sans-serif").resolve_simple(12.0);
+        let font = CairoFont::new(FontFamily::SANS_SERIF).resolve_simple(12.0);
 
         let expected_3 = GraphemeBoundaries {
             curr_idx: 3,

--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -219,7 +219,7 @@ mod test {
         let input = "piet text is the best text!";
         let width = 50.0;
 
-        let font = CairoFont::new("sans-serif").resolve_simple(12.0);
+        let font = CairoFont::new(FontFamily::SANS_SERIF).resolve_simple(12.0);
         let line_metrics = calculate_line_metrics(input, &font, width);
 
         // Some print debugging, in case font size/width needs to be changed in future because of
@@ -249,7 +249,7 @@ mod test {
         let input = "piet text is the best text!";
         let width = 50.0;
 
-        let font = CairoFont::new("sans-serif").resolve_simple(14.0);
+        let font = CairoFont::new(FontFamily::SANS_SERIF).resolve_simple(14.0);
         let line_metrics = calculate_line_metrics(input, &font, width);
 
         // Some print debugging, in case font size/width needs to be changed in future because of
@@ -277,7 +277,7 @@ mod test {
         let input = "piet\ntext";
         let width = 10.0;
 
-        let font = CairoFont::new("sans-serif").resolve_simple(12.0);
+        let font = CairoFont::new(FontFamily::SANS_SERIF).resolve_simple(12.0);
         let line_metrics = calculate_line_metrics(input, &font, width);
 
         // Some print debugging, in case font size/width needs to be changed in future because of
@@ -406,7 +406,7 @@ mod test {
         }];
 
         // setup cairo layout
-        let font = CairoFont::new("sans-serif").resolve_simple(13.0);
+        let font = CairoFont::new(FontFamily::SANS_SERIF).resolve_simple(13.0);
 
         println!(
             "piet text width: {}",
@@ -482,7 +482,7 @@ mod test {
         ];
 
         // setup cairo layout
-        let font = CairoFont::new("sans-serif").resolve_simple(13.0);
+        let font = CairoFont::new(FontFamily::SANS_SERIF).resolve_simple(13.0);
 
         test_metrics_with_width(width_small, expected_small, input, &font);
     }

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -30,16 +30,6 @@ pub type Brush = piet_cairo::Brush;
 /// This type matches `RenderContext::Text`
 pub type PietText = CairoText;
 
-/// The associated font type for this backend.
-///
-/// This type matches `RenderContext::Text::Font`
-pub type PietFont = CairoFont;
-
-/// The associated font builder for this backend.
-///
-/// This type matches `RenderContext::Text::FontBuilder`
-pub type PietFontBuilder = CairoFontBuilder;
-
 /// The associated text layout type for this backend.
 ///
 /// This type matches `RenderContext::Text::TextLayout`

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -29,16 +29,6 @@ pub type Brush = piet_coregraphics::Brush;
 /// This type matches `RenderContext::Text`
 pub type PietText = CoreGraphicsText;
 
-/// The associated font type for this backend.
-///
-/// This type matches `RenderContext::Text::Font`
-pub type PietFont = CoreGraphicsFont;
-
-/// The associated font builder for this backend.
-///
-/// This type matches `RenderContext::Text::FontBuilder`
-pub type PietFontBuilder = CoreGraphicsFontBuilder;
-
 /// The associated text layout type for this backend.
 ///
 /// This type matches `RenderContext::Text::TextLayout`

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -31,16 +31,6 @@ pub type Brush = D2DBrush;
 /// This type matches `RenderContext::Text`
 pub type PietText = D2DText;
 
-/// The associated font type for this backend.
-///
-/// This type matches `RenderContext::Text::Font`
-pub type PietFont = D2DFont;
-
-/// The associated font builder for this backend.
-///
-/// This type matches `RenderContext::Text::FontBuilder`
-pub type PietFontBuilder = D2DFontBuilder;
-
 /// The associated text layout type for this backend.
 ///
 /// This type matches `RenderContext::Text::TextLayout`

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -65,8 +65,6 @@ mod test {
         piet: Piet<'a>,
         brush: Brush,
         piet_text: PietText,
-        piet_font: PietFont,
-        piet_font_builder: PietFontBuilder,
         piet_text_layout: PietTextLayout,
         piet_text_layout_builder: PietTextLayoutBuilder,
         image: Image,

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -29,16 +29,6 @@ pub type Brush = piet_web::Brush;
 /// This type matches `RenderContext::Text`
 pub type PietText = WebText;
 
-/// The associated font type for this backend.
-///
-/// This type matches `RenderContext::Text::Font`
-pub type PietFont = WebFont;
-
-/// The associated font builder for this backend.
-///
-/// This type matches `RenderContext::Text::FontBuilder`
-pub type PietFontBuilder = WebFontBuilder;
-
 /// The associated text layout type for this backend.
 ///
 /// This type matches `RenderContext::Text::TextLayout`

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -269,6 +269,7 @@ impl<'a> From<CTLine> for Line<'a> {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn system_font(size: CGFloat) -> CTFont {
     unsafe {
         let font = CTFontCreateUIFontForLanguage(kCTFontSystemFontType, size, std::ptr::null());

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -78,7 +78,7 @@ impl<'a> CoreGraphicsContext<'a> {
 
         CoreGraphicsContext {
             ctx,
-            text: CoreGraphicsText::new(),
+            text: CoreGraphicsText::new_with_unique_state(),
             transform_stack: Vec::new(),
         }
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -243,8 +243,7 @@ impl CoreGraphicsTextLayoutBuilder {
                 (traits_key, traits.as_CFType()),
             ]);
             let descriptor = font_descriptor::new_from_attributes(&attributes);
-            let font = font::new_from_descriptor(&descriptor, self.attrs.size());
-            font
+            font::new_from_descriptor(&descriptor, self.attrs.size())
         }
     }
 

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -17,8 +17,8 @@ use core_text::{font, font::CTFont, font_descriptor, string_attributes};
 
 use piet::kurbo::{Point, Rect, Size};
 use piet::{
-    util, Error, Font, FontBuilder, FontFamily, FontWeight, HitTestPoint, HitTestPosition,
-    LineMetric, Text, TextAlignment, TextAttribute, TextLayout, TextLayoutBuilder,
+    util, Error, FontFamily, FontWeight, HitTestPoint, HitTestPosition, LineMetric, Text,
+    TextAlignment, TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
 use crate::ct_helpers::{AttributedString, FontCollection, Frame, Framesetter, Line};
@@ -226,7 +226,6 @@ impl CoreGraphicsTextLayoutBuilder {
             let family_key =
                 CFString::wrap_under_create_rule(font_descriptor::kCTFontFamilyNameAttribute);
             let family = CFString::new(self.attrs.font().as_str());
-            //let family = self.attrs.font().family_name();
 
             let traits_key =
                 CFString::wrap_under_create_rule(font_descriptor::kCTFontTraitsAttribute);
@@ -366,35 +365,15 @@ impl CoreGraphicsText {
 }
 
 impl Text for CoreGraphicsText {
-    type Font = CoreGraphicsFont;
-    type FontBuilder = CoreGraphicsFontBuilder;
     type TextLayout = CoreGraphicsTextLayout;
     type TextLayoutBuilder = CoreGraphicsTextLayoutBuilder;
-
-    fn new_font_by_name(&mut self, name: &str, size: f64) -> Self::FontBuilder {
-        CoreGraphicsFontBuilder(font::new_from_name(name, size).ok())
-    }
 
     fn font(&mut self, family_name: &str) -> Option<FontFamily> {
         self.shared.get_font(family_name)
     }
 
-    fn system_font(&mut self, size: f64) -> Self::Font {
-        CoreGraphicsFont(crate::ct_helpers::system_font(size))
-    }
-
     fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder {
         CoreGraphicsTextLayoutBuilder::new(text)
-    }
-}
-
-impl Font for CoreGraphicsFont {}
-
-impl FontBuilder for CoreGraphicsFontBuilder {
-    type Out = CoreGraphicsFont;
-
-    fn build(self) -> Result<Self::Out, Error> {
-        self.0.map(CoreGraphicsFont).ok_or(Error::MissingFont)
     }
 }
 
@@ -435,7 +414,6 @@ impl CoreGraphicsTextLayoutBuilder {
 
 impl TextLayoutBuilder for CoreGraphicsTextLayoutBuilder {
     type Out = CoreGraphicsTextLayout;
-    type Font = CoreGraphicsFont;
 
     fn max_width(mut self, width: f64) -> Self {
         self.width = width;

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -344,6 +344,12 @@ impl Text for CoreGraphicsText {
         CoreGraphicsFontBuilder(font::new_from_name(name, size).ok())
     }
 
+    fn font(&mut self, family_name: &str) -> Option<Self::Font> {
+        font::new_from_name(family_name, 12.0)
+            .ok()
+            .map(CoreGraphicsFont)
+    }
+
     fn system_font(&mut self, size: f64) -> Self::Font {
         CoreGraphicsFont(crate::ct_helpers::system_font(size))
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -368,7 +368,7 @@ impl Text for CoreGraphicsText {
     type TextLayout = CoreGraphicsTextLayout;
     type TextLayoutBuilder = CoreGraphicsTextLayoutBuilder;
 
-    fn font(&mut self, family_name: &str) -> Option<FontFamily> {
+    fn font_family(&mut self, family_name: &str) -> Option<FontFamily> {
         self.shared.get_font(family_name)
     }
 
@@ -861,7 +861,7 @@ mod tests {
     #[test]
     fn missing_font_is_missing() {
         assert!(CoreGraphicsText::new_with_unique_state()
-            .font("Segoe UI")
+            .font_family("Segoe UI")
             .is_none());
     }
 }

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -353,10 +353,11 @@ impl TextLayout {
         }
     }
 
-    pub(crate) fn set_font_family(&mut self, start: usize, len: usize, family: &FamilyName) {
+    pub(crate) fn set_font_family(&mut self, start: usize, len: usize, family: &str) {
         let range = make_text_range(start, len);
+        let wide_name = family.to_wide_null();
         unsafe {
-            self.0.SetFontFamilyName(family.wide_name.as_ptr(), range);
+            self.0.SetFontFamilyName(wide_name.as_ptr(), range);
         }
     }
 

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -229,7 +229,7 @@ impl FontFamily {
                     .into_string()
                     .unwrap_or_else(|err| err.to_string_lossy().into_owned());
 
-                Ok(PietFontFamily::new_unchecked(&name))
+                Ok(PietFontFamily::new_unchecked(name))
             } else {
                 Err(hr.into())
             }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -32,7 +32,7 @@ use piet::{
 use crate::d2d::wrap_unit;
 pub use crate::d2d::{D2DDevice, D2DFactory, DeviceContext as D2DDeviceContext};
 pub use crate::dwrite::DwriteFactory;
-pub use crate::text::{D2DFont, D2DFontBuilder, D2DText, D2DTextLayout, D2DTextLayoutBuilder};
+pub use crate::text::{D2DText, D2DTextLayout, D2DTextLayoutBuilder};
 
 use crate::conv::{
     affine_to_matrix3x2f, color_to_colorf, convert_stroke_style, gradient_stop_to_d2d,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -92,6 +92,14 @@ impl Text for D2DText {
         D2DFontBuilder { font }
     }
 
+    fn font(&mut self, family_name: &str) -> Option<Self::Font> {
+        self.dwrite
+            .system_font_collection()
+            .ok()
+            .and_then(|fonts| fonts.font_family(name))
+            .map(|family| D2DFont { family, size: 12.0 })
+    }
+
     fn system_font(&mut self, size: f64) -> Self::Font {
         let collection = self.dwrite.system_font_collection().unwrap();
         //TODO: this is maybe not the best thing? I _think_ if we pass an empty string

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -918,4 +918,10 @@ mod test {
         assert_eq!(pt.idx, 5);
         assert_eq!(pt.is_inside, false);
     }
+
+    #[test]
+    fn missing_font_is_missing() {
+        let mut text = D2DText::new_for_test();
+        assert!(text.font("A Quite Unlikely Font Ñame").is_none());
+    }
 }

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -69,7 +69,7 @@ impl Text for D2DText {
     type TextLayoutBuilder = D2DTextLayoutBuilder;
     type TextLayout = D2DTextLayout;
 
-    fn font(&mut self, family_name: &str) -> Option<FontFamily> {
+    fn font_family(&mut self, family_name: &str) -> Option<FontFamily> {
         self.dwrite
             .system_font_collection()
             .ok()
@@ -301,7 +301,7 @@ fn resolve_family_name(family: &FontFamily) -> &str {
         f if f == &FontFamily::SYSTEM_UI || f == &FontFamily::SANS_SERIF => "Segoe UI",
         f if f == &FontFamily::SERIF => "Times New Roman",
         f if f == &FontFamily::MONOSPACE => "Consolas",
-        other => other.as_str(),
+        other => other.name(),
     }
 }
 
@@ -331,7 +331,7 @@ mod test {
         let mut text_layout = D2DText::new_for_test();
 
         let input = "piet text!";
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
 
         let layout = text_layout
             .new_text_layout(&input[0..4])
@@ -414,7 +414,7 @@ mod test {
         let input = "é";
         assert_eq!(input.len(), 2);
 
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -445,7 +445,7 @@ mod test {
 
         let mut text_layout = D2DText::new_for_test();
 
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -475,7 +475,7 @@ mod test {
         let input = "é\u{0023}\u{FE0F}\u{20E3}1\u{1D407}"; // #️⃣,, 𝐇
         assert_eq!(input.len(), 14);
 
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -527,7 +527,7 @@ mod test {
     fn test_hit_test_point_basic() {
         let mut text_layout = D2DText::new_for_test();
 
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let layout = text_layout
             .new_text_layout("piet text!")
             .font(font, 12.0)
@@ -572,7 +572,7 @@ mod test {
         // 14 utf-8 code units (2/1/3/3/1/4)
         // 4 graphemes
         let input = "é\u{0023}\u{FE0F}\u{20E3}1\u{1D407}"; // #️⃣,, 𝐇
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -613,7 +613,7 @@ mod test {
         let width_small = 30.0;
 
         let mut text_layout = D2DText::new_for_test();
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .max_width(width_small)
@@ -637,7 +637,7 @@ mod test {
         let width_large = 1000.0;
 
         let mut text_layout = D2DText::new_for_test();
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
         let mut layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -663,7 +663,7 @@ mod test {
         let mut text_layout = D2DText::new_for_test();
 
         let input = "piet  text!";
-        let font = text_layout.font("Segoe UI").unwrap();
+        let font = text_layout.font_family("Segoe UI").unwrap();
 
         let layout = text_layout
             .new_text_layout(&input[0..4])
@@ -822,7 +822,7 @@ mod test {
 
         let mut text = D2DText::new_for_test();
 
-        let font = text.font("Segoe UI").unwrap();
+        let font = text.font_family("Segoe UI").unwrap();
         // this should break into four lines
         let layout = text
             .new_text_layout(input)
@@ -888,6 +888,6 @@ mod test {
     #[test]
     fn missing_font_is_missing() {
         let mut text = D2DText::new_for_test();
-        assert!(text.font("A Quite Unlikely Font Ñame").is_none());
+        assert!(text.font_family("A Quite Unlikely Font Ñame").is_none());
     }
 }

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -175,7 +175,10 @@ impl D2DTextLayoutBuilder {
             };
 
             match attr {
-                TextAttribute::Font(font) => layout.set_font_family(start, len, &font.as_str()),
+                TextAttribute::Font(font) => {
+                    let family_name = resolve_family_name(&font);
+                    layout.set_font_family(start, len, family_name);
+                }
                 TextAttribute::Size(size) => layout.set_size(start, len, size as f32),
                 TextAttribute::Weight(weight) => layout.set_weight(start, len, weight),
                 TextAttribute::Italic(flag) => layout.set_italic(start, len, flag),
@@ -289,6 +292,16 @@ impl TextLayout for D2DTextLayout {
             .map(|http| HitTestPosition {
                 point: Point::new(http.point_x as f64, http.point_y as f64),
             })
+    }
+}
+
+//  this is not especially robust, but all of these are preinstalled on win 7+
+fn resolve_family_name(family: &FontFamily) -> &str {
+    match family {
+        f if f == &FontFamily::SYSTEM_UI || f == &FontFamily::SANS_SERIF => "Segoe UI",
+        f if f == &FontFamily::SERIF => "Times New Roman",
+        f if f == &FontFamily::MONOSPACE => "Consolas",
+        other => other.as_str(),
     }
 }
 

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -59,7 +59,7 @@ mod test {
         expected: Vec<LineMetric>,
         input: &str,
         text_layout: &mut D2DText,
-        font: &D2DFont,
+        font: &FontFamily,
         font_size: f64,
     ) {
         let layout = text_layout
@@ -177,7 +177,7 @@ mod test {
 
         // setup dwrite layout
         let mut text = D2DText::new_for_test();
-        let font = text.new_font_by_name("Segoe UI", 12.0).build().unwrap();
+        let font = text.font("Segoe UI").unwrap();
 
         test_metrics_with_width(width_small, expected_small, input, &mut text, &font, 12.0);
         test_metrics_with_width(width_medium, expected_medium, input, &mut text, &font, 12.0);

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -177,7 +177,7 @@ mod test {
 
         // setup dwrite layout
         let mut text = D2DText::new_for_test();
-        let font = text.font("Segoe UI").unwrap();
+        let font = text.font_family("Segoe UI").unwrap();
 
         test_metrics_with_width(width_small, expected_small, input, &mut text, &font, 12.0);
         test_metrics_with_width(width_medium, expected_medium, input, &mut text, &font, 12.0);

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -22,7 +22,7 @@ impl piet::Text for Text {
     type TextLayout = TextLayout;
     type TextLayoutBuilder = TextLayoutBuilder;
 
-    fn font(&mut self, _family_name: &str) -> Option<FontFamily> {
+    fn font_family(&mut self, _family_name: &str) -> Option<FontFamily> {
         Some(FontFamily::default())
     }
 

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -28,6 +28,10 @@ impl piet::Text for Text {
         FontBuilder
     }
 
+    fn font(&mut self, _family_name: &str) -> Option<Self::Font> {
+        Some(Font)
+    }
+
     fn system_font(&mut self, _size: f64) -> Self::Font {
         Font
     }

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -19,21 +19,11 @@ impl Text {
 }
 
 impl piet::Text for Text {
-    type Font = Font;
-    type FontBuilder = FontBuilder;
     type TextLayout = TextLayout;
     type TextLayoutBuilder = TextLayoutBuilder;
 
-    fn new_font_by_name(&mut self, _name: &str, _size: f64) -> FontBuilder {
-        FontBuilder
-    }
-
     fn font(&mut self, _family_name: &str) -> Option<FontFamily> {
         Some(FontFamily::default())
-    }
-
-    fn system_font(&mut self, _size: f64) -> Self::Font {
-        Font
     }
 
     fn new_text_layout(&mut self, _text: &str) -> TextLayoutBuilder {
@@ -41,28 +31,10 @@ impl piet::Text for Text {
     }
 }
 
-/// SVG font builder (unimplemented)
-pub struct FontBuilder;
-
-impl piet::FontBuilder for FontBuilder {
-    type Out = Font;
-
-    fn build(self) -> Result<Font> {
-        Err(Error::NotSupported)
-    }
-}
-
-/// SVG font (unimplemented)
-#[derive(Clone)]
-pub struct Font;
-
-impl piet::Font for Font {}
-
 pub struct TextLayoutBuilder;
 
 impl piet::TextLayoutBuilder for TextLayoutBuilder {
     type Out = TextLayout;
-    type Font = Font;
 
     fn max_width(self, _width: f64) -> Self {
         self

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -3,7 +3,7 @@
 use std::ops::RangeBounds;
 
 use piet::kurbo::{Point, Rect, Size};
-use piet::{Error, HitTestPoint, HitTestPosition, LineMetric, TextAttribute};
+use piet::{Error, FontFamily, HitTestPoint, HitTestPosition, LineMetric, TextAttribute};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -28,8 +28,8 @@ impl piet::Text for Text {
         FontBuilder
     }
 
-    fn font(&mut self, _family_name: &str) -> Option<Self::Font> {
-        Some(Font)
+    fn font(&mut self, _family_name: &str) -> Option<FontFamily> {
+        Some(FontFamily::default())
     }
 
     fn system_font(&mut self, _size: f64) -> Self::Font {
@@ -72,14 +72,14 @@ impl piet::TextLayoutBuilder for TextLayoutBuilder {
         self
     }
 
-    fn default_attribute(self, _attribute: impl Into<TextAttribute<Self::Font>>) -> Self {
+    fn default_attribute(self, _attribute: impl Into<TextAttribute>) -> Self {
         self
     }
 
     fn range_attribute(
         self,
         _range: impl RangeBounds<usize>,
-        _attribute: impl Into<TextAttribute<Self::Font>>,
+        _attribute: impl Into<TextAttribute>,
     ) -> Self {
         self
     }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -24,7 +24,7 @@ use piet::{
     LineJoin, RenderContext, StrokeStyle,
 };
 
-pub use text::{WebFont, WebFontBuilder, WebTextLayout, WebTextLayoutBuilder};
+pub use text::{WebFont, WebTextLayout, WebTextLayoutBuilder};
 
 pub struct WebRenderContext {
     ctx: CanvasRenderingContext2d,

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -59,7 +59,7 @@ impl Text for WebText {
     type TextLayout = WebTextLayout;
     type TextLayoutBuilder = WebTextLayoutBuilder;
 
-    fn font(&mut self, family_name: &str) -> Option<FontFamily> {
+    fn font_family(&mut self, family_name: &str) -> Option<FontFamily> {
         Some(FontFamily::new_unchecked(family_name))
     }
 
@@ -98,7 +98,7 @@ impl WebFont {
             style_str,
             self.weight,
             self.size,
-            self.family.as_str()
+            self.family.name()
         )
     }
 }
@@ -459,7 +459,7 @@ pub(crate) mod test {
         let mut text_layout = WebText::new(context);
 
         let input = "piet text!";
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
 
         let layout = text_layout
             .new_text_layout(&input[0..4])
@@ -548,7 +548,7 @@ pub(crate) mod test {
         let input = "é";
         assert_eq!(input.len(), 2);
 
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -583,7 +583,7 @@ pub(crate) mod test {
         assert_eq!(input.len(), 7);
         assert_eq!(input.chars().count(), 3);
 
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -614,7 +614,7 @@ pub(crate) mod test {
         let input = "é\u{0023}\u{FE0F}\u{20E3}1\u{1D407}"; // #️⃣,, 𝐇
         assert_eq!(input.len(), 14);
 
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font.clone(), 12.0)
@@ -681,7 +681,7 @@ pub(crate) mod test {
         let (_window, context) = setup_ctx();
         let mut text_layout = WebText::new(context);
 
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout("piet text!")
             .font(font, 16.0)
@@ -728,7 +728,7 @@ pub(crate) mod test {
         let mut text_layout = WebText::new(context);
 
         // base condition, one grapheme
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout("t")
             .font(font.clone(), 16.0)
@@ -772,7 +772,7 @@ pub(crate) mod test {
         let input = "é\u{0023}\u{FE0F}\u{20E3}1\u{1D407}"; // #️⃣,, 𝐇
 
         let font = text_layout
-            .font("sans-serif") // font size hacked to fit test
+            .font_family("sans-serif") // font size hacked to fit test
             .unwrap();
         let layout = text_layout
             .new_text_layout(input)
@@ -824,7 +824,7 @@ pub(crate) mod test {
         // This corresponds to the char 'y' in the input.
         let input = "tßßypi";
 
-        let font = text_layout.font("sans-serif").unwrap();
+        let font = text_layout.font_family("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 14.0)
@@ -851,7 +851,7 @@ pub(crate) mod test {
 
         let input = "piet  text!";
         let font = text_layout
-            .font("sans-serif") // change this for osx
+            .font_family("sans-serif") // change this for osx
             .unwrap();
 
         let layout = text_layout
@@ -1022,7 +1022,7 @@ pub(crate) mod test {
         let (_window, context) = setup_ctx();
         let mut text = WebText::new(context);
 
-        let font = text.font("sans-serif").unwrap();
+        let font = text.font_family("sans-serif").unwrap();
         // this should break into four lines
         // Had to shift font in order to break at 4 lines (larger font than cairo, wider lines)
         let layout = text

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -73,6 +73,15 @@ impl Text for WebText {
         WebFontBuilder(font)
     }
 
+    fn font(&mut self, family_name: &str) -> Option<Self::Font> {
+        Some(WebFont {
+            family: family_name.to_owned(),
+            size: 0.0,
+            weight: 400,
+            style: FontStyle::Normal,
+        })
+    }
+
     fn system_font(&mut self, size: f64) -> Self::Font {
         let font = WebFont {
             family: "sans-serif".to_owned(),
@@ -430,7 +439,7 @@ pub(crate) fn text_width(text: &str, ctx: &CanvasRenderingContext2d) -> f64 {
 #[cfg(test)]
 pub(crate) mod test {
     use piet::kurbo::Point;
-    use piet::{FontBuilder, Text, TextLayout, TextLayoutBuilder};
+    use piet::{Text, TextLayout, TextLayoutBuilder};
     use wasm_bindgen_test::*;
     use web_sys::{console, window, HtmlCanvasElement};
 
@@ -478,10 +487,7 @@ pub(crate) mod test {
         let mut text_layout = WebText::new(context);
 
         let input = "piet text!";
-        let font = text_layout
-            .new_font_by_name("sans-serif", 12.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
 
         let layout = text_layout
             .new_text_layout(&input[0..4])
@@ -570,10 +576,7 @@ pub(crate) mod test {
         let input = "é";
         assert_eq!(input.len(), 2);
 
-        let font = text_layout
-            .new_font_by_name("sans-serif", 12.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -608,10 +611,7 @@ pub(crate) mod test {
         assert_eq!(input.len(), 7);
         assert_eq!(input.chars().count(), 3);
 
-        let font = text_layout
-            .new_font_by_name("sans-serif", 12.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 12.0)
@@ -642,10 +642,7 @@ pub(crate) mod test {
         let input = "é\u{0023}\u{FE0F}\u{20E3}1\u{1D407}"; // #️⃣,, 𝐇
         assert_eq!(input.len(), 14);
 
-        let font = text_layout
-            .new_font_by_name("sans-serif", 12.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font.clone(), 12.0)
@@ -712,10 +709,7 @@ pub(crate) mod test {
         let (_window, context) = setup_ctx();
         let mut text_layout = WebText::new(context);
 
-        let font = text_layout
-            .new_font_by_name("sans-serif", 16.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout("piet text!")
             .font(font, 16.0)
@@ -762,10 +756,7 @@ pub(crate) mod test {
         let mut text_layout = WebText::new(context);
 
         // base condition, one grapheme
-        let font = text_layout
-            .new_font_by_name("sans-serif", 16.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout("t")
             .font(font.clone(), 16.0)
@@ -809,8 +800,7 @@ pub(crate) mod test {
         let input = "é\u{0023}\u{FE0F}\u{20E3}1\u{1D407}"; // #️⃣,, 𝐇
 
         let font = text_layout
-            .new_font_by_name("sans-serif", 13.0) // font size hacked to fit test
-            .build()
+            .font("sans-serif") // font size hacked to fit test
             .unwrap();
         let layout = text_layout
             .new_text_layout(input)
@@ -862,10 +852,7 @@ pub(crate) mod test {
         // This corresponds to the char 'y' in the input.
         let input = "tßßypi";
 
-        let font = text_layout
-            .new_font_by_name("sans-serif", 14.0)
-            .build()
-            .unwrap();
+        let font = text_layout.font("sans-serif").unwrap();
         let layout = text_layout
             .new_text_layout(input)
             .font(font, 14.0)
@@ -892,8 +879,7 @@ pub(crate) mod test {
 
         let input = "piet  text!";
         let font = text_layout
-            .new_font_by_name("sans-serif", 15.0) // change this for osx
-            .build()
+            .font("sans-serif") // change this for osx
             .unwrap();
 
         let layout = text_layout
@@ -1064,7 +1050,7 @@ pub(crate) mod test {
         let (_window, context) = setup_ctx();
         let mut text = WebText::new(context);
 
-        let font = text.new_font_by_name("sans-serif", 14.0).build().unwrap();
+        let font = text.font("sans-serif").unwrap();
         // this should break into four lines
         // Had to shift font in order to break at 4 lines (larger font than cairo, wider lines)
         let layout = text

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -11,8 +11,8 @@ use web_sys::CanvasRenderingContext2d;
 use piet::kurbo::{Point, Rect, Size};
 
 use piet::{
-    Error, Font, FontBuilder, HitTestPoint, HitTestPosition, LineMetric, Text, TextAttribute,
-    TextLayout, TextLayoutBuilder,
+    Error, Font, FontBuilder, FontFamily, HitTestPoint, HitTestPosition, LineMetric, Text,
+    TextAttribute, TextLayout, TextLayoutBuilder,
 };
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -73,13 +73,8 @@ impl Text for WebText {
         WebFontBuilder(font)
     }
 
-    fn font(&mut self, family_name: &str) -> Option<Self::Font> {
-        Some(WebFont {
-            family: family_name.to_owned(),
-            size: 0.0,
-            weight: 400,
-            style: FontStyle::Normal,
-        })
+    fn font(&mut self, family_name: &str) -> Option<FontFamily> {
+        Some(FontFamily::new_unchecked(family_name))
     }
 
     fn system_font(&mut self, size: f64) -> Self::Font {
@@ -144,7 +139,7 @@ impl TextLayoutBuilder for WebTextLayoutBuilder {
         self
     }
 
-    fn default_attribute(self, _attribute: impl Into<TextAttribute<Self::Font>>) -> Self {
+    fn default_attribute(self, _attribute: impl Into<TextAttribute>) -> Self {
         web_sys::console::log_1(&"Text attributes not yet implemented for web".into());
         self
     }
@@ -152,7 +147,7 @@ impl TextLayoutBuilder for WebTextLayoutBuilder {
     fn range_attribute(
         self,
         _range: impl RangeBounds<usize>,
-        _attribute: impl Into<TextAttribute<Self::Font>>,
+        _attribute: impl Into<TextAttribute>,
     ) -> Self {
         web_sys::console::log_1(&"Text attributes not yet implemented for web".into());
         self

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -6,9 +6,9 @@ use std::ops::RangeBounds;
 use kurbo::{Affine, Point, Rect, Shape, Size};
 
 use crate::{
-    Color, Error, FixedGradient, Font, FontBuilder, FontFamily, HitTestPoint, HitTestPosition,
-    ImageFormat, InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text,
-    TextAttribute, TextLayout, TextLayoutBuilder,
+    Color, Error, FixedGradient, FontFamily, HitTestPoint, HitTestPosition, ImageFormat,
+    InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextAttribute,
+    TextLayout, TextLayoutBuilder,
 };
 
 /// A render context that doesn't render.
@@ -27,12 +27,6 @@ pub struct NullImage;
 #[derive(Clone)]
 #[doc(hidden)]
 pub struct NullText;
-
-#[doc(hidden)]
-#[derive(Clone)]
-pub struct NullFont;
-#[doc(hidden)]
-pub struct NullFontBuilder;
 
 #[doc(hidden)]
 #[derive(Clone)]
@@ -134,18 +128,8 @@ impl RenderContext for NullRenderContext {
 }
 
 impl Text for NullText {
-    type Font = NullFont;
-    type FontBuilder = NullFontBuilder;
     type TextLayout = NullTextLayout;
     type TextLayoutBuilder = NullTextLayoutBuilder;
-
-    fn new_font_by_name(&mut self, _name: &str, _size: f64) -> Self::FontBuilder {
-        NullFontBuilder
-    }
-
-    fn system_font(&mut self, _size: f64) -> Self::Font {
-        NullFont
-    }
 
     fn new_text_layout(&mut self, _text: &str) -> Self::TextLayoutBuilder {
         NullTextLayoutBuilder
@@ -156,19 +140,8 @@ impl Text for NullText {
     }
 }
 
-impl Font for NullFont {}
-
-impl FontBuilder for NullFontBuilder {
-    type Out = NullFont;
-
-    fn build(self) -> Result<Self::Out, Error> {
-        Ok(NullFont)
-    }
-}
-
 impl TextLayoutBuilder for NullTextLayoutBuilder {
     type Out = NullTextLayout;
-    type Font = NullFont;
 
     fn max_width(self, _width: f64) -> Self {
         self

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -135,7 +135,7 @@ impl Text for NullText {
         NullTextLayoutBuilder
     }
 
-    fn font(&mut self, _family_name: &str) -> Option<FontFamily> {
+    fn font_family(&mut self, _family_name: &str) -> Option<FontFamily> {
         Some(FontFamily::default())
     }
 }

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -6,9 +6,9 @@ use std::ops::RangeBounds;
 use kurbo::{Affine, Point, Rect, Shape, Size};
 
 use crate::{
-    Color, Error, FixedGradient, Font, FontBuilder, HitTestPoint, HitTestPosition, ImageFormat,
-    InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextAttribute,
-    TextLayout, TextLayoutBuilder,
+    Color, Error, FixedGradient, Font, FontBuilder, FontFamily, HitTestPoint, HitTestPosition,
+    ImageFormat, InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text,
+    TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
 /// A render context that doesn't render.
@@ -151,8 +151,8 @@ impl Text for NullText {
         NullTextLayoutBuilder
     }
 
-    fn font(&mut self, _family_name: &str) -> Option<Self::Font> {
-        Some(NullFont)
+    fn font(&mut self, _family_name: &str) -> Option<FontFamily> {
+        Some(FontFamily::default())
     }
 }
 
@@ -178,14 +178,14 @@ impl TextLayoutBuilder for NullTextLayoutBuilder {
         self
     }
 
-    fn default_attribute(self, _attribute: impl Into<TextAttribute<Self::Font>>) -> Self {
+    fn default_attribute(self, _attribute: impl Into<TextAttribute>) -> Self {
         self
     }
 
     fn range_attribute(
         self,
         _range: impl RangeBounds<usize>,
-        _attribute: impl Into<TextAttribute<Self::Font>>,
+        _attribute: impl Into<TextAttribute>,
     ) -> Self {
         self
     }

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -150,6 +150,10 @@ impl Text for NullText {
     fn new_text_layout(&mut self, _text: &str) -> Self::TextLayoutBuilder {
         NullTextLayoutBuilder
     }
+
+    fn font(&mut self, _family_name: &str) -> Option<Self::Font> {
+        Some(NullFont)
+    }
 }
 
 impl Font for NullFont {}

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -18,7 +18,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &BLUE, 1.0);
 
-    let georgia = rc.text().font("Georgia").ok_or(Error::MissingFont)?;
+    let georgia = rc.text().font_family("Georgia").ok_or(Error::MissingFont)?;
 
     let path = arc1();
     rc.stroke(path, &GREEN, 1.0);

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -2,8 +2,8 @@
 
 use crate::kurbo::{Affine, BezPath, Line, Point, Rect, RoundedRect, Size, Vec2};
 use crate::{
-    Color, Error, FontBuilder, ImageFormat, InterpolationMode, RenderContext, Text, TextAttribute,
-    TextLayout, TextLayoutBuilder,
+    Color, Error, ImageFormat, InterpolationMode, RenderContext, Text, TextAttribute, TextLayout,
+    TextLayoutBuilder,
 };
 
 const BLUE: Color = Color::rgb8(0x00, 0x00, 0x80);
@@ -18,8 +18,8 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &BLUE, 1.0);
 
-    let segoe = rc.text().new_font_by_name("Segoe UI", 12.).build()?;
-    let georgia = rc.text().new_font_by_name("Georgia", 8.).build()?;
+    let segoe = rc.text().font("Segoe UI").ok_or(Error::MissingFont)?;
+    let georgia = rc.text().font("Georgia").ok_or(Error::MissingFont)?;
 
     let path = arc1();
     rc.stroke(path, &GREEN, 1.0);

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -2,8 +2,8 @@
 
 use crate::kurbo::{Affine, BezPath, Line, Point, Rect, RoundedRect, Size, Vec2};
 use crate::{
-    Color, Error, ImageFormat, InterpolationMode, RenderContext, Text, TextAttribute, TextLayout,
-    TextLayoutBuilder,
+    Color, Error, FontFamily, ImageFormat, InterpolationMode, RenderContext, Text, TextAttribute,
+    TextLayout, TextLayoutBuilder,
 };
 
 const BLUE: Color = Color::rgb8(0x00, 0x00, 0x80);
@@ -18,7 +18,6 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &BLUE, 1.0);
 
-    let segoe = rc.text().font("Segoe UI").ok_or(Error::MissingFont)?;
     let georgia = rc.text().font("Georgia").ok_or(Error::MissingFont)?;
 
     let path = arc1();
@@ -36,8 +35,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let layout = rc
         .text()
         .new_text_layout("Hello piet!")
-        .default_attribute(segoe)
-        .default_attribute(TextAttribute::Size(12.0))
+        .font(FontFamily::SYSTEM_UI, 12.0)
         .default_attribute(TextAttribute::ForegroundColor(RED_ALPHA))
         .build()?;
 
@@ -85,8 +83,7 @@ pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     let layout = rc
         .text()
         .new_text_layout("CLIPPED")
-        .default_attribute(georgia)
-        .default_attribute(TextAttribute::Size(8.0))
+        .font(georgia, 8.0)
         .default_attribute(TextAttribute::ForegroundColor(RED_ALPHA))
         .build()?;
     rc.draw_text(&layout, (80.0, 50.0));

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -16,7 +16,9 @@ const BLUE: Color = Color::rgb8(0, 0, 255);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
-    let courier = text.font("Courier New").unwrap_or(FontFamily::MONOSPACE);
+    let courier = text
+        .font_family("Courier New")
+        .unwrap_or(FontFamily::MONOSPACE);
     let layout = text
         .new_text_layout(TEXT)
         .max_width(200.0)

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -2,7 +2,8 @@
 
 use crate::kurbo::{Size, Vec2};
 use crate::{
-    Color, Error, FontWeight, RenderContext, Text, TextAttribute, TextLayout, TextLayoutBuilder,
+    Color, Error, FontFamily, FontWeight, RenderContext, Text, TextAttribute, TextLayout,
+    TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(480., 560.);
@@ -15,12 +16,10 @@ const BLUE: Color = Color::rgb8(0, 0, 255);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
-    let font = text.font("system-ui").unwrap();
-    let font2 = text.font("monospace").unwrap();
     let layout = text
         .new_text_layout(TEXT)
         .max_width(200.0)
-        .default_attribute(font2)
+        .default_attribute(FontFamily::MONOSPACE)
         .default_attribute(TextAttribute::Underline(true))
         .default_attribute(TextAttribute::Italic(true))
         .default_attribute(TextAttribute::ForegroundColor(RED))
@@ -30,7 +29,8 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(40..300, TextAttribute::Underline(false))
         .range_attribute(60..160, TextAttribute::Italic(false))
         .range_attribute(140..220, FontWeight::NORMAL)
-        .range_attribute(240.., font)
+        .range_attribute(240.., FontFamily::SYSTEM_UI)
+        .range_attribute(340.., TextAttribute::Size(24.0))
         .build()?;
 
     let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -16,10 +16,11 @@ const BLUE: Color = Color::rgb8(0, 0, 255);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
+    let courier = text.font("Courier New").unwrap_or(FontFamily::MONOSPACE);
     let layout = text
         .new_text_layout(TEXT)
         .max_width(200.0)
-        .default_attribute(FontFamily::MONOSPACE)
+        .default_attribute(courier)
         .default_attribute(TextAttribute::Underline(true))
         .default_attribute(TextAttribute::Italic(true))
         .default_attribute(TextAttribute::ForegroundColor(RED))
@@ -30,7 +31,6 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(60..160, TextAttribute::Italic(false))
         .range_attribute(140..220, FontWeight::NORMAL)
         .range_attribute(240.., FontFamily::SYSTEM_UI)
-        .range_attribute(340.., TextAttribute::Size(24.0))
         .build()?;
 
     let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -2,8 +2,7 @@
 
 use crate::kurbo::{Size, Vec2};
 use crate::{
-    Color, Error, FontBuilder, FontWeight, RenderContext, Text, TextAttribute, TextLayout,
-    TextLayoutBuilder,
+    Color, Error, FontWeight, RenderContext, Text, TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(480., 560.);
@@ -16,8 +15,8 @@ const BLUE: Color = Color::rgb8(0, 0, 255);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
-    let font = text.system_font(12.0);
-    let font2 = text.new_font_by_name("Courier New", 12.0).build().unwrap();
+    let font = text.font("system-ui").unwrap();
+    let font2 = text.font("monospace").unwrap();
     let layout = text
         .new_text_layout(TEXT)
         .max_width(200.0)

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -2,26 +2,19 @@
 
 use crate::kurbo::Size;
 use crate::{
-    Color, Error, FontBuilder, FontWeight, RenderContext, Text, TextAlignment, TextAttribute,
-    TextLayoutBuilder,
+    Color, Error, FontWeight, RenderContext, Text, TextAlignment, TextAttribute, TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(400., 800.);
 
 static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
-const SERIF: &str = "Times New Roman";
-#[cfg(target_os = "windows")]
-const MONO: &str = "Courier New";
-#[cfg(not(target_os = "windows"))]
-const MONO: &str = "Courier";
-
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
-    let font = text.system_font(12.0);
-    let serif = text.new_font_by_name(SERIF, 20.0).build().unwrap();
-    let mono = text.new_font_by_name(MONO, 12.0).build().unwrap();
+    let font = text.font("system-ui").unwrap();
+    let serif = text.font("serif").unwrap();
+    let mono = text.font("monospace").unwrap();
 
     let en_leading = text
         .new_text_layout(SAMPLE_EN)

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -2,7 +2,8 @@
 
 use crate::kurbo::Size;
 use crate::{
-    Color, Error, FontWeight, RenderContext, Text, TextAlignment, TextAttribute, TextLayoutBuilder,
+    Color, Error, FontFamily, FontWeight, RenderContext, Text, TextAlignment, TextAttribute,
+    TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(400., 800.);
@@ -12,20 +13,17 @@ static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
-    let font = text.font("system-ui").unwrap();
-    let serif = text.font("serif").unwrap();
-    let mono = text.font("monospace").unwrap();
 
     let en_leading = text
         .new_text_layout(SAMPLE_EN)
         .max_width(200.0)
-        .default_attribute(font)
+        .default_attribute(FontFamily::SYSTEM_UI)
         .alignment(TextAlignment::Start)
         .range_attribute(10..80, TextAttribute::Size(8.0))
-        .range_attribute(20..120, serif)
+        .range_attribute(20..120, FontFamily::SERIF)
         .range_attribute(40..60, FontWeight::BOLD)
         .range_attribute(60..140, FontWeight::THIN)
-        .range_attribute(90..300, mono)
+        .range_attribute(90..300, FontFamily::MONOSPACE)
         .range_attribute(
             120..150,
             TextAttribute::ForegroundColor(Color::rgb(0.6, 0., 0.)),

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -25,7 +25,9 @@ const GREEN: Color = Color::rgb8(105, 255, 0);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
     let text = rc.text();
-    let courier = text.font("Courier New").unwrap_or(FontFamily::MONOSPACE);
+    let courier = text
+        .font_family("Courier New")
+        .unwrap_or(FontFamily::MONOSPACE);
     let layout = text
         .new_text_layout(SAMPLE_EN)
         .max_width(200.0)

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -25,17 +25,15 @@ const GREEN: Color = Color::rgb8(105, 255, 0);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
     let text = rc.text();
-
+    let courier = text.font("Courier New").unwrap_or(FontFamily::MONOSPACE);
     let layout = text
         .new_text_layout(SAMPLE_EN)
-        .default_attribute(FontFamily::SYSTEM_UI)
-        .default_attribute(TextAttribute::Size(24.0))
         .max_width(200.0)
         .alignment(TextAlignment::Start)
-        .default_attribute(TextAttribute::Size(24.0))
-        .range_attribute(23..35, FontFamily::MONOSPACE)
+        .font(FontFamily::SYSTEM_UI, 24.0)
+        .range_attribute(23..35, courier.clone())
         .range_attribute(23..35, TextAttribute::Size(18.0))
-        .range_attribute(47..52, FontFamily::MONOSPACE)
+        .range_attribute(47..52, courier)
         .range_attribute(47..52, TextAttribute::Size(36.0))
         .build()?;
 

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -2,7 +2,8 @@
 
 use crate::kurbo::{Line, Size, Vec2};
 use crate::{
-    Color, Error, RenderContext, Text, TextAlignment, TextAttribute, TextLayout, TextLayoutBuilder,
+    Color, Error, FontFamily, RenderContext, Text, TextAlignment, TextAttribute, TextLayout,
+    TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(464., 800.);
@@ -24,19 +25,17 @@ const GREEN: Color = Color::rgb8(105, 255, 0);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
     let text = rc.text();
-    let font = text.font("system-ui").unwrap();
-    let mono = text.font("monospace").unwrap();
 
     let layout = text
         .new_text_layout(SAMPLE_EN)
-        .default_attribute(font)
+        .default_attribute(FontFamily::SYSTEM_UI)
         .default_attribute(TextAttribute::Size(24.0))
         .max_width(200.0)
         .alignment(TextAlignment::Start)
         .default_attribute(TextAttribute::Size(24.0))
-        .range_attribute(23..35, mono.clone())
+        .range_attribute(23..35, FontFamily::MONOSPACE)
         .range_attribute(23..35, TextAttribute::Size(18.0))
-        .range_attribute(47..52, mono)
+        .range_attribute(47..52, FontFamily::MONOSPACE)
         .range_attribute(47..52, TextAttribute::Size(36.0))
         .build()?;
 

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -2,8 +2,7 @@
 
 use crate::kurbo::{Line, Size, Vec2};
 use crate::{
-    Color, Error, FontBuilder, RenderContext, Text, TextAlignment, TextAttribute, TextLayout,
-    TextLayoutBuilder,
+    Color, Error, RenderContext, Text, TextAlignment, TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(464., 800.);
@@ -25,11 +24,8 @@ const GREEN: Color = Color::rgb8(105, 255, 0);
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(LIGHT_GREY);
     let text = rc.text();
-    let font = text.system_font(24.0);
-    let mono = text
-        .new_font_by_name("Courier New", 18.0)
-        .build()
-        .expect("missing Courier New");
+    let font = text.font("system-ui").unwrap();
+    let mono = text.font("monospace").unwrap();
 
     let layout = text
         .new_text_layout(SAMPLE_EN)

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -10,34 +10,14 @@ pub trait Text: Clone {
     type TextLayoutBuilder: TextLayoutBuilder<Out = Self::TextLayout>;
     type TextLayout: TextLayout;
 
-    /// Returns a a [`Font`] object corresponding to the given family name,
-    /// if one can be found.
+    /// Query the platform for a font with a given name, and return a `FontFamily`
+    /// object corresponding to that font, if it is found.
     ///
-    /// The family name should be either the explicit name of a font family
-    /// (such as "Times New Roman", or "Helvetica") or it can be a "generic
-    /// family name"; see below.
-    ///
-    /// ## Platform behaviour:
-    ///
-    /// Different platforms may search for fonts in different ways. On macOS,
-    /// for instance, passing "courier" will (assuming "Courier" is not installed)
-    /// will return "Courier New". on Windows, in the same situation, it will return
-    /// `None`. You should assume that matching is literal, and you should try
-    /// to use known literal names.
-    ///
-    /// ## Generic family names
-    ///
-    /// We provide limited support for "generic family names", as defined by CSS.
-    /// Currently, we support four of these names: `serif`, `sans-serif`, `monospace`,
-    /// and `system-ui`. These are available as constants on the [`Font`] trait.
-    ///
-    /// If you use a generic family name, this API **will not fail**, although
-    /// we do not guarantee we will always return an appropriate font; if nothing
-    /// can be found we will let the platform pick a fallback for us.
+    /// If that font exists, `Some` will be returned,
     ///
     /// # Examples
     ///
-    /// Using the system UI font:
+    /// Trying a preferred font, falling back if it isn't found.
     ///
     /// ```
     /// # use piet::*;
@@ -58,6 +38,20 @@ pub trait Text: Clone {
     fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder;
 }
 
+/// A reference to a font family.
+///
+/// This may be either a CSS-style "generic family name", such as "serif"
+/// or "monospace", or it can be an explicit family name.
+///
+/// To use a generic family name, use the provided associated constants:
+/// `FontFamily::SERIF`, `FontFamily::SANS_SERIF`, `FontFamily::SYSTEM_UI`,
+/// and `FontFamily::MONOSPACE`.
+///
+/// To use a specific font family you should not construct this type directly;
+/// instead you should verify that the desired family exists, via the
+/// [`Text::font`] API.
+///
+/// [`Text::font`]: trait.Text.html#tymethod.font
 #[derive(Debug, Clone)]
 pub struct FontFamily {
     inner: ArcOrStaticStr,

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -52,7 +52,7 @@ pub trait Text: Clone {
 /// [`Text::font`] API.
 ///
 /// [`Text::font`]: trait.Text.html#tymethod.font
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FontFamily {
     inner: ArcOrStaticStr,
 }
@@ -84,6 +84,13 @@ impl FontFamily {
 
     pub fn as_str(&self) -> &str {
         self.inner.as_ref()
+    }
+
+    pub fn is_generic_family(&self) -> bool {
+        self == &FontFamily::SYSTEM_UI
+            || self == &FontFamily::SERIF
+            || self == &FontFamily::SANS_SERIF
+            || self == &FontFamily::MONOSPACE
     }
 }
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -172,14 +172,32 @@ impl ArcOrStaticStr {
     pub(crate) fn new_arc(s: Arc<str>) -> Self {
         ArcOrStaticStr::Arc(s)
     }
-}
 
-impl AsRef<str> for ArcOrStaticStr {
-    fn as_ref(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         match self {
             ArcOrStaticStr::Arc(s) => &s,
             ArcOrStaticStr::Static(s) => s,
         }
+    }
+}
+
+impl AsRef<str> for ArcOrStaticStr {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq for ArcOrStaticStr {
+    fn eq(&self, other: &ArcOrStaticStr) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for ArcOrStaticStr {}
+
+impl std::hash::Hash for ArcOrStaticStr {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
     }
 }
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -1,7 +1,6 @@
 //! Code useful for multiple backends
 
 use std::ops::{Bound, Range, RangeBounds};
-use std::sync::Arc;
 
 use crate::kurbo::{Rect, Size};
 use crate::{Color, FontFamily, FontWeight, TextAttribute};
@@ -151,53 +150,6 @@ impl Default for LayoutDefaults {
             italic: false,
             underline: false,
         }
-    }
-}
-
-/// Kind of like a Cow, but dumber and simpler.
-///
-/// The main rationale for this type is that we can have a `const` constructor,
-/// which we can't have for `Arc<str>` on its own.
-#[derive(Debug, Clone)]
-pub(crate) enum ArcOrStaticStr {
-    Arc(Arc<str>),
-    Static(&'static str),
-}
-
-impl ArcOrStaticStr {
-    pub(crate) const fn new_const(s: &'static str) -> Self {
-        ArcOrStaticStr::Static(s)
-    }
-
-    pub(crate) fn new_arc(s: Arc<str>) -> Self {
-        ArcOrStaticStr::Arc(s)
-    }
-
-    pub(crate) fn as_str(&self) -> &str {
-        match self {
-            ArcOrStaticStr::Arc(s) => &s,
-            ArcOrStaticStr::Static(s) => s,
-        }
-    }
-}
-
-impl AsRef<str> for ArcOrStaticStr {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl PartialEq for ArcOrStaticStr {
-    fn eq(&self, other: &ArcOrStaticStr) -> bool {
-        self.as_str() == other.as_str()
-    }
-}
-
-impl Eq for ArcOrStaticStr {}
-
-impl std::hash::Hash for ArcOrStaticStr {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.as_str().hash(state);
     }
 }
 


### PR DESCRIPTION
This PR is now a big rollup of font-related changes, including:

- use of a `FontFamily` type as the token you receive when querying a font
- non-failable 'generic font families' (`FontFamily::SERIF`, e.g.)
- removal of `Font` and `FontBuilder` traits
- a bunch of doc improvements around text


This is hopefully the last major API change; there are still a few API additions to make, but hopefully nothing earth-shattering.