### PR TITLE
[cg] Reuse text object when creating context

### DIFF
--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -100,7 +100,7 @@ impl<'a> BitmapTarget<'a> {
     /// Note: caller is responsible for calling `finish` on the render
     /// context at the end of rendering.
     pub fn render_context(&mut self) -> CoreGraphicsContext {
-        CoreGraphicsContext::new_y_up(&mut self.ctx, self.height)
+        CoreGraphicsContext::new_y_up(&mut self.ctx, self.height, None)
     }
 
     /// Get raw RGBA pixels from the bitmap.

--- a/piet-coregraphics/examples/test-picture.rs
+++ b/piet-coregraphics/examples/test-picture.rs
@@ -26,7 +26,8 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
     let path = base_dir.join(file_name);
 
     let mut cg_ctx = make_cg_ctx(size);
-    let mut piet_context = CoreGraphicsContext::new_y_up(&mut cg_ctx, size.height * SCALE.recip());
+    let mut piet_context =
+        CoreGraphicsContext::new_y_up(&mut cg_ctx, size.height * SCALE.recip(), None);
 
     sample.draw(&mut piet_context)?;
 

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -400,8 +400,7 @@ impl CoreGraphicsText {
     /// it will not share a cache with any other objects created with this method.
     ///
     /// In general this should be created once and then cloned and passed around.
-    #[allow(clippy::new_without_default)]
-    pub(crate) fn new_with_unique_state() -> CoreGraphicsText {
+    pub fn new_with_unique_state() -> CoreGraphicsText {
         let collection = FontCollection::new_with_all_fonts();
         let inner = Arc::new(Mutex::new(TextState {
             collection,


### PR DESCRIPTION
The CoreGraphicsText struct now has state, and it should not be
created anew each time a RenderContext is created.


This is something I ran into immediately when trying to update druid; we expect to just be able to create text objects out of thin air.