### PR TITLE
Add shape specializations to d2d.

### DIFF
--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -2,12 +2,12 @@
 
 use winapi::um::d2d1::{
     D2D1_CAP_STYLE, D2D1_CAP_STYLE_FLAT, D2D1_CAP_STYLE_ROUND, D2D1_CAP_STYLE_SQUARE, D2D1_COLOR_F,
-    D2D1_DASH_STYLE_CUSTOM, D2D1_DASH_STYLE_SOLID, D2D1_GRADIENT_STOP, D2D1_LINE_JOIN,
-    D2D1_LINE_JOIN_BEVEL, D2D1_LINE_JOIN_MITER, D2D1_LINE_JOIN_ROUND, D2D1_MATRIX_3X2_F,
-    D2D1_POINT_2F, D2D1_RECT_F, D2D1_STROKE_STYLE_PROPERTIES,
+    D2D1_DASH_STYLE_CUSTOM, D2D1_DASH_STYLE_SOLID, D2D1_ELLIPSE, D2D1_GRADIENT_STOP,
+    D2D1_LINE_JOIN, D2D1_LINE_JOIN_BEVEL, D2D1_LINE_JOIN_MITER, D2D1_LINE_JOIN_ROUND,
+    D2D1_MATRIX_3X2_F, D2D1_POINT_2F, D2D1_RECT_F, D2D1_ROUNDED_RECT, D2D1_STROKE_STYLE_PROPERTIES,
 };
 
-use piet::kurbo::{Affine, Point, Rect, Vec2};
+use piet::kurbo::{Affine, Circle, Point, Rect, RoundedRect, Vec2};
 
 use piet::{Color, Error, GradientStop, LineCap, LineJoin, RoundFrom, RoundInto, StrokeStyle};
 
