### PR TITLE
Add TextLayout::text and TextLayout::rects_for_range

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -167,6 +167,10 @@ impl TextLayout for CairoTextLayout {
         self.size.to_rect()
     }
 
+    fn text(&self) -> &str {
+        &self.text
+    }
+
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error> {
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -207,6 +207,10 @@ impl TextLayout for D2DTextLayout {
         self.size.to_rect() + self.inking_insets
     }
 
+    fn text(&self) -> &str {
+        &self.text
+    }
+
     /// given a new max width, update width of text layout to fit within the max width
     // TODO add this doc to trait method? or is this windows specific?
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error> {

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -105,4 +105,8 @@ impl piet::TextLayout for TextLayout {
     fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestPosition> {
         unimplemented!()
     }
+
+    fn text(&self) -> &str {
+        unimplemented!()
+    }
 }

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -161,6 +161,10 @@ impl TextLayout for WebTextLayout {
         self.size.to_rect()
     }
 
+    fn text(&self) -> &str {
+        &self.text
+    }
+
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) -> Result<(), Error> {
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -204,6 +204,10 @@ impl TextLayout for NullTextLayout {
     fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestPosition> {
         None
     }
+
+    fn text(&self) -> &str {
+        ""
+    }
 }
 
 impl IntoBrush<NullRenderContext> for NullBrush {

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -21,11 +21,12 @@ mod picture_9;
 
 mod picture_10;
 mod picture_11;
+mod picture_12;
 
 type BoxErr = Box<dyn std::error::Error>;
 
 /// The total number of samples in this module.
-pub const SAMPLE_COUNT: usize = 12;
+pub const SAMPLE_COUNT: usize = 13;
 
 /// file we save an os fingerprint to
 pub const GENERATED_BY: &str = "GENERATED_BY";
@@ -45,6 +46,7 @@ pub fn get<R: RenderContext>(number: usize) -> SamplePicture<R> {
         9 => SamplePicture::new(picture_9::SIZE, picture_9::draw),
         10 => SamplePicture::new(picture_10::SIZE, picture_10::draw),
         11 => SamplePicture::new(picture_11::SIZE, picture_11::draw),
+        12 => SamplePicture::new(picture_12::SIZE, picture_12::draw),
         _ => panic!("No sample #{} exists", number),
     }
 }

--- a/piet/src/samples/picture_12.rs
+++ b/piet/src/samples/picture_12.rs
@@ -1,0 +1,44 @@
+//! range attributes should override default attributes
+
+use crate::kurbo::{Size, Vec2};
+use crate::{
+    Color, Error, FontFamily, RenderContext, Text, TextAttribute, TextLayout, TextLayoutBuilder,
+};
+
+pub const SIZE: Size = Size::new(480., 560.);
+
+static TEXT: &str = r#"The idea of "structurelessness," however, has moved from a healthy counter to those tendencies to becoming a goddess in its own right. The idea is as little examined as the term is much used, but it has become an intrinsic and unquestioned part of women's liberation ideology. For the early development of the movement this did not much matter."#;
+
+const SELECTION_COLOR: Color = Color::rgb8(165, 205, 255);
+const HILIGHT_COLOR: Color = Color::rgba8(255, 242, 54, 96);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(Color::WHITE);
+    let text = rc.text();
+    let font2 = text.font_family("Courier New").unwrap();
+    let layout = text
+        .new_text_layout(TEXT)
+        .max_width(200.0)
+        .font(FontFamily::SYSTEM_UI, 12.0)
+        .range_attribute(280.., font2)
+        .range_attribute(280.., TextAttribute::Size(18.0))
+        .build()?;
+
+    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+    let text_pos = Vec2::new(16.0, y_pos);
+
+    let sel_one = layout.rects_for_range(10..72);
+    let sel_two = layout.rects_for_range(240..);
+
+    for rect in sel_one {
+        rc.fill(rect + text_pos, &SELECTION_COLOR);
+    }
+
+    rc.draw_text(&layout, text_pos.to_point());
+
+    for rect in sel_two {
+        rc.fill(rect + text_pos, &HILIGHT_COLOR);
+    }
+
+    Ok(())
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -358,6 +358,9 @@ pub trait TextLayout: Clone {
     /// This is sometimes called the bounding box or the inking rect.
     fn image_bounds(&self) -> Rect;
 
+    /// The text used to create this layout.
+    fn text(&self) -> &str;
+
     /// Change the width of this `TextLayout`.
     ///
     /// This may be an `f64`, or `None` if this layout is not constrained;
@@ -427,6 +430,50 @@ pub trait TextLayout: Clone {
     //case would be when trimming has caused an index to not be included in the
     //layout's text?`
     fn hit_test_text_position(&self, idx: usize) -> Option<HitTestPosition>;
+
+    /// Returns a vector of `Rect`s that cover the region of the text indicated
+    /// by `range`.
+    ///
+    /// The returned rectangles are suitable for things like drawing selection
+    /// regions or highlights.
+    ///
+    /// `range` will be clamped to the length of the text if necessary.
+    ///
+    /// Note: this implementation is not currently BiDi aware; it will be updated
+    /// when BiDi support is added.
+    fn rects_for_range(&self, range: impl RangeBounds<usize>) -> Vec<Rect> {
+        let text_len = self.text().len();
+        let mut range = crate::util::resolve_range(range, text_len);
+        range.start = range.start.min(text_len);
+        range.end = range.end.min(text_len);
+
+        let first_line = self.hit_test_text_position(range.start).unwrap().line;
+        let last_line = self.hit_test_text_position(range.end).unwrap().line;
+
+        let mut result = Vec::new();
+
+        for line in first_line..=last_line {
+            let metrics = self.line_metric(line).unwrap();
+            let y0 = metrics.y_offset;
+            let y1 = y0 + metrics.height;
+            let line_range_start = if line == first_line {
+                range.start
+            } else {
+                metrics.start_offset
+            };
+
+            let line_range_end = if line == last_line {
+                range.end
+            } else {
+                metrics.end_offset - metrics.trailing_whitespace
+            };
+            let start_point = self.hit_test_text_position(line_range_start).unwrap();
+            let end_point = self.hit_test_text_position(line_range_end).unwrap();
+            result.push(Rect::new(start_point.point.x, y0, end_point.point.x, y1));
+        }
+
+        result
+    }
 }
 
 /// Metadata about each line in a text layout.


### PR DESCRIPTION
The TextLayout::text was added because we need access to the
length of the text in order to provide a nice default implementation
for TextLayout::rects_for_range.

This also includes a new sample picture, picture_12, which
illustrates drawing selections and highlights.

![coregraphics-test-12](https://user-images.githubusercontent.com/3330916/89313087-0d744580-d646-11ea-9cd5-2b3877c799c3.png)
