### PR TITLE
Make TextLayout::hit_test_text_position return non Option

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -250,7 +250,7 @@ impl TextLayout for CairoTextLayout {
         htp
     }
 
-    fn hit_test_text_position(&self, idx: usize) -> Option<HitTestPosition> {
+    fn hit_test_text_position(&self, idx: usize) -> HitTestPosition {
         let idx = idx.min(self.text.len());
         assert!(self.text.is_char_boundary(idx));
 
@@ -266,7 +266,7 @@ impl TextLayout for CairoTextLayout {
         let line_position = idx - lm.start_offset;
 
         let x_pos = hit_test_line_position(&self.font, line, line_position);
-        Some(HitTestPosition::new(Point::new(x_pos, y_pos), line_num))
+        HitTestPosition::new(Point::new(x_pos, y_pos), line_num)
     }
 }
 
@@ -423,37 +423,29 @@ mod test {
         let full_width = full_layout.size().width;
 
         assert_close!(
-            full_layout.hit_test_text_position(4).unwrap().point.x,
+            full_layout.hit_test_text_position(4).point.x,
             piet_width,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(3).unwrap().point.x,
+            full_layout.hit_test_text_position(3).point.x,
             pie_width,
             3.0,
         );
+        assert_close!(full_layout.hit_test_text_position(2).point.x, pi_width, 3.0,);
+        assert_close!(full_layout.hit_test_text_position(1).point.x, p_width, 3.0,);
         assert_close!(
-            full_layout.hit_test_text_position(2).unwrap().point.x,
-            pi_width,
-            3.0,
-        );
-        assert_close!(
-            full_layout.hit_test_text_position(1).unwrap().point.x,
-            p_width,
-            3.0,
-        );
-        assert_close!(
-            full_layout.hit_test_text_position(0).unwrap().point.x,
+            full_layout.hit_test_text_position(0).point.x,
             null_width,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(10).unwrap().point.x,
+            full_layout.hit_test_text_position(10).point.x,
             full_width,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(11).unwrap().point.x,
+            full_layout.hit_test_text_position(11).point.x,
             full_width,
             3.0,
         );
@@ -467,9 +459,9 @@ mod test {
         let mut text_layout = CairoText::new();
         let layout = text_layout.new_text_layout(input).build().unwrap();
 
-        assert_close!(layout.hit_test_text_position(0).unwrap().point.x, 0.0, 3.0);
+        assert_close!(layout.hit_test_text_position(0).point.x, 0.0, 3.0);
         assert_close!(
-            layout.hit_test_text_position(2).unwrap().point.x,
+            layout.hit_test_text_position(2).point.x,
             layout.size().width,
             3.0,
         );
@@ -492,9 +484,9 @@ mod test {
         let mut text_layout = CairoText::new();
         let layout = text_layout.new_text_layout(input).build().unwrap();
 
-        assert_close!(layout.hit_test_text_position(0).unwrap().point.x, 0.0, 3.0);
+        assert_close!(layout.hit_test_text_position(0).point.x, 0.0, 3.0);
         assert_close!(
-            layout.hit_test_text_position(7).unwrap().point.x,
+            layout.hit_test_text_position(7).point.x,
             layout.size().width,
             3.0,
         );
@@ -518,24 +510,24 @@ mod test {
         let test_layout_2 = text_layout.new_text_layout(&input[0..10]).build().unwrap();
 
         // Note: text position is in terms of utf8 code units
-        assert_close!(layout.hit_test_text_position(0).unwrap().point.x, 0.0, 3.0);
+        assert_close!(layout.hit_test_text_position(0).point.x, 0.0, 3.0);
         assert_close!(
-            layout.hit_test_text_position(2).unwrap().point.x,
+            layout.hit_test_text_position(2).point.x,
             test_layout_0.size().width,
             3.0,
         );
         assert_close!(
-            layout.hit_test_text_position(9).unwrap().point.x,
+            layout.hit_test_text_position(9).point.x,
             test_layout_1.size().width,
             3.0,
         );
         assert_close!(
-            layout.hit_test_text_position(10).unwrap().point.x,
+            layout.hit_test_text_position(10).point.x,
             test_layout_2.size().width,
             3.0,
         );
         assert_close!(
-            layout.hit_test_text_position(14).unwrap().point.x,
+            layout.hit_test_text_position(14).point.x,
             layout.size().width,
             3.0,
         );
@@ -543,12 +535,12 @@ mod test {
         // Code point boundaries, but not grapheme boundaries.
         // Width should stay at the current grapheme boundary.
         assert_close!(
-            layout.hit_test_text_position(3).unwrap().point.x,
+            layout.hit_test_text_position(3).point.x,
             test_layout_0.size().width,
             3.0,
         );
         assert_close!(
-            layout.hit_test_text_position(6).unwrap().point.x,
+            layout.hit_test_text_position(6).point.x,
             test_layout_0.size().width,
             3.0,
         );
@@ -908,80 +900,68 @@ mod test {
 
         // these just test the x position of text positions on the second line
         assert_close!(
-            full_layout.hit_test_text_position(10).unwrap().point.x,
+            full_layout.hit_test_text_position(10).point.x,
             text_width,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(9).unwrap().point.x,
+            full_layout.hit_test_text_position(9).point.x,
             tex_width,
             3.0,
         );
-        assert_close!(
-            full_layout.hit_test_text_position(8).unwrap().point.x,
-            te_width,
-            3.0,
-        );
-        assert_close!(
-            full_layout.hit_test_text_position(7).unwrap().point.x,
-            t_width,
-            3.0,
-        );
+        assert_close!(full_layout.hit_test_text_position(8).point.x, te_width, 3.0,);
+        assert_close!(full_layout.hit_test_text_position(7).point.x, t_width, 3.0,);
         // This should be beginning of second line
-        assert_close!(
-            full_layout.hit_test_text_position(6).unwrap().point.x,
-            0.0,
-            3.0,
-        );
+        assert_close!(full_layout.hit_test_text_position(6).point.x, 0.0, 3.0,);
 
         assert_close!(
-            full_layout.hit_test_text_position(3).unwrap().point.x,
+            full_layout.hit_test_text_position(3).point.x,
             pie_width,
             3.0,
         );
 
         // This tests that trailing whitespace is included in the first line width.
         assert_close!(
-            full_layout.hit_test_text_position(5).unwrap().point.x,
+            full_layout.hit_test_text_position(5).point.x,
             piet_space_width,
             3.0,
         );
 
         // These test y position of text positions on line 1 (0-index)
         assert_close!(
-            full_layout.hit_test_text_position(10).unwrap().point.y,
+            full_layout.hit_test_text_position(10).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(9).unwrap().point.y,
+            full_layout.hit_test_text_position(9).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(8).unwrap().point.y,
+            full_layout.hit_test_text_position(8).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(7).unwrap().point.y,
+            full_layout.hit_test_text_position(7).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(6).unwrap().point.y,
+            full_layout.hit_test_text_position(6).point.y,
             line_one_baseline,
             3.0,
         );
 
         // this tests y position of 0 line
         assert_close!(
-            full_layout.hit_test_text_position(5).unwrap().point.y,
+            full_layout.hit_test_text_position(5).point.y,
             line_zero_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(4).unwrap().point.y,
+            full_layout.hit_test_text_position(4).point.y,
             line_zero_baseline,
             3.0,
         );
@@ -1084,80 +1064,68 @@ mod test {
 
         // these just test the x position of text positions on the second line
         assert_close!(
-            full_layout.hit_test_text_position(10).unwrap().point.x,
+            full_layout.hit_test_text_position(10).point.x,
             text_width,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(9).unwrap().point.x,
+            full_layout.hit_test_text_position(9).point.x,
             tex_width,
             3.0,
         );
-        assert_close!(
-            full_layout.hit_test_text_position(8).unwrap().point.x,
-            te_width,
-            3.0,
-        );
-        assert_close!(
-            full_layout.hit_test_text_position(7).unwrap().point.x,
-            t_width,
-            3.0,
-        );
+        assert_close!(full_layout.hit_test_text_position(8).point.x, te_width, 3.0,);
+        assert_close!(full_layout.hit_test_text_position(7).point.x, t_width, 3.0,);
         // This should be beginning of second line
-        assert_close!(
-            full_layout.hit_test_text_position(6).unwrap().point.x,
-            0.0,
-            3.0,
-        );
+        assert_close!(full_layout.hit_test_text_position(6).point.x, 0.0, 3.0,);
 
         assert_close!(
-            full_layout.hit_test_text_position(3).unwrap().point.x,
+            full_layout.hit_test_text_position(3).point.x,
             pie_width,
             3.0,
         );
 
         // This tests that trailing whitespace is included in the first line width.
         assert_close!(
-            full_layout.hit_test_text_position(5).unwrap().point.x,
+            full_layout.hit_test_text_position(5).point.x,
             piet_space_width,
             3.0,
         );
 
         // These test y position of text positions on line 1 (0-index)
         assert_close!(
-            full_layout.hit_test_text_position(10).unwrap().point.y,
+            full_layout.hit_test_text_position(10).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(9).unwrap().point.y,
+            full_layout.hit_test_text_position(9).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(8).unwrap().point.y,
+            full_layout.hit_test_text_position(8).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(7).unwrap().point.y,
+            full_layout.hit_test_text_position(7).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(6).unwrap().point.y,
+            full_layout.hit_test_text_position(6).point.y,
             line_one_baseline,
             3.0,
         );
 
         // this tests y position of 0 line
         assert_close!(
-            full_layout.hit_test_text_position(5).unwrap().point.y,
+            full_layout.hit_test_text_position(5).point.y,
             line_zero_baseline,
             3.0,
         );
         assert_close!(
-            full_layout.hit_test_text_position(4).unwrap().point.y,
+            full_layout.hit_test_text_position(4).point.y,
             line_zero_baseline,
             3.0,
         );

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -659,7 +659,7 @@ impl TextLayout for CoreGraphicsTextLayout {
         HitTestPoint::new(offset, is_inside)
     }
 
-    fn hit_test_text_position(&self, idx: usize) -> Option<HitTestPosition> {
+    fn hit_test_text_position(&self, idx: usize) -> HitTestPosition {
         let idx = idx.min(self.text.len());
         assert!(self.text.is_char_boundary(idx));
 
@@ -673,7 +673,7 @@ impl TextLayout for CoreGraphicsTextLayout {
         let char_idx = line_range.location + off16 as isize;
         let x_pos = line.get_offset_for_string_index(char_idx);
         let y_pos = self.line_y_positions[line_num];
-        Some(HitTestPosition::new(Point::new(x_pos, y_pos), line_num))
+        HitTestPosition::new(Point::new(x_pos, y_pos), line_num)
     }
 
     fn rects_for_range(&self, range: impl RangeBounds<usize>) -> Vec<Rect> {
@@ -698,8 +698,8 @@ impl TextLayout for CoreGraphicsTextLayout {
             } else {
                 metrics.end_offset - metrics.trailing_whitespace
             };
-            let start_point = self.hit_test_text_position(line_range_start).unwrap();
-            let end_point = self.hit_test_text_position(line_range_end).unwrap();
+            let start_point = self.hit_test_text_position(line_range_start);
+            let end_point = self.hit_test_text_position(line_range_end);
             result.push(Rect::new(start_point.point.x, y0, end_point.point.x, y1));
         }
         result
@@ -943,10 +943,10 @@ mod tests {
             .font(a_font, 16.0)
             .build()
             .unwrap();
-        let p1 = layout.hit_test_text_position(0).unwrap();
+        let p1 = layout.hit_test_text_position(0);
         assert_eq!(p1.point, Point::new(0.0, 16.0));
 
-        let p1 = layout.hit_test_text_position(7).unwrap();
+        let p1 = layout.hit_test_text_position(7);
         assert_eq!(p1.point.y, 36.0);
         // just the general idea that this is the second character
         assert!(p1.point.x > 5.0 && p1.point.x < 15.0);
@@ -960,9 +960,9 @@ mod tests {
             .font(a_font, 16.0)
             .build()
             .unwrap();
-        let p0 = layout.hit_test_text_position(4).unwrap();
-        let p1 = layout.hit_test_text_position(8).unwrap();
-        let p2 = layout.hit_test_text_position(13).unwrap();
+        let p0 = layout.hit_test_text_position(4);
+        let p1 = layout.hit_test_text_position(8);
+        let p2 = layout.hit_test_text_position(13);
 
         assert!(p1.point.x > p0.point.x);
         assert!(p1.point.y == p0.point.y);

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -106,7 +106,7 @@ impl piet::TextLayout for TextLayout {
         unimplemented!()
     }
 
-    fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestPosition> {
+    fn hit_test_text_position(&self, _text_position: usize) -> HitTestPosition {
         unimplemented!()
     }
 

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -254,7 +254,7 @@ impl TextLayout for WebTextLayout {
         htp
     }
 
-    fn hit_test_text_position(&self, idx: usize) -> Option<HitTestPosition> {
+    fn hit_test_text_position(&self, idx: usize) -> HitTestPosition {
         let idx = idx.min(self.text.len());
         assert!(self.text.is_char_boundary(idx));
         // first need to find line it's on, and get line start offset
@@ -268,7 +268,7 @@ impl TextLayout for WebTextLayout {
         let line_position = idx - lm.start_offset;
 
         let x_pos = hit_test_line_position(&self.ctx, line, line_position);
-        Some(HitTestPosition::new(Point::new(x_pos, y_pos), line_num))
+        HitTestPosition::new(Point::new(x_pos, y_pos), line_num)
     }
 }
 
@@ -475,37 +475,29 @@ pub(crate) mod test {
         let full_width = full_layout.size().width;
 
         assert_close_to(
-            full_layout.hit_test_text_position(4).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(4).point.x,
             piet_width,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(3).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(3).point.x,
             pie_width,
             3.0,
         );
+        assert_close_to(full_layout.hit_test_text_position(2).point.x, pi_width, 3.0);
+        assert_close_to(full_layout.hit_test_text_position(1).point.x, p_width, 3.0);
         assert_close_to(
-            full_layout.hit_test_text_position(2).unwrap().point.x as f64,
-            pi_width,
-            3.0,
-        );
-        assert_close_to(
-            full_layout.hit_test_text_position(1).unwrap().point.x as f64,
-            p_width,
-            3.0,
-        );
-        assert_close_to(
-            full_layout.hit_test_text_position(0).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(0).point.x,
             null_width,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(10).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(10).point.x,
             full_width,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(11).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(11).point.x,
             full_width,
             3.0,
         );
@@ -526,9 +518,9 @@ pub(crate) mod test {
             .build()
             .unwrap();
 
-        assert_close_to(layout.hit_test_text_position(0).unwrap().point.x, 0.0, 3.0);
+        assert_close_to(layout.hit_test_text_position(0).point.x, 0.0, 3.0);
         assert_close_to(
-            layout.hit_test_text_position(2).unwrap().point.x,
+            layout.hit_test_text_position(2).point.x,
             layout.size().width,
             3.0,
         );
@@ -537,7 +529,7 @@ pub(crate) mod test {
         // This one panics in d2d because this is not a code unit boundary.
         // But it works here! Harder to deal with this right now, since unicode-segmentation
         // doesn't give code point offsets.
-        assert_close_to(layout.hit_test_text_position(1).unwrap().point.x, 0.0, 3.0);
+        assert_close_to(layout.hit_test_text_position(1).point.x, 0.0, 3.0);
 
         // unicode segmentation is wrong on this one for now.
         //let input = "🤦\u{1f3fc}\u{200d}\u{2642}\u{fe0f}";
@@ -561,15 +553,15 @@ pub(crate) mod test {
             .build()
             .unwrap();
 
-        assert_close_to(layout.hit_test_text_position(0).unwrap().point.x, 0.0, 3.0);
+        assert_close_to(layout.hit_test_text_position(0).point.x, 0.0, 3.0);
         assert_close_to(
-            layout.hit_test_text_position(7).unwrap().point.x,
+            layout.hit_test_text_position(7).point.x,
             layout.size().width,
             3.0,
         );
 
         // note code unit not at grapheme boundary
-        assert_close_to(layout.hit_test_text_position(1).unwrap().point.x, 0.0, 3.0);
+        assert_close_to(layout.hit_test_text_position(1).point.x, 0.0, 3.0);
     }
 
     #[wasm_bindgen_test]
@@ -609,38 +601,38 @@ pub(crate) mod test {
             .unwrap();
 
         // Note: text position is in terms of utf8 code units
-        assert_close_to(layout.hit_test_text_position(0).unwrap().point.x, 0.0, 3.0);
+        assert_close_to(layout.hit_test_text_position(0).point.x, 0.0, 3.0);
         assert_close_to(
-            layout.hit_test_text_position(2).unwrap().point.x,
+            layout.hit_test_text_position(2).point.x,
             test_layout_0.size().width,
             3.0,
         );
         assert_close_to(
-            layout.hit_test_text_position(9).unwrap().point.x,
+            layout.hit_test_text_position(9).point.x,
             test_layout_1.size().width,
             3.0,
         );
         assert_close_to(
-            layout.hit_test_text_position(10).unwrap().point.x,
+            layout.hit_test_text_position(10).point.x,
             test_layout_2.size().width,
             3.0,
         );
         assert_close_to(
-            layout.hit_test_text_position(14).unwrap().point.x,
+            layout.hit_test_text_position(14).point.x,
             layout.size().width,
             3.0,
         );
 
         // Code point boundaries, but not grapheme boundaries.
         // Width should stay at the last complete grapheme boundary.
-        assert_close_to(layout.hit_test_text_position(1).unwrap().point.x, 0.0, 3.0);
+        assert_close_to(layout.hit_test_text_position(1).point.x, 0.0, 3.0);
         assert_close_to(
-            layout.hit_test_text_position(3).unwrap().point.x,
+            layout.hit_test_text_position(3).point.x,
             test_layout_0.size().width,
             3.0,
         );
         assert_close_to(
-            layout.hit_test_text_position(6).unwrap().point.x,
+            layout.hit_test_text_position(6).point.x,
             test_layout_0.size().width,
             3.0,
         );
@@ -906,80 +898,68 @@ pub(crate) mod test {
 
         // these just test the x position of text positions on the second line
         assert_close_to(
-            full_layout.hit_test_text_position(10).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(10).point.x,
             text_width,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(9).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(9).point.x,
             tex_width,
             3.0,
         );
-        assert_close_to(
-            full_layout.hit_test_text_position(8).unwrap().point.x as f64,
-            te_width,
-            3.0,
-        );
-        assert_close_to(
-            full_layout.hit_test_text_position(7).unwrap().point.x as f64,
-            t_width,
-            3.0,
-        );
+        assert_close_to(full_layout.hit_test_text_position(8).point.x, te_width, 3.0);
+        assert_close_to(full_layout.hit_test_text_position(7).point.x, t_width, 3.0);
         // This should be beginning of second line
-        assert_close_to(
-            full_layout.hit_test_text_position(6).unwrap().point.x as f64,
-            0.0,
-            3.0,
-        );
+        assert_close_to(full_layout.hit_test_text_position(6).point.x, 0.0, 3.0);
 
         assert_close_to(
-            full_layout.hit_test_text_position(3).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(3).point.x,
             pie_width,
             3.0,
         );
 
         // This tests that trailing whitespace is included in the first line width.
         assert_close_to(
-            full_layout.hit_test_text_position(5).unwrap().point.x as f64,
+            full_layout.hit_test_text_position(5).point.x,
             piet_space_width,
             3.0,
         );
 
         // These test y position of text positions on line 1 (0-index)
         assert_close_to(
-            full_layout.hit_test_text_position(10).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(10).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(9).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(9).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(8).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(8).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(7).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(7).point.y,
             line_one_baseline,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(6).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(6).point.y,
             line_one_baseline,
             3.0,
         );
 
         // this tests y position of 0 line
         assert_close_to(
-            full_layout.hit_test_text_position(5).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(5).point.y,
             line_zero_baseline,
             3.0,
         );
         assert_close_to(
-            full_layout.hit_test_text_position(4).unwrap().point.y as f64,
+            full_layout.hit_test_text_position(4).point.y,
             line_zero_baseline,
             3.0,
         );

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -205,8 +205,8 @@ impl TextLayout for NullTextLayout {
         HitTestPoint::default()
     }
 
-    fn hit_test_text_position(&self, _text_position: usize) -> Option<HitTestPosition> {
-        None
+    fn hit_test_text_position(&self, _text_position: usize) -> HitTestPosition {
+        HitTestPosition::default()
     }
 
     fn text(&self) -> &str {

--- a/piet/src/samples/picture_11.rs
+++ b/piet/src/samples/picture_11.rs
@@ -30,7 +30,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         while x < SIZE.width / 2.0 {
             let point = Point::new(x, y);
             let test_point = layout.hit_test_point(point - text_pos);
-            let test_pos = layout.hit_test_text_position(test_point.idx).unwrap();
+            let test_pos = layout.hit_test_text_position(test_point.idx);
             let hit_point = test_pos.point + text_pos;
 
             let color = if test_point.is_inside { &RED } else { &BLUE };

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -475,18 +475,15 @@ pub trait TextLayout: Clone {
     /// return a [`HitTestPosition`] object describing the location of that boundary
     /// within the layout.
     ///
+    /// For more on text positions, see docs for the [`TextLayout`] trait.
+    ///
     /// ## Panics:
     ///
     /// This method will panic if the text position is not a character boundary,
     ///
-    /// For more on text positions, see docs for the [`TextLayout`] trait.
-    ///
     /// [`HitTestPosition`]: struct.HitTestPosition.html
     /// [`TextLayout`]: ../piet/trait.TextLayout.html
-    //FIXME: under what circumstances should this return `None`? A reasonable
-    //case would be when trimming has caused an index to not be included in the
-    //layout's text?`
-    fn hit_test_text_position(&self, idx: usize) -> Option<HitTestPosition>;
+    fn hit_test_text_position(&self, idx: usize) -> HitTestPosition;
 
     /// Returns a vector of `Rect`s that cover the region of the text indicated
     /// by `range`.
@@ -504,8 +501,8 @@ pub trait TextLayout: Clone {
         range.start = range.start.min(text_len);
         range.end = range.end.min(text_len);
 
-        let first_line = self.hit_test_text_position(range.start).unwrap().line;
-        let last_line = self.hit_test_text_position(range.end).unwrap().line;
+        let first_line = self.hit_test_text_position(range.start).line;
+        let last_line = self.hit_test_text_position(range.end).line;
 
         let mut result = Vec::new();
 
@@ -524,8 +521,8 @@ pub trait TextLayout: Clone {
             } else {
                 metrics.end_offset - metrics.trailing_whitespace
             };
-            let start_point = self.hit_test_text_position(line_range_start).unwrap();
-            let end_point = self.hit_test_text_position(line_range_end).unwrap();
+            let start_point = self.hit_test_text_position(line_range_start);
+            let end_point = self.hit_test_text_position(line_range_end);
             result.push(Rect::new(start_point.point.x, y0, end_point.point.x, y1));
         }
 


### PR DESCRIPTION
The None path was only being used in directwrite, and only when
encountering an error from winapi. In that case we will now
just return the first text position (panicking would also be a
reasonable choice).


This is based off of #262; they're both addressing inconsistencies in the behaviour of the hit_test_text_position method.