### PR TITLE
Add FontStyle enum

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -9,8 +9,8 @@ use cairo::{FontFace, FontOptions, FontSlant, FontWeight, Matrix, ScaledFont};
 
 use piet::kurbo::{Point, Rect, Size};
 use piet::{
-    util, Color, Error, FontFamily, HitTestPoint, HitTestPosition, LineMetric, Text, TextAttribute,
-    TextLayout, TextLayoutBuilder,
+    util, Color, Error, FontFamily, FontStyle, HitTestPoint, HitTestPosition, LineMetric, Text,
+    TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
 use unicode_segmentation::UnicodeSegmentation;
@@ -135,10 +135,9 @@ impl TextLayoutBuilder for CairoTextLayoutBuilder {
         } else {
             FontWeight::Bold
         };
-        let slant = if self.defaults.italic {
-            FontSlant::Italic
-        } else {
-            FontSlant::Normal
+        let slant = match self.defaults.style {
+            FontStyle::Italic => FontSlant::Italic,
+            FontStyle::Regular => FontSlant::Normal,
         };
 
         let scaled_font = font.resolve(size, slant, weight);

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -31,7 +31,7 @@ use wio::com::ComPtr;
 use wio::wide::{FromWide, ToWide};
 
 use piet::kurbo::Insets;
-use piet::{FontFamily as PietFontFamily, FontWeight, TextAlignment};
+use piet::{FontFamily as PietFontFamily, FontStyle, FontWeight, TextAlignment};
 
 use crate::Brush;
 
@@ -357,11 +357,10 @@ impl TextLayout {
         }
     }
 
-    pub(crate) fn set_italic(&mut self, range: Utf16Range, ital: bool) {
-        let val = if ital {
-            DWRITE_FONT_STYLE_ITALIC
-        } else {
-            DWRITE_FONT_STYLE_NORMAL
+    pub(crate) fn set_style(&mut self, range: Utf16Range, style: FontStyle) {
+        let val = match style {
+            FontStyle::Italic => DWRITE_FONT_STYLE_ITALIC,
+            FontStyle::Regular => DWRITE_FONT_STYLE_NORMAL,
         };
         unsafe {
             self.0.SetFontStyle(val, range.into());

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -243,7 +243,7 @@ impl D2DTextLayoutBuilder {
                 }
                 TextAttribute::FontSize(size) => layout.set_size(utf16_range, size as f32),
                 TextAttribute::Weight(weight) => layout.set_weight(utf16_range, weight),
-                TextAttribute::Italic(flag) => layout.set_italic(utf16_range, flag),
+                TextAttribute::Style(style) => layout.set_style(utf16_range, style),
                 TextAttribute::Underline(flag) => layout.set_underline(utf16_range, flag),
                 TextAttribute::ForegroundColor(color) => self.colors.push((utf16_range, color)),
             }

--- a/piet/src/font.rs
+++ b/piet/src/font.rs
@@ -40,8 +40,20 @@ pub enum FontFamilyInner {
 /// `FontWeight::BOLD`.
 ///
 /// [CSS `font-weight`]: https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FontWeight(u16);
+
+/// A font style, which may be italic or regular.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FontStyle {
+    /// Prefer the regular style for the current font family, if available.
+    Regular,
+    /// Prefer the italic style for the current font family, if available.
+    ///
+    /// If italic is not available and oblique is, we will use that; if neither
+    /// is available we will apply synthetic italics to the regular style.
+    Italic,
+}
 
 impl FontFamily {
     /// A san-serif font, such as Arial or Helvetica.
@@ -134,5 +146,11 @@ impl Default for FontFamily {
 impl Default for FontWeight {
     fn default() -> Self {
         FontWeight::REGULAR
+    }
+}
+
+impl Default for FontStyle {
+    fn default() -> Self {
+        FontStyle::Regular
     }
 }

--- a/piet/src/samples/picture_13.rs
+++ b/piet/src/samples/picture_13.rs
@@ -2,7 +2,7 @@
 
 use crate::kurbo::{Size, Vec2};
 use crate::{
-    Color, Error, FontFamily, FontWeight, RenderContext, Text, TextAttribute, TextLayout,
+    Color, Error, FontFamily, FontStyle, FontWeight, RenderContext, Text, TextLayout,
     TextLayoutBuilder,
 };
 
@@ -32,7 +32,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(100..150, FontWeight::EXTRA_BLACK)
         .range_attribute(150..250, FontWeight::BOLD)
         // italic does not exist. should be synthetic italic?
-        .range_attribute(200..300, TextAttribute::Italic(true))
+        .range_attribute(200..300, FontStyle::Italic)
         // weight does not exist; should resolve to regular
         .range_attribute(250..320, FontWeight::EXTRA_LIGHT)
         .build()?;

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -2,8 +2,8 @@
 
 use crate::kurbo::{Size, Vec2};
 use crate::{
-    Color, Error, FontFamily, FontWeight, RenderContext, Text, TextAttribute, TextLayout,
-    TextLayoutBuilder,
+    Color, Error, FontFamily, FontStyle, FontWeight, RenderContext, Text, TextAttribute,
+    TextLayout, TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(480., 560.);
@@ -24,13 +24,13 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .max_width(200.0)
         .default_attribute(courier)
         .default_attribute(TextAttribute::Underline(true))
-        .default_attribute(TextAttribute::Italic(true))
+        .default_attribute(FontStyle::Italic)
         .default_attribute(TextAttribute::ForegroundColor(RED))
         .default_attribute(FontWeight::BOLD)
         .range_attribute(..200, TextAttribute::ForegroundColor(BLUE))
         .range_attribute(10..100, FontWeight::NORMAL)
         .range_attribute(40..300, TextAttribute::Underline(false))
-        .range_attribute(60..160, TextAttribute::Italic(false))
+        .range_attribute(60..160, FontStyle::Regular)
         .range_attribute(140..220, FontWeight::NORMAL)
         .range_attribute(240.., FontFamily::SYSTEM_UI)
         .build()?;

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -2,8 +2,8 @@
 
 use crate::kurbo::Size;
 use crate::{
-    Color, Error, FontFamily, FontWeight, RenderContext, Text, TextAlignment, TextAttribute,
-    TextLayoutBuilder,
+    Color, Error, FontFamily, FontStyle, FontWeight, RenderContext, Text, TextAlignment,
+    TextAttribute, TextLayoutBuilder,
 };
 
 pub const SIZE: Size = Size::new(400., 800.);
@@ -38,7 +38,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         )
         .range_attribute(200.., FontWeight::EXTRA_BLACK)
         .range_attribute(220.., TextAttribute::FontSize(18.0))
-        .range_attribute(240.., TextAttribute::Italic(true))
+        .range_attribute(240.., FontStyle::Italic)
         .range_attribute(280.., TextAttribute::Underline(true))
         .build()?;
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -3,7 +3,7 @@
 use std::ops::{Range, RangeBounds};
 
 use crate::kurbo::{Point, Rect, Size};
-use crate::{Color, Error, FontFamily, FontWeight};
+use crate::{Color, Error, FontFamily, FontStyle, FontWeight};
 
 /// The Piet text API.
 ///
@@ -111,8 +111,10 @@ pub enum TextAttribute {
     Weight(FontWeight),
     /// The foreground color of the text.
     ForegroundColor(crate::Color),
-    /// Italics.
-    Italic(bool),
+    /// The [`FontStyle`]; either regular or italic.
+    ///
+    /// [`FontStyle`]: enum.FontStyle.html
+    Style(FontStyle),
     /// Underline.
     Underline(bool),
 }
@@ -215,7 +217,7 @@ pub trait TextLayoutBuilder: Sized {
     /// let times = text.font_family("Times New Roman").unwrap();
     /// let layout = text.new_text_layout("This API is okay, I guess?")
     ///     .font(FontFamily::MONOSPACE, 12.0)
-    ///     .default_attribute(TextAttribute::Italic(true))
+    ///     .default_attribute(FontStyle::Italic)
     ///     .range_attribute(..5, FontWeight::BOLD)
     ///     .range_attribute(5..14, times)
     ///     .range_attribute(20.., TextAttribute::ForegroundColor(Color::rgb(1.0, 0., 0.,)))
@@ -534,6 +536,12 @@ impl From<FontFamily> for TextAttribute {
 impl From<FontWeight> for TextAttribute {
     fn from(src: FontWeight) -> TextAttribute {
         TextAttribute::Weight(src)
+    }
+}
+
+impl From<FontStyle> for TextAttribute {
+    fn from(src: FontStyle) -> TextAttribute {
+        TextAttribute::Style(src)
     }
 }
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -3,7 +3,7 @@
 use std::ops::{Bound, Range, RangeBounds};
 
 use crate::kurbo::{Rect, Size};
-use crate::{Color, FontFamily, FontWeight, LineMetric, TextAttribute};
+use crate::{Color, FontFamily, FontStyle, FontWeight, LineMetric, TextAttribute};
 
 /// The default point sie for text in piet.
 pub const DEFAULT_FONT_SIZE: f64 = 12.0;
@@ -134,7 +134,7 @@ pub struct LayoutDefaults {
     pub font_size: f64,
     pub weight: FontWeight,
     pub fg_color: Color,
-    pub italic: bool,
+    pub style: FontStyle,
     pub underline: bool,
 }
 
@@ -145,7 +145,7 @@ impl LayoutDefaults {
             TextAttribute::FontFamily(t) => self.font = t,
             TextAttribute::FontSize(size) => self.font_size = size,
             TextAttribute::Weight(weight) => self.weight = weight,
-            TextAttribute::Italic(flag) => self.italic = flag,
+            TextAttribute::Style(style) => self.style = style,
             TextAttribute::Underline(flag) => self.underline = flag,
             TextAttribute::ForegroundColor(color) => self.fg_color = color,
         }
@@ -159,7 +159,7 @@ impl Default for LayoutDefaults {
             font_size: DEFAULT_FONT_SIZE,
             weight: FontWeight::default(),
             fg_color: DEFAULT_TEXT_COLOR,
-            italic: false,
+            style: FontStyle::default(),
             underline: false,
         }
     }


### PR DESCRIPTION
based off of #284.

This was motivated by wondering how I would go about storing something like font style in the druid environment, or stash it in other places, and convincing myself that this does make more sense as an independent type.