@@ -95,6 +95,22 @@ pub(crate) fn rect_to_rectf(rect: Rect) -> D2D1_RECT_F {
         top: rect.y0 as f32,
         right: rect.x1 as f32,
         bottom: rect.y1 as f32,
+    }
+}
+
+pub(crate) fn rounded_rect_to_d2d(round_rect: RoundedRect) -> D2D1_ROUNDED_RECT {
+    D2D1_ROUNDED_RECT {
+        rect: rect_to_rectf(round_rect.rect()),
+        radiusX: round_rect.radius() as f32,
+        radiusY: round_rect.radius() as f32,
+    }
+}
+
+pub(crate) fn circle_to_d2d(circle: Circle) -> D2D1_ELLIPSE {
+    D2D1_ELLIPSE {
+        point: to_point2f(circle.center),
+        radiusX: circle.radius as f32,
+        radiusY: circle.radius as f32,
     }
 }
 

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -156,7 +156,7 @@ fn convert_line_join(line_join: LineJoin) -> D2D1_LINE_JOIN {
 pub(crate) fn convert_stroke_style(
     factory: &D2DFactory,
     stroke_style: &StrokeStyle,
-    width: f32,
+    width: f64,
 ) -> Result<crate::d2d::StrokeStyle, Error> {
     #[allow(unused)]
     let cap = convert_line_cap(stroke_style.line_cap.unwrap_or(LineCap::Butt));
@@ -169,7 +169,7 @@ pub(crate) fn convert_stroke_style(
                 Some(
                     dashes
                         .iter()
-                        .map(|x| *x as f32 * width_recip)
+                        .map(|x| (*x * width_recip) as f32)
                         .collect::<Vec<f32>>(),
                 ),
                 D2D1_DASH_STYLE_CUSTOM,

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -170,6 +170,10 @@ fn optional<T>(val: &Option<T>) -> *const T {
     val.as_ref().map(|x| x as *const T).unwrap_or(null())
 }
 
+fn stroke_style_to_d2d(style: Option<&StrokeStyle>) -> *mut ID2D1StrokeStyle {
+    style.map(|ss| ss.0.as_raw()).unwrap_or(null_mut())
+}
+
 impl D2DFactory {
     /// Create a new Direct2D factory.
     ///
@@ -396,14 +400,71 @@ impl DeviceContext {
         }
     }
 
-    pub(crate) fn draw_line(&self, line: Line, brush: &Brush) {
+    pub(crate) fn draw_line(
+        &self,
+        line: Line,
+        brush: &Brush,
+        width: f32,
+        style: Option<&StrokeStyle>,
+    ) {
         unsafe {
             self.0.DrawLine(
                 to_point2f(line.p0),
                 to_point2f(line.p1),
                 brush.as_raw(),
-                1.0,
-                null_mut(),
+                width,
+                stroke_style_to_d2d(style),
+            );
+        }
+    }
+
+    pub(crate) fn draw_rect(
+        &self,
+        rect: Rect,
+        brush: &Brush,
+        width: f32,
+        style: Option<&StrokeStyle>,
+    ) {
+        unsafe {
+            self.0.DrawRectangle(
+                &rect_to_rectf(rect),
+                brush.as_raw(),
+                width,
+                stroke_style_to_d2d(style),
+            );
+        }
+    }
+
+    pub(crate) fn draw_rounded_rect(
+        &self,
+        rect: RoundedRect,
+        brush: &Brush,
+        width: f32,
+        style: Option<&StrokeStyle>,
+    ) {
+        unsafe {
+            self.0.DrawRoundedRectangle(
+                &rounded_rect_to_d2d(rect),
+                brush.as_raw(),
+                width,
+                stroke_style_to_d2d(style),
+            );
+        }
+    }
+
+    pub(crate) fn draw_circle(
+        &self,
+        circle: Circle,
+        brush: &Brush,
+        width: f32,
+        style: Option<&StrokeStyle>,
+    ) {
+        unsafe {
+            self.0.DrawEllipse(
+                &circle_to_d2d(circle),
+                brush.as_raw(),
+                width,
+                stroke_style_to_d2d(style),
             );
         }
     }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -12,6 +12,8 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::ptr::{null, null_mut};
 
+use piet::kurbo::{Circle, Line, Rect, RoundedRect};
+
 use wio::com::ComPtr;
 
 use winapi::shared::dxgi::{IDXGIDevice, IDXGISurface};
@@ -42,6 +44,7 @@ use winapi::um::d2d1effects::{CLSID_D2D1GaussianBlur, D2D1_GAUSSIANBLUR_PROP_STA
 use winapi::um::dcommon::{D2D1_ALPHA_MODE, D2D1_ALPHA_MODE_PREMULTIPLIED, D2D1_PIXEL_FORMAT};
 use winapi::Interface;
 
+use crate::conv::{circle_to_d2d, rect_to_rectf, rounded_rect_to_d2d, to_point2f};
 use crate::dwrite::TextLayout;
 
 pub enum FillRule {
@@ -390,6 +393,37 @@ impl DeviceContext {
                 width,
                 style.map(|ss| ss.0.as_raw()).unwrap_or(null_mut()),
             );
+        }
+    }
+
+    pub(crate) fn draw_line(&self, line: Line, brush: &Brush) {
+        unsafe {
+            self.0.DrawLine(
+                to_point2f(line.p0),
+                to_point2f(line.p1),
+                brush.as_raw(),
+                1.0,
+                null_mut(),
+            );
+        }
+    }
+
+    pub(crate) fn fill_rect(&self, rect: Rect, brush: &Brush) {
+        unsafe {
+            self.0.FillRectangle(&rect_to_rectf(rect), brush.as_raw());
+        }
+    }
+
+    pub(crate) fn fill_rounded_rect(&self, rect: RoundedRect, brush: &Brush) {
+        unsafe {
+            self.0
+                .FillRoundedRectangle(&rounded_rect_to_d2d(rect), brush.as_raw());
+        }
+    }
+
+    pub(crate) fn fill_circle(&self, circle: Circle, brush: &Brush) {
+        unsafe {
+            self.0.FillEllipse(&circle_to_d2d(circle), brush.as_raw());
         }
     }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -219,17 +219,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     }
 
     fn stroke(&mut self, shape: impl Shape, brush: &impl IntoBrush<Self>, width: f64) {
-        let brush = brush.make_brush(self, || shape.bounding_box());
-        // TODO: various special-case shapes, for efficiency
-        let path = match path_from_shape(self.factory, false, shape, FillRule::EvenOdd) {
-            Ok(path) => path,
-            Err(e) => {
-                self.err = Err(e);
-                return;
-            }
-        };
-        let width = width as f32;
-        self.rt.draw_geometry(&path, &*brush, width, None);
+        self.stroke_impl(shape, brush, width, None)
     }
 
     fn stroke_styled(
@@ -239,19 +229,9 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         width: f64,
         style: &StrokeStyle,
     ) {
-        let brush = brush.make_brush(self, || shape.bounding_box());
-        // TODO: various special-case shapes, for efficiency
-        let path = match path_from_shape(self.factory, false, shape, FillRule::EvenOdd) {
-            Ok(path) => path,
-            Err(e) => {
-                self.err = Err(e);
-                return;
-            }
-        };
-        let width = width as f32;
-        let style = convert_stroke_style(self.factory, style, width)
+        let style = convert_stroke_style(self.factory, style, width as f32)
             .expect("stroke style conversion failed");
-        self.rt.draw_geometry(&path, &*brush, width, Some(&style));
+        self.stroke_impl(shape, brush, width, Some(&style));
     }
 
     fn clip(&mut self, shape: impl Shape) {
@@ -423,6 +403,37 @@ impl<'a> D2DRenderContext<'a> {
                 Ok(path) => self.rt.fill_geometry(&path, &brush, None),
                 Err(e) => self.err = Err(e),
             }
+        }
+    }
+
+    fn stroke_impl(
+        &mut self,
+        shape: impl Shape,
+        brush: &impl IntoBrush<Self>,
+        width: f64,
+        style: Option<&crate::d2d::StrokeStyle>,
+    ) {
+        let brush = brush.make_brush(self, || shape.bounding_box());
+        let width = width as f32;
+
+        if let Some(line) = shape.as_line() {
+            self.rt.draw_line(line, &brush, width, style)
+        } else if let Some(rect) = shape.as_rect() {
+            self.rt.draw_rect(rect, &brush, width, style)
+        } else if let Some(round_rect) = shape.as_rounded_rect() {
+            self.rt.draw_rounded_rect(round_rect, &brush, width, style)
+        } else if let Some(circle) = shape.as_circle() {
+            self.rt.draw_circle(circle, &brush, width, style)
+        } else {
+            let path = match path_from_shape(self.factory, false, shape, FillRule::EvenOdd) {
+                Ok(path) => path,
+                Err(e) => {
+                    self.err = Err(e);
+                    return;
+                }
+            };
+            let width = width;
+            self.rt.draw_geometry(&path, &*brush, width, style);
         }
     }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -229,7 +229,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         width: f64,
         style: &StrokeStyle,
     ) {
-        let style = convert_stroke_style(self.factory, style, width as f32)
+        let style = convert_stroke_style(self.factory, style, width)
             .expect("stroke style conversion failed");
         self.stroke_impl(shape, brush, width, Some(&style));
     }


### PR DESCRIPTION
Fixes #60.

I plan to tackle the rest of the TODO comments on this, but I wanted to ensure I'm doing things correctly first. I haven't done much testing, are the snapshots good enough or should I do more? Also, do the FillRules affect simple shapes? A quick read of the docs on msdn leads me to think no, but this is all new to me. If not then I'll probably refactor the two methods into just calling a combined `fill_impl`, but if there needs to be something more involved then they may stay separate.  And does calling fill on a line actually need to do any work (like I've currently got) or will it all be handled by `stroke` (which will then get specialized to call DrawLine)?