### PR TITLE
Remove LineMetric.cumulative_height

### DIFF
--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -33,7 +33,7 @@ pub(crate) fn calculate_line_metrics(text: &str, font: &ScaledFont, width: f64) 
     let mut line_metrics = Vec::new();
     let mut line_start = 0;
     let mut prev_break = 0;
-    let mut cumulative_height = 0.0;
+    let mut y_offset = 0.0;
 
     // vertical measures constant across all lines for now (cairo toy text)
     let height = font.extents().height;
@@ -66,7 +66,7 @@ pub(crate) fn calculate_line_metrics(text: &str, font: &ScaledFont, width: f64) 
                     prev_break,
                     baseline,
                     height,
-                    &mut cumulative_height,
+                    &mut y_offset,
                     &mut line_metrics,
                 );
 
@@ -86,7 +86,7 @@ pub(crate) fn calculate_line_metrics(text: &str, font: &ScaledFont, width: f64) 
                         line_break,
                         baseline,
                         height,
-                        &mut cumulative_height,
+                        &mut y_offset,
                         &mut line_metrics,
                     );
 
@@ -123,7 +123,7 @@ pub(crate) fn calculate_line_metrics(text: &str, font: &ScaledFont, width: f64) 
                         prev_break,
                         baseline,
                         height,
-                        &mut cumulative_height,
+                        &mut y_offset,
                         &mut line_metrics,
                     );
 
@@ -138,7 +138,7 @@ pub(crate) fn calculate_line_metrics(text: &str, font: &ScaledFont, width: f64) 
                 line_break,
                 baseline,
                 height,
-                &mut cumulative_height,
+                &mut y_offset,
                 &mut line_metrics,
             );
             line_start = line_break;
@@ -155,12 +155,9 @@ fn add_line_metric(
     end_offset: usize,
     baseline: f64,
     height: f64,
-    cumulative_height: &mut f64,
+    y_offset: &mut f64,
     line_metrics: &mut Vec<LineMetric>,
 ) {
-    let y_offset = *cumulative_height;
-    *cumulative_height += height;
-
     let line = &text[start_offset..end_offset];
     let trailing_whitespace = count_trailing_whitespace(line);
 
@@ -171,10 +168,10 @@ fn add_line_metric(
         trailing_whitespace,
         baseline,
         height,
-        y_offset,
-        cumulative_height: *cumulative_height,
+        y_offset: *y_offset,
     };
     line_metrics.push(line_metric);
+    *y_offset += height;
 }
 
 // TODO: is non-breaking space trailing whitespace? Check with dwrite and
