### PR TITLE
Remove warning about missing TextAlignment support with Cairo.

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -110,7 +110,7 @@ impl TextLayoutBuilder for CairoTextLayoutBuilder {
     }
 
     fn alignment(self, _alignment: piet::TextAlignment) -> Self {
-        eprintln!("TextAlignment not supported by cairo toy text");
+        // TextAlignment is not supported by cairo toy text.
         self
     }
 


### PR DESCRIPTION
This was mentioned by @smmalis37 before, and I encountered it just now while updating my project.

Warnings like this are quite annoying as they just keep spaming the terminal, I think this would be better off in a GitHub issue.