### PR TITLE
Add asserts to check TextLayoutBuilder used as expected

### DIFF
--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -492,6 +492,10 @@ impl TextLayoutBuilder for CoreGraphicsTextLayoutBuilder {
     }
 
     fn default_attribute(mut self, attribute: impl Into<TextAttribute>) -> Self {
+        debug_assert!(
+            !self.has_set_default_attrs,
+            "default attributes mut be added before range attributes"
+        );
         let attribute = attribute.into();
         self.attrs.defaults.set(attribute);
         self


### PR DESCRIPTION
We expect default attributes to always be added before any range
attributes, and that range attributes are added in non-descending order;
this will now crash more aggressively when those conditions are broken.