@@ -328,7 +325,6 @@ mod test {
                 end_offset: 5,
                 trailing_whitespace: 1,
                 y_offset: 0.,
-                cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -337,7 +333,6 @@ mod test {
                 end_offset: 10,
                 trailing_whitespace: 1,
                 y_offset: 14.0,
-                cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -346,7 +341,6 @@ mod test {
                 end_offset: 15,
                 trailing_whitespace: 1,
                 y_offset: 28.0,
-                cumulative_height: 42.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -355,7 +349,6 @@ mod test {
                 end_offset: 19,
                 trailing_whitespace: 0,
                 y_offset: 42.0,
-                cumulative_height: 56.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -368,7 +361,6 @@ mod test {
                 end_offset: 10,
                 trailing_whitespace: 1,
                 y_offset: 0.0,
-                cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -377,7 +369,6 @@ mod test {
                 end_offset: 19,
                 trailing_whitespace: 0,
                 y_offset: 14.0,
-                cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -389,7 +380,6 @@ mod test {
             end_offset: 19,
             trailing_whitespace: 0,
             y_offset: 0.0,
-            cumulative_height: 14.0,
             baseline: 12.0,
             height: 14.0,
         }];
@@ -400,7 +390,6 @@ mod test {
             end_offset: 0,
             trailing_whitespace: 0,
             y_offset: 0.0,
-            cumulative_height: 14.0,
             baseline: 12.0,
             height: 14.0,
         }];
@@ -448,7 +437,6 @@ mod test {
                 end_offset: 5,
                 trailing_whitespace: 1,
                 y_offset: 0.0,
-                cumulative_height: 14.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -457,7 +445,6 @@ mod test {
                 end_offset: 10,
                 trailing_whitespace: 1,
                 y_offset: 14.0,
-                cumulative_height: 28.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -466,7 +453,6 @@ mod test {
                 end_offset: 15,
                 trailing_whitespace: 1,
                 y_offset: 28.0,
-                cumulative_height: 42.0,
                 baseline: 12.0,
                 height: 14.0,
             },
@@ -475,7 +461,6 @@ mod test {
                 end_offset: 19,
                 trailing_whitespace: 0,
                 y_offset: 42.0,
-                cumulative_height: 56.0,
                 baseline: 12.0,
                 height: 14.0,
             },

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -505,7 +505,6 @@ impl TextLayout for CoreGraphicsTextLayout {
         let leading = (typo_bounds.leading + 0.5).floor();
         let height = ascent + descent + leading;
         let y_offset = self.line_y_positions[line_number] - ascent;
-        let cumulative_height = self.line_y_positions[line_number] + descent + leading;
         #[allow(deprecated)]
         Some(LineMetric {
             start_offset,
@@ -513,7 +512,6 @@ impl TextLayout for CoreGraphicsTextLayout {
             trailing_whitespace,
             baseline: typo_bounds.ascent,
             height,
-            cumulative_height,
             y_offset,
         })
     }

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -6,7 +6,7 @@ pub(crate) fn fetch_line_metrics(text: &str, layout: &dwrite::TextLayout) -> Vec
     layout.get_line_metrics(&mut raw_line_metrics);
 
     let mut offset_utf8 = 0;
-    let mut cumulative_height = 0.0;
+    let mut y_offset = 0.0;
 
     let mut out = Vec::with_capacity(raw_line_metrics.len());
 
@@ -19,8 +19,6 @@ pub(crate) fn fetch_line_metrics(text: &str, layout: &dwrite::TextLayout) -> Vec
         );
 
         let end_offset = offset_utf8 + non_ws_len_8 + ws_len_8;
-        let y_offset = cumulative_height;
-        cumulative_height += raw_metric.height as f64;
 
         #[allow(deprecated)]
         let metric = LineMetric {
@@ -29,10 +27,10 @@ pub(crate) fn fetch_line_metrics(text: &str, layout: &dwrite::TextLayout) -> Vec
             trailing_whitespace: ws_len_8,
             height: raw_metric.height as f64,
             y_offset,
-            cumulative_height,
             baseline: raw_metric.baseline as f64,
         };
 
+        y_offset += metric.height;
         offset_utf8 = end_offset;
         out.push(metric);
     }
@@ -98,7 +96,6 @@ mod test {
                 end_offset: 5,
                 trailing_whitespace: 1,
                 y_offset: 0.0,
-                cumulative_height: 15.960_937_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
             },
@@ -107,7 +104,6 @@ mod test {
                 end_offset: 10,
                 trailing_whitespace: 1,
                 y_offset: 15.960_937_5,
-                cumulative_height: 31.921_875,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
             },
@@ -116,7 +112,6 @@ mod test {
                 end_offset: 15,
                 trailing_whitespace: 1,
                 y_offset: 31.921_875,
-                cumulative_height: 47.882_812_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
             },
@@ -125,7 +120,6 @@ mod test {
                 end_offset: 19,
                 trailing_whitespace: 0,
                 y_offset: 47.882_812_5,
-                cumulative_height: 63.843_75,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
             },
@@ -138,7 +132,6 @@ mod test {
                 end_offset: 10,
                 trailing_whitespace: 1,
                 y_offset: 0.0,
-                cumulative_height: 15.960_937_5,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
             },
@@ -147,7 +140,6 @@ mod test {
                 end_offset: 19,
                 trailing_whitespace: 0,
                 y_offset: 15.960_937_5,
-                cumulative_height: 31.921_875,
                 baseline: 12.949_218_75,
                 height: 15.960_937_5,
             },
@@ -159,7 +151,6 @@ mod test {
             end_offset: 19,
             trailing_whitespace: 0,
             y_offset: 0.0,
-            cumulative_height: 15.960_937_5,
             baseline: 12.949_218_75,
             height: 15.960_937_5,
         }];
@@ -170,7 +161,6 @@ mod test {
             end_offset: 0,
             trailing_whitespace: 0,
             y_offset: 0.0,
-            cumulative_height: 15.960_937_5,
             baseline: 12.949_218_75,
             height: 15.960_937_5,
         }];

--- a/piet-web/src/text/lines.rs
+++ b/piet-web/src/text/lines.rs
@@ -47,7 +47,7 @@ pub(crate) fn calculate_line_metrics(
     let mut line_metrics = Vec::new();
     let mut line_start = 0;
     let mut prev_break = 0;
-    let mut cumulative_height = 0.0;
+    let mut y_offset = 0.0;
 
     // Vertical measures constant across all lines for now (web text)
     // We use heuristics because we don't have access to web apis through web-sys yet.
@@ -81,7 +81,7 @@ pub(crate) fn calculate_line_metrics(
                     prev_break,
                     baseline,
                     height,
-                    &mut cumulative_height,
+                    &mut y_offset,
                     &mut line_metrics,
                 );
 
@@ -101,7 +101,7 @@ pub(crate) fn calculate_line_metrics(
                         line_break,
                         baseline,
                         height,
-                        &mut cumulative_height,
+                        &mut y_offset,
                         &mut line_metrics,
                     );
 
@@ -138,7 +138,7 @@ pub(crate) fn calculate_line_metrics(
                         prev_break,
                         baseline,
                         height,
-                        &mut cumulative_height,
+                        &mut y_offset,
                         &mut line_metrics,
                     );
 
@@ -153,7 +153,7 @@ pub(crate) fn calculate_line_metrics(
                 line_break,
                 baseline,
                 height,
-                &mut cumulative_height,
+                &mut y_offset,
                 &mut line_metrics,
             );
             line_start = line_break;
@@ -170,12 +170,9 @@ fn add_line_metric(
     end_offset: usize,
     baseline: f64,
     height: f64,
-    cumulative_height: &mut f64,
+    y_offset: &mut f64,
     line_metrics: &mut Vec<LineMetric>,
 ) {
-    let y_offset = *cumulative_height;
-    *cumulative_height += height;
-
     let line = &text[start_offset..end_offset];
     let trailing_whitespace = count_trailing_whitespace(line);
 
@@ -186,10 +183,10 @@ fn add_line_metric(
         trailing_whitespace,
         baseline,
         height,
-        cumulative_height: *cumulative_height,
-        y_offset,
+        y_offset: *y_offset,
     };
     line_metrics.push(line_metric);
+    *y_offset += height;
 }
 
 // TODO: is non-breaking space trailing whitespace? Check with dwrite and

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -254,7 +254,6 @@ pub enum TextAlignment {
 /// - line trailing whitespace (in UTF-8 code units)
 /// - line's baseline, distance of the baseline from the top of the line
 /// - line height
-/// - cumulative line height (includes previous line heights)
 ///
 /// The trailing whitespace distinction is important. Lines are broken at the grapheme boundary after
 /// whitespace, but that whitepace is not necessarily rendered since it's just the trailing
@@ -403,10 +402,6 @@ pub struct LineMetric {
     /// that `y_offset + height` for line `n` is equal to the `y_offset` of
     /// line `n + 1`, this is not strictly enforced, and should not be counted on.
     pub height: f64,
-
-    /// Cumulative line height (includes previous line heights)
-    #[deprecated(since = "0.2.0", note = "use y_offset instead")]
-    pub cumulative_height: f64,
 
     /// The y position of the top of this line, relative to the top of the layout.
     ///


### PR DESCRIPTION
This was marked deprecated but we've already broken the API so
no need to keep it around.