### PR TITLE
TextLayout::size should use line height with empty string

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -184,7 +184,7 @@ impl TextLayout for CairoTextLayout {
             .line_metrics
             .last()
             .map(|l| l.y_offset + l.height)
-            .unwrap_or_default();
+            .unwrap_or_else(|| self.font.extents().height);
         self.size = Size::new(width, height);
 
         Ok(())

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -562,6 +562,10 @@ impl TextLayout for CoreGraphicsTextLayout {
             self.frame = Some(frame);
             self.frame_size = Size::new(frame_size.width, frame_size.height);
 
+            if self.text.is_empty() {
+                self.frame_size.height = self.default_line_height;
+            }
+
             let mut line_bounds = lines
                 .iter()
                 .map(|l| Line::new(&l).get_image_bounds())


### PR DESCRIPTION
- closes #292

This also fixes a bug in the d2d backend where we were not correctly recomputing various metrics when the width of the layout changed.