### PR TITLE
Support wght axis when present on a variable font

### DIFF
--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -388,6 +388,12 @@ impl FontCollection {
 extern "C" {
     static kCTFontFamilyNameKey: CFStringRef;
 
+    pub static kCTFontVariationAxisIdentifierKey: CFStringRef;
+    //static kCTFontVariationAxisMinimumValueKey: CFStringRef;
+    //static kCTFontVariationAxisMaximumValueKey: CFStringRef;
+    //static kCTFontVariationAxisDefaultValueKey: CFStringRef;
+    //pub static kCTFontVariationAxisNameKey: CFStringRef;
+
     fn CTFrameGetLines(frame: CTFrameRef) -> CFArrayRef;
     fn CTFontCreateUIFontForLanguage(
         font_type: CTFontUIFontType,

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -249,9 +249,12 @@ impl CoreGraphicsTextLayoutBuilder {
             let descriptor = font_descriptor::new_from_attributes(&attributes);
             let font = font::new_from_descriptor(&descriptor, self.attrs.size());
 
-            // if this font supports variations, use them for weight
+            // if this font supports variations, use them for weight, unless it's a system font
+            // (then things get weird)
             let variation_axes = match font.get_variation_axes() {
                 None => return font,
+                // skip system fonts
+                Some(_) if self.attrs.font().is_generic() => return font,
                 Some(axes) => axes
                     .iter()
                     .flat_map(|dict| {

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -222,7 +222,7 @@ impl CoreGraphicsTextLayoutBuilder {
         //store a tuple of attributes resolved to a generated CTFont.
 
         // 'wght' as an int
-        const WEIGHT_AXIS_ID: i32 = 2003265652;
+        const WEIGHT_AXIS_TAG: i32 = make_opentype_tag("wght") as i32;
 
         unsafe {
             let family_key =
@@ -267,11 +267,11 @@ impl CoreGraphicsTextLayoutBuilder {
             };
 
             // only set weight axis if it exists
-            if !variation_axes.contains(&WEIGHT_AXIS_ID) {
+            if !variation_axes.contains(&WEIGHT_AXIS_TAG) {
                 return font;
             }
 
-            let weight_axis_id: CFNumber = WEIGHT_AXIS_ID.into();
+            let weight_axis_id: CFNumber = WEIGHT_AXIS_TAG.into();
             let descriptor = font_descriptor::CTFontDescriptorCreateCopyWithVariation(
                 descriptor.as_concrete_TypeRef(),
                 weight_axis_id.as_concrete_TypeRef(),
@@ -791,6 +791,16 @@ impl CoreGraphicsTextLayout {
             );
         }
     }
+}
+
+/// Generate an opentype tag. The string should be exactly 4 bytes long.
+///
+/// ```no_compile
+/// const WEIGHT_AXIS = make_opentype_tag("wght");
+/// ```
+const fn make_opentype_tag(raw: &str) -> u32 {
+    let b = raw.as_bytes();
+    ((b[0] as u32) << 24) | ((b[1] as u32) << 16) | ((b[2] as u32) << 8) | (b[3] as u32)
 }
 
 #[cfg(test)]

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -23,11 +23,12 @@ mod picture_10;
 mod picture_11;
 mod picture_12;
 mod picture_13;
+mod picture_14;
 
 type BoxErr = Box<dyn std::error::Error>;
 
 /// The total number of samples in this module.
-pub const SAMPLE_COUNT: usize = 14;
+pub const SAMPLE_COUNT: usize = 15;
 
 /// file we save an os fingerprint to
 pub const GENERATED_BY: &str = "GENERATED_BY";
@@ -49,6 +50,7 @@ pub fn get<R: RenderContext>(number: usize) -> SamplePicture<R> {
         11 => SamplePicture::new(picture_11::SIZE, picture_11::draw),
         12 => SamplePicture::new(picture_12::SIZE, picture_12::draw),
         13 => SamplePicture::new(picture_13::SIZE, picture_13::draw),
+        14 => SamplePicture::new(picture_14::SIZE, picture_14::draw),
         _ => panic!("No sample #{} exists", number),
     }
 }

--- a/piet/src/samples/picture_14.rs
+++ b/piet/src/samples/picture_14.rs
@@ -1,0 +1,43 @@
+//! Setting font weight when a variable font has a 'wght' axis
+
+use crate::kurbo::{Size, Vec2};
+use crate::{
+    Color, Error, FontFamily, FontWeight, RenderContext, Text, TextLayout, TextLayoutBuilder,
+};
+
+pub const SIZE: Size = Size::new(480., 560.);
+
+static TEXT: &str = r#"100200300400500
+600700800900950"#;
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(Color::WHITE);
+    let text = rc.text();
+    let font = text
+        .load_font(include_bytes!(
+            "../../../snapshots/resources/Inconsolata-variable.ttf"
+        ))
+        .unwrap_or(FontFamily::SYSTEM_UI);
+
+    let layout = text
+        .new_text_layout(TEXT)
+        .max_width(200.0)
+        .font(font, 24.0)
+        .range_attribute(..3, FontWeight::THIN)
+        .range_attribute(3..6, FontWeight::EXTRA_LIGHT)
+        .range_attribute(6..9, FontWeight::LIGHT)
+        .range_attribute(9..12, FontWeight::REGULAR)
+        .range_attribute(12..15, FontWeight::MEDIUM)
+        .range_attribute(16..19, FontWeight::SEMI_BOLD)
+        .range_attribute(19..22, FontWeight::BOLD)
+        .range_attribute(22..25, FontWeight::EXTRA_BOLD)
+        .range_attribute(25..28, FontWeight::BLACK)
+        .range_attribute(28..31, FontWeight::EXTRA_BLACK)
+        .build()?;
+
+    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+    let text_pos = Vec2::new(16.0, y_pos);
+    rc.draw_text(&layout, text_pos.to_point());
+
+    Ok(())
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -152,6 +152,11 @@ impl FontFamily {
         }
     }
 
+    /// Returns `true` if this is a generic font family.
+    pub fn is_generic(&self) -> bool {
+        !matches!(self.0, FontFamilyInner::Named(_))
+    }
+
     /// Backend-only API; access the inner `FontFamilyInner` enum.
     #[doc(hidden)]
     pub fn inner(&self) -> &FontFamilyInner {


### PR DESCRIPTION
We don't expose fine grained control for variable fonts, but if
a font has a weight axis, we will use it.