### PR TITLE
Add support for strikethrough formatting on text.

### DIFF
--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -97,6 +97,11 @@ struct CTParagraphStyleSetting {
     value: *const c_void,
 }
 
+#[allow(non_upper_case_globals)]
+// UnderlineStyle constants are also used for strikethrough styles
+const kCTUnderlineStyleNone: i32 = 0x00;
+const kCTUnderlineStyleSingle: i32 = 0x01;
+
 impl CTParagraphStyleSetting {
     fn alignment(alignment: TextAlignment, is_rtl: bool) -> Self {
         static LEFT: CTTextAlignment = CTTextAlignment::Left;
@@ -154,9 +159,6 @@ impl AttributedString {
 
     #[allow(non_upper_case_globals)]
     pub(crate) fn set_underline(&mut self, range: CFRange, underline: bool) {
-        const kCTUnderlineStyleNone: i32 = 0x00;
-        const kCTUnderlineStyleSingle: i32 = 0x01;
-
         let value = if underline {
             kCTUnderlineStyleSingle
         } else {
@@ -171,12 +173,7 @@ impl AttributedString {
         }
     }
 
-    #[allow(non_upper_case_globals)]
     pub(crate) fn set_strikethrough(&mut self, range: CFRange, strikethrough: bool) {
-        // UnderlineStyle constants are also used for strikethrough styles
-        const kCTUnderlineStyleNone: i32 = 0x00;
-        const kCTUnderlineStyleSingle: i32 = 0x01;
-
         let value = if strikethrough {
             kCTUnderlineStyleSingle
         } else {

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -97,11 +97,6 @@ struct CTParagraphStyleSetting {
     value: *const c_void,
 }
 
-#[allow(non_upper_case_globals)]
-// UnderlineStyle constants are also used for strikethrough styles
-const kCTUnderlineStyleNone: i32 = 0x00;
-const kCTUnderlineStyleSingle: i32 = 0x01;
-
 impl CTParagraphStyleSetting {
     fn alignment(alignment: TextAlignment, is_rtl: bool) -> Self {
         static LEFT: CTTextAlignment = CTTextAlignment::Left;
@@ -159,6 +154,9 @@ impl AttributedString {
 
     #[allow(non_upper_case_globals)]
     pub(crate) fn set_underline(&mut self, range: CFRange, underline: bool) {
+        const kCTUnderlineStyleNone: i32 = 0x00;
+        const kCTUnderlineStyleSingle: i32 = 0x01;
+
         let value = if underline {
             kCTUnderlineStyleSingle
         } else {
@@ -174,18 +172,7 @@ impl AttributedString {
     }
 
     pub(crate) fn set_strikethrough(&mut self, range: CFRange, strikethrough: bool) {
-        let value = if strikethrough {
-            kCTUnderlineStyleSingle
-        } else {
-            kCTUnderlineStyleNone
-        };
-        unsafe {
-            self.inner.set_attribute(
-                range,
-                string_attributes::kCTStrikethroughStyleAttributeName,
-                &CFNumber::from(value).as_CFType(),
-            )
-        }
+        todo!()
     }
 
     pub(crate) fn set_fg_color(&mut self, range: CFRange, color: &Color) {

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -171,10 +171,6 @@ impl AttributedString {
         }
     }
 
-    pub(crate) fn set_strikethrough(&mut self, range: CFRange, strikethrough: bool) {
-        todo!()
-    }
-
     pub(crate) fn set_fg_color(&mut self, range: CFRange, color: &Color) {
         let (r, g, b, a) = color.as_rgba();
         let color = CGColor::rgb(r, g, b, a);

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -171,6 +171,26 @@ impl AttributedString {
         }
     }
 
+    #[allow(non_upper_case_globals)]
+    pub(crate) fn set_strikethrough(&mut self, range: CFRange, strikethrough: bool) {
+        // UnderlineStyle constants are also used for strikethrough styles
+        const kCTUnderlineStyleNone: i32 = 0x00;
+        const kCTUnderlineStyleSingle: i32 = 0x01;
+
+        let value = if strikethrough {
+            kCTUnderlineStyleSingle
+        } else {
+            kCTUnderlineStyleNone
+        };
+        unsafe {
+            self.inner.set_attribute(
+                range,
+                string_attributes::kCTStrikethroughStyleAttributeName,
+                &CFNumber::from(value).as_CFType(),
+            )
+        }
+    }
+
     pub(crate) fn set_fg_color(&mut self, range: CFRange, color: &Color) {
         let (r, g, b, a) = color.as_rgba();
         let color = CGColor::rgb(r, g, b, a);

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -135,8 +135,7 @@ impl CoreGraphicsTextLayoutBuilder {
         }
         // Some attributes are 'standalone' and can just be added to the attributed string
         // immediately.
-        if matches!(&attr, TextAttribute::ForegroundColor(_) | TextAttribute::Underline(_) | TextAttribute::Strikethrough(_))
-        {
+        if matches!(&attr, TextAttribute::ForegroundColor(_) | TextAttribute::Underline(_)) {
             return self.add_immediately(attr, range);
         }
 
@@ -165,8 +164,6 @@ impl CoreGraphicsTextLayoutBuilder {
             .set_fg_color(whole_range, &self.attrs.defaults.fg_color);
         self.attr_string
             .set_underline(whole_range, self.attrs.defaults.underline);
-        self.attr_string
-            .set_strikethrough(whole_range, self.attrs.defaults.strikethrough);
     }
 
     fn add_immediately(&mut self, attr: TextAttribute, range: Range<usize>) {
@@ -178,7 +175,6 @@ impl CoreGraphicsTextLayoutBuilder {
                 self.attr_string.set_fg_color(range, &color);
             }
             TextAttribute::Underline(flag) => self.attr_string.set_underline(range, flag),
-            TextAttribute::Strikethrough(flag) => self.attr_string.set_strikethrough(range, flag),
             _ => unreachable!(),
         }
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -135,7 +135,8 @@ impl CoreGraphicsTextLayoutBuilder {
         }
         // Some attributes are 'standalone' and can just be added to the attributed string
         // immediately.
-        if matches!(&attr, TextAttribute::ForegroundColor(_) | TextAttribute::Underline(_)) {
+        if matches!(&attr, TextAttribute::ForegroundColor(_) | TextAttribute::Underline(_) | TextAttribute::Strikethrough(_))
+        {
             return self.add_immediately(attr, range);
         }
 
@@ -164,6 +165,8 @@ impl CoreGraphicsTextLayoutBuilder {
             .set_fg_color(whole_range, &self.attrs.defaults.fg_color);
         self.attr_string
             .set_underline(whole_range, self.attrs.defaults.underline);
+        self.attr_string
+            .set_strikethrough(whole_range, self.attrs.defaults.strikethrough);
     }
 
     fn add_immediately(&mut self, attr: TextAttribute, range: Range<usize>) {
@@ -175,6 +178,7 @@ impl CoreGraphicsTextLayoutBuilder {
                 self.attr_string.set_fg_color(range, &color);
             }
             TextAttribute::Underline(flag) => self.attr_string.set_underline(range, flag),
+            TextAttribute::Strikethrough(flag) => self.attr_string.set_strikethrough(range, flag),
             _ => unreachable!(),
         }
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -323,6 +323,8 @@ impl Attributes {
             TextAttribute::Weight(w) => self.weight = Some(Span::new(w, range)),
             TextAttribute::FontSize(s) => self.size = Some(Span::new(s, range)),
             TextAttribute::Style(s) => self.style = Some(Span::new(s, range)),
+            TextAttribute::Strikethrough(_) => { /* Unimplemented for now as coregraphics doesn't have native strikethrough support. */
+            }
             _ => unreachable!(),
         }
     }

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -374,6 +374,13 @@ impl TextLayout {
         }
     }
 
+    pub(crate) fn set_strikethrough(&mut self, range: Utf16Range, flag: bool) {
+        let flag = if flag { TRUE } else { FALSE };
+        unsafe {
+            self.0.SetStrikethrough(flag, range.into());
+        }
+    }
+
     pub(crate) fn set_size(&mut self, range: Utf16Range, size: f32) {
         unsafe {
             self.0.SetFontSize(size, range.into());

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -234,6 +234,7 @@ impl D2DTextLayoutBuilder {
                 TextAttribute::Weight(weight) => layout.set_weight(utf16_range, weight),
                 TextAttribute::Style(style) => layout.set_style(utf16_range, style),
                 TextAttribute::Underline(flag) => layout.set_underline(utf16_range, flag),
+                TextAttribute::Strikethrough(flag) => layout.set_strikethrough(utf16_range, flag),
                 TextAttribute::ForegroundColor(color) => self.colors.push((utf16_range, color)),
             }
         }

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -29,6 +29,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .default_attribute(FontWeight::BOLD)
         .range_attribute(..200, TextAttribute::ForegroundColor(BLUE))
         .range_attribute(10..100, FontWeight::NORMAL)
+        .range_attribute(20..50, TextAttribute::Strikethrough(true))
         .range_attribute(40..300, TextAttribute::Underline(false))
         .range_attribute(60..160, FontStyle::Regular)
         .range_attribute(140..220, FontWeight::NORMAL)

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -40,6 +40,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(220.., TextAttribute::FontSize(18.0))
         .range_attribute(240.., FontStyle::Italic)
         .range_attribute(280.., TextAttribute::Underline(true))
+        .range_attribute(320.., TextAttribute::Strikethrough(true))
         .build()?;
 
     rc.draw_text(&en_leading, (0., 0.));

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -123,6 +123,8 @@ pub enum TextAttribute {
     Style(FontStyle),
     /// Underline.
     Underline(bool),
+    /// Strikethrough
+    Strikethrough(bool),
 }
 
 /// A trait for laying out text.

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -123,7 +123,7 @@ pub enum TextAttribute {
     Style(FontStyle),
     /// Underline.
     Underline(bool),
-    /// Strikethrough
+    /// Strikethrough.
     Strikethrough(bool),
 }
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -136,6 +136,7 @@ pub struct LayoutDefaults {
     pub fg_color: Color,
     pub style: FontStyle,
     pub underline: bool,
+    pub strikethrough: bool,
 }
 
 impl LayoutDefaults {
@@ -148,6 +149,7 @@ impl LayoutDefaults {
             TextAttribute::Style(style) => self.style = style,
             TextAttribute::Underline(flag) => self.underline = flag,
             TextAttribute::ForegroundColor(color) => self.fg_color = color,
+            TextAttribute::Strikethrough(flag) => self.strikethrough = flag,
         }
     }
 }
@@ -161,6 +163,7 @@ impl Default for LayoutDefaults {
             fg_color: DEFAULT_TEXT_COLOR,
             style: FontStyle::default(),
             underline: false,
+            strikethrough: false,
         }
     }
 }


### PR DESCRIPTION
Made by basically just copying underline. Just like underline this does not have any support for formatting the strikethrough itself, although the underlying apis support it. ~~I do not have access to a mac to test the coregraphics implementation (nor have I ever written mac code before)~~, however the d2d implementation appears to work on my Win 10 box. This will need a snapshots update.