### PR TITLE
[web] Fix signatures to match other piet-common backends

### DIFF
--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -55,7 +55,6 @@ pub use backend::*;
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::marker::PhantomData;
 
     use static_assertions as sa;
 
@@ -68,7 +67,6 @@ mod test {
         piet_text_layout: PietTextLayout,
         piet_text_layout_builder: PietTextLayoutBuilder,
         image: Image,
-        _phantom: PhantomData<&'a ()>,
     }
 
     sa::assert_impl_all!(Device: Send);

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -17,7 +17,7 @@ use piet::ImageFormat;
 #[doc(hidden)]
 pub use piet_web::*;
 
-pub type Piet<'a> = WebRenderContext;
+pub type Piet<'a> = WebRenderContext<'a>;
 
 /// The associated brush type for this backend.
 ///


### PR DESCRIPTION
I do not know why this worked before, why it stopped working, or
why it matters; but this mismatch was blocking the compilation
of the druid web backend.