### PR TITLE
Standardize behaviour of TextLayout::hit_test_text_position

### DIFF
--- a/piet-cairo/src/text/grapheme.rs
+++ b/piet-cairo/src/text/grapheme.rs
@@ -15,8 +15,8 @@ pub(crate) fn get_grapheme_boundaries(
     let (text_position, _) = graphemes.nth(grapheme_position)?;
     let (next_text_position, _) = graphemes.next().unwrap_or_else(|| (text.len(), ""));
 
-    let curr_edge = hit_test_line_position(font, text, text_position)?;
-    let next_edge = hit_test_line_position(font, text, next_text_position)?;
+    let curr_edge = hit_test_line_position(font, text, text_position);
+    let next_edge = hit_test_line_position(font, text, next_text_position);
 
     let res = GraphemeBoundaries {
         curr_idx: text_position,

--- a/piet-web/src/text/grapheme.rs
+++ b/piet-web/src/text/grapheme.rs
@@ -20,8 +20,8 @@ pub(crate) fn get_grapheme_boundaries(
     let (text_position, _) = graphemes.nth(grapheme_position)?;
     let (next_text_position, _) = graphemes.next().unwrap_or_else(|| (text.len(), ""));
 
-    let curr_edge = hit_test_line_position(ctx, text, text_position)?;
-    let next_edge = hit_test_line_position(ctx, text, next_text_position)?;
+    let curr_edge = hit_test_line_position(ctx, text, text_position);
+    let next_edge = hit_test_line_position(ctx, text, next_text_position);
 
     let res = GraphemeBoundaries {
         curr_idx: text_position,

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -472,23 +472,12 @@ pub trait TextLayout: Clone {
     fn hit_test_point(&self, point: Point) -> HitTestPoint;
 
     /// Given a grapheme boundary in the string used to create this [`TextLayout`],
-    /// return information about the location of that boundary within the layout
-    /// object.
-    ///
-    ///
-    /// ## Return value:
-    /// Returns a [`HitTestPosition`][] struct describing the results of the test.
-    ///
-    /// The [`HitTestPosition`][] field `point` is a `Point`, on the baseline
-    /// of the line containing this grapheme cluster, of the grapheme's leading edge,
-    /// relative to the origin of the layout object.
+    /// return a [`HitTestPosition`] object describing the location of that boundary
+    /// within the layout.
     ///
     /// ## Panics:
     ///
-    // FIXME: behaviour currently differs between backends, but some backends panic.
-    // decide whether this panics or not, and standardize backend behaviour.
-    /// This method may panic if the text position is not a codepoint boundary,
-    /// or if it is greater than the length of the text.
+    /// This method will panic if the text position is not a character boundary,
     ///
     /// For more on text positions, see docs for the [`TextLayout`] trait.
     ///


### PR DESCRIPTION
We will now always clamp an out of bounds position to the end of
the text, and we will always panic if the text position is not
a character boundary.