### PR TITLE
Make new_text_layout take impl Into<Arc<str>>

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -4,6 +4,7 @@ mod grapheme;
 mod lines;
 
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use cairo::{FontFace, FontOptions, FontSlant, FontWeight, Matrix, ScaledFont};
 
@@ -36,14 +37,14 @@ pub struct CairoTextLayout {
     pub(crate) fg_color: Color,
     size: Size,
     pub(crate) font: ScaledFont,
-    pub(crate) text: String,
+    pub(crate) text: Arc<str>,
 
     // currently calculated on build
     pub(crate) line_metrics: Vec<LineMetric>,
 }
 
 pub struct CairoTextLayoutBuilder {
-    text: String,
+    text: Arc<str>,
     defaults: util::LayoutDefaults,
     width_constraint: f64,
 }
@@ -71,10 +72,10 @@ impl Text for CairoText {
         Err(Error::NotSupported)
     }
 
-    fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder {
         CairoTextLayoutBuilder {
             defaults: util::LayoutDefaults::default(),
-            text: text.to_owned(),
+            text: text.into(),
             width_constraint: f64::INFINITY,
         }
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -49,7 +49,7 @@ struct TextState {
 
 #[derive(Clone)]
 pub struct CoreGraphicsTextLayout {
-    text: String,
+    text: Arc<str>,
     attr_string: AttributedString,
     framesetter: Framesetter,
     pub(crate) frame: Option<Frame>,
@@ -69,7 +69,7 @@ pub struct CoreGraphicsTextLayout {
 pub struct CoreGraphicsTextLayoutBuilder {
     width: f64,
     alignment: TextAlignment,
-    text: String,
+    text: Arc<str>,
     /// the end bound up to which we have already added attrs to our AttributedString
     last_resolved_pos: usize,
     last_resolved_utf16: usize,
@@ -433,7 +433,7 @@ impl Text for CoreGraphicsText {
         self.shared.get_font(family_name)
     }
 
-    fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder {
         CoreGraphicsTextLayoutBuilder::new(text)
     }
 
@@ -464,13 +464,14 @@ impl SharedTextState {
 }
 
 impl CoreGraphicsTextLayoutBuilder {
-    fn new(text: &str) -> Self {
-        let attr_string = AttributedString::new(text);
+    fn new(text: impl Into<Arc<str>>) -> Self {
+        let text = text.into();
+        let attr_string = AttributedString::new(&text);
         CoreGraphicsTextLayoutBuilder {
             width: f64::INFINITY,
             alignment: TextAlignment::default(),
             attrs: Default::default(),
-            text: text.to_string(),
+            text,
             last_resolved_pos: 0,
             last_resolved_utf16: 0,
             attr_string,
@@ -741,7 +742,7 @@ impl TextLayout for CoreGraphicsTextLayout {
 
 impl CoreGraphicsTextLayout {
     fn new(
-        text: String,
+        text: Arc<str>,
         attr_string: AttributedString,
         width_constraint: f64,
         default_baseline: f64,

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -1,6 +1,7 @@
 //! Text functionality for Piet svg backend
 
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use piet::kurbo::{Point, Rect, Size};
 use piet::{Error, FontFamily, HitTestPoint, HitTestPosition, LineMetric, TextAttribute};
@@ -30,7 +31,7 @@ impl piet::Text for Text {
         Ok(FontFamily::default())
     }
 
-    fn new_text_layout(&mut self, _text: &str) -> TextLayoutBuilder {
+    fn new_text_layout(&mut self, _text: impl Into<Arc<str>>) -> TextLayoutBuilder {
         TextLayoutBuilder
     }
 }

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -5,6 +5,7 @@ mod lines;
 
 use std::borrow::Cow;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use web_sys::CanvasRenderingContext2d;
 
@@ -32,7 +33,7 @@ pub struct WebTextLayout {
     ctx: CanvasRenderingContext2d,
     // TODO like cairo, should this be pub(crate)?
     pub font: WebFont,
-    pub text: String,
+    pub text: Arc<str>,
 
     // Calculated on build
     pub(crate) line_metrics: Vec<LineMetric>,
@@ -42,7 +43,7 @@ pub struct WebTextLayout {
 pub struct WebTextLayoutBuilder {
     ctx: CanvasRenderingContext2d,
     font: WebFont,
-    text: String,
+    text: Arc<str>,
     width: f64,
 }
 
@@ -67,13 +68,13 @@ impl Text for WebText {
         Err(Error::MissingFeature)
     }
 
-    fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder {
         WebTextLayoutBuilder {
             // TODO: it's very likely possible to do this without cloning ctx, but
             // I couldn't figure out the lifetime errors from a `&'a` reference.
             ctx: self.ctx.clone(),
             font: WebFont::new(FontFamily::default()),
-            text: text.to_owned(),
+            text: text.into(),
             width: f64::INFINITY,
         }
     }

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 
 use kurbo::{Affine, Point, Rect, Shape, Size};
 
@@ -135,7 +136,7 @@ impl Text for NullText {
         Ok(FontFamily::default())
     }
 
-    fn new_text_layout(&mut self, _text: &str) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, _text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder {
         NullTextLayoutBuilder
     }
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -1,6 +1,7 @@
 //! Traits for fonts and text handling.
 
 use std::ops::{Range, RangeBounds};
+use std::sync::Arc;
 
 use crate::kurbo::{Point, Rect, Size};
 use crate::{Color, Error, FontFamily, FontStyle, FontWeight};
@@ -97,8 +98,13 @@ pub trait Text: Clone {
     /// The returned object is a [`TextLayoutBuilder`]; methods on that type
     /// can be used to customize the layout.
     ///
+    /// The text is a type that impls `Into<Arc<str>>`. This is an optimization;
+    /// because the layout object needs to retain the text, if the caller wants
+    /// to avoid duplicate data they can use an `Arc`. If this doesn't matter,
+    /// they can pass a `&str`, which the layout will retain.
+    ///
     /// [`TextLayoutBuilder`]: trait.TextLayoutBuilder.html
-    fn new_text_layout(&mut self, text: &str) -> Self::TextLayoutBuilder;
+    fn new_text_layout(&mut self, text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder;
 }
 
 /// Attributes that can be applied to text.


### PR DESCRIPTION
This will still allow the simple case of passing a string slice, but
will also let druid share string objects with piet, which should enable
better APIs that aren't giving up efficiency.

Another benefit of this work is making cloning of layout objects
cheaper.

closes #295