### PR TITLE
Cache solid color brushes in d2d.

### DIFF
--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "0.2.0-pre3", path = "../piet" }
 utf16_lit = "1.0"
+associative-cache = "1.0"
 
 wio = "0.2.2"
 winapi = { version = "0.3.8", features = ["d2d1", "d2d1_1", "d2d1effects", "d3d11", "dxgi", "winnls"] }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -12,7 +12,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::{null, null_mut};
 
-use associative_cache::{AssociativeCache, Capacity64, HashDirectMapped, RoundRobinReplacement};
+use associative_cache::{AssociativeCache, Capacity1024, HashDirectMapped, RoundRobinReplacement};
 
 use wio::com::ComPtr;
 
@@ -83,7 +83,7 @@ pub struct DeviceContext(
     AssociativeCache<
         ColorWrapper,
         Result<Brush, Error>,
-        Capacity64,
+        Capacity1024,
         HashDirectMapped,
         RoundRobinReplacement,
     >,

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -12,8 +12,6 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::{null, null_mut};
 
-use associative_cache::{AssociativeCache, Capacity1024, HashDirectMapped, RoundRobinReplacement};
-
 use wio::com::ComPtr;
 
 use winapi::shared::dxgi::{IDXGIDevice, IDXGISurface};
@@ -51,7 +49,6 @@ pub enum FillRule {
     NonZero,
 }
 
-#[derive(Clone)]
 pub enum Error {
     WinapiError(HRESULT),
 }
@@ -78,16 +75,8 @@ unsafe impl Send for D2DDevice {}
 ///
 /// This struct is public only to use for system integration in piet_common and druid-shell. It is not intended
 /// that end-users directly use this struct.
-pub struct DeviceContext(
-    ComPtr<ID2D1DeviceContext>,
-    AssociativeCache<
-        ColorWrapper,
-        Result<Brush, Error>,
-        Capacity1024,
-        HashDirectMapped,
-        RoundRobinReplacement,
-    >,
-);
+#[derive(Clone)]
+pub struct DeviceContext(ComPtr<ID2D1DeviceContext>);
 
 pub struct PathGeometry(ComPtr<ID2D1PathGeometry>);
 
@@ -119,10 +108,6 @@ pub struct Effect(ComPtr<ID2D1Effect>);
 // Note: there may be an opportunity here to combine with the version in
 // piet-common direct2d_back, but the use cases are somewhat different.
 pub struct BitmapRenderTarget(ComPtr<ID2D1BitmapRenderTarget>);
-
-// A wrapper that exists solely to implement Hash and PartialEq over
-// color values so we can cache brushes.
-struct ColorWrapper(D2D1_COLOR_F);
 
 impl From<HRESULT> for Error {
     fn from(hr: HRESULT) -> Error {
@@ -255,7 +240,7 @@ impl D2DDevice {
             let mut ptr = null_mut();
             let options = D2D1_DEVICE_CONTEXT_OPTIONS_NONE;
             let hr = self.0.CreateDeviceContext(options, &mut ptr);
-            wrap(hr, ptr, |c| DeviceContext::new(c))
+            wrap(hr, ptr, DeviceContext)
         }
     }
 }
@@ -278,7 +263,7 @@ impl DeviceContext {
     /// # Safety
     /// TODO
     pub unsafe fn new(ptr: ComPtr<ID2D1DeviceContext>) -> DeviceContext {
-        DeviceContext(ptr, Default::default())
+        DeviceContext(ptr)
     }
 
     /// Get the raw pointer
@@ -443,21 +428,16 @@ impl DeviceContext {
         }
     }
 
+    /// This method should not be called directly. Callers should instead call
+    /// D2DRenderContext::solid_brush so values can be cached.
     pub(crate) fn create_solid_color(&mut self, color: D2D1_COLOR_F) -> Result<Brush, Error> {
-        let key = ColorWrapper(color);
-        let com_ptr = &self.0;
-        self.1
-            .entry(&key)
-            .or_insert_with(
-                || key,
-                || unsafe {
-                    let mut ptr = null_mut();
-                    let hr =
-                        com_ptr.CreateSolidColorBrush(&color, &DEFAULT_BRUSH_PROPERTIES, &mut ptr);
-                    wrap(hr, ptr, |p| Brush(p.up()))
-                },
-            )
-            .clone()
+        unsafe {
+            let mut ptr = null_mut();
+            let hr = self
+                .0
+                .CreateSolidColorBrush(&color, &DEFAULT_BRUSH_PROPERTIES, &mut ptr);
+            wrap(hr, ptr, |p| Brush(p.up()))
+        }
     }
 
     pub(crate) fn create_gradient_stops(
@@ -799,24 +779,6 @@ impl Brush {
     // render target).
     pub(crate) fn as_raw(&self) -> *mut ID2D1Brush {
         self.0.as_raw()
-    }
-}
-
-impl PartialEq for ColorWrapper {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.r == other.0.r
-            && self.0.g == other.0.g
-            && self.0.b == other.0.b
-            && self.0.a == other.0.a
-    }
-}
-
-impl std::hash::Hash for ColorWrapper {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        state.write_u32(self.0.r.to_bits());
-        state.write_u32(self.0.g.to_bits());
-        state.write_u32(self.0.b.to_bits());
-        state.write_u32(self.0.a.to_bits());
     }
 }
 

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 /// Currently this is only a 32 bit RGBA value, but it will likely
 /// extend to some form of wide-gamut colorspace, and in the meantime
 /// is useful for giving programs proper type.
-#[derive(Clone, PartialEq, Hash)]
+#[derive(Clone, PartialEq)]
 pub enum Color {
     Rgba32(u32),
 }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 /// Currently this is only a 32 bit RGBA value, but it will likely
 /// extend to some form of wide-gamut colorspace, and in the meantime
 /// is useful for giving programs proper type.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Hash)]
 pub enum Color {
     Rgba32(u32),
 }


### PR DESCRIPTION
Fixes #303, fixes #304.

Doing this required a few weird changes: removing Clone on DeviceContext and adding it to Error, but it all works out. Apparently nothing was using the Clone on DeviceContext? Testing with https://github.com/smmalis37/sudoku_rust shows a massive responsiveness improvement.

Design questions:
Currently this is caching the full result of the CreateSolidBrush call. This means if the call fails we won't retry it until that brush leaves the cache. Only caching successful brushes would require doing something to work around wrap, so I went with this approach instead. Good enough or should I try to only cache successes?

Cache capacity. It supports powers of 2 up to 8192, I picked 64 arbitrarily.

Replacement strategy. Round robin is the simplest so I went with it. Lru is possible but requires some additional code to insert timestamps.

Cache storage. It has to live somewhere, so I just added it to the DeviceContext. If DeviceContext must be Clone then it would have to move somewhere else (the cache doesn't impl Clone for some reason).