### PR TITLE
Add TextStorage trait

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -4,14 +4,14 @@ mod grapheme;
 mod lines;
 
 use std::ops::RangeBounds;
-use std::sync::Arc;
+use std::rc::Rc;
 
 use cairo::{FontFace, FontOptions, FontSlant, FontWeight, Matrix, ScaledFont};
 
 use piet::kurbo::{Point, Rect, Size};
 use piet::{
     util, Color, Error, FontFamily, FontStyle, HitTestPoint, HitTestPosition, LineMetric, Text,
-    TextAttribute, TextLayout, TextLayoutBuilder,
+    TextAttribute, TextLayout, TextLayoutBuilder, TextStorage,
 };
 
 use unicode_segmentation::UnicodeSegmentation;
@@ -37,14 +37,14 @@ pub struct CairoTextLayout {
     pub(crate) fg_color: Color,
     size: Size,
     pub(crate) font: ScaledFont,
-    pub(crate) text: Arc<str>,
+    pub(crate) text: Rc<dyn TextStorage>,
 
     // currently calculated on build
     pub(crate) line_metrics: Vec<LineMetric>,
 }
 
 pub struct CairoTextLayoutBuilder {
-    text: Arc<str>,
+    text: Rc<dyn TextStorage>,
     defaults: util::LayoutDefaults,
     width_constraint: f64,
 }
@@ -72,10 +72,10 @@ impl Text for CairoText {
         Err(Error::NotSupported)
     }
 
-    fn new_text_layout(&mut self, text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, text: impl TextStorage) -> Self::TextLayoutBuilder {
         CairoTextLayoutBuilder {
             defaults: util::LayoutDefaults::default(),
-            text: text.into(),
+            text: Rc::new(text),
             width_constraint: f64::INFINITY,
         }
     }

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -54,7 +54,7 @@ mod test {
     fn test_metrics_with_width(
         width: f64,
         expected: Vec<LineMetric>,
-        input: &str,
+        input: impl TextStorage,
         text_layout: &mut D2DText,
         font: &FontFamily,
         font_size: f64,

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -1,10 +1,11 @@
 //! Text functionality for Piet svg backend
 
 use std::ops::RangeBounds;
-use std::sync::Arc;
 
 use piet::kurbo::{Point, Rect, Size};
-use piet::{Error, FontFamily, HitTestPoint, HitTestPosition, LineMetric, TextAttribute};
+use piet::{
+    Error, FontFamily, HitTestPoint, HitTestPosition, LineMetric, TextAttribute, TextStorage,
+};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -31,7 +32,7 @@ impl piet::Text for Text {
         Ok(FontFamily::default())
     }
 
-    fn new_text_layout(&mut self, _text: impl Into<Arc<str>>) -> TextLayoutBuilder {
+    fn new_text_layout(&mut self, _text: impl TextStorage) -> TextLayoutBuilder {
         TextLayoutBuilder
     }
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -220,10 +220,8 @@ impl RenderContext for WebRenderContext<'_> {
         self.ctx.set_font(&layout.font.get_font_string());
         let pos = pos.into();
         for lm in &layout.line_metrics {
-            let draw_line = self
-                .ctx
-                .fill_text(&layout.text[lm.start_offset..lm.end_offset], pos.x, pos.y)
-                .wrap();
+            let line_text = &layout.text[lm.range()];
+            let draw_line = self.ctx.fill_text(line_text, pos.x, pos.y).wrap();
 
             if let Err(e) = draw_line {
                 self.err = Err(e);

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -2,14 +2,13 @@
 
 use std::borrow::Cow;
 use std::ops::RangeBounds;
-use std::sync::Arc;
 
 use kurbo::{Affine, Point, Rect, Shape, Size};
 
 use crate::{
     Color, Error, FixedGradient, FontFamily, HitTestPoint, HitTestPosition, ImageFormat,
     InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextAttribute,
-    TextLayout, TextLayoutBuilder,
+    TextLayout, TextLayoutBuilder, TextStorage,
 };
 
 /// A render context that doesn't render.
@@ -136,7 +135,7 @@ impl Text for NullText {
         Ok(FontFamily::default())
     }
 
-    fn new_text_layout(&mut self, _text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder {
+    fn new_text_layout(&mut self, _text: impl TextStorage) -> Self::TextLayoutBuilder {
         NullTextLayoutBuilder
     }
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -1,7 +1,6 @@
 //! Traits for fonts and text handling.
 
 use std::ops::{Range, RangeBounds};
-use std::sync::Arc;
 
 use crate::kurbo::{Point, Rect, Size};
 use crate::{Color, Error, FontFamily, FontStyle, FontWeight};
@@ -104,7 +103,36 @@ pub trait Text: Clone {
     /// they can pass a `&str`, which the layout will retain.
     ///
     /// [`TextLayoutBuilder`]: trait.TextLayoutBuilder.html
-    fn new_text_layout(&mut self, text: impl Into<Arc<str>>) -> Self::TextLayoutBuilder;
+    fn new_text_layout(&mut self, text: impl TextStorage) -> Self::TextLayoutBuilder;
+}
+
+/// A type that stores text.
+///
+/// This allows the client to more completely control how text is stored.
+/// If you do not care about this, implementations are provided for `String`,
+/// `Arc<str>`, and `Rc<str>`.
+///
+/// This has a `'static` bound because the inner type will be behind a shared
+/// pointer.
+pub trait TextStorage: 'static {
+    /// Return the underlying text as a contiguous buffer.
+    ///
+    /// Types that do not store their text as a contiguous buffer (such as ropes
+    /// or gap buffers) will need to use a wrapper to maintain a separate
+    /// contiguous buffer as required.
+    ///
+    /// In practice, these types should be using a [`TextLayout`] object
+    /// per paragraph, and in general a separate buffer will be unnecessary.
+    ///
+    /// [`TextLayout`]: trait.TextLayout.html
+    fn as_str(&self) -> &str;
+}
+
+impl std::ops::Deref for dyn TextStorage {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
 }
 
 /// Attributes that can be applied to text.
@@ -545,5 +573,29 @@ impl From<FontStyle> for TextAttribute {
 impl Default for TextAlignment {
     fn default() -> Self {
         TextAlignment::Start
+    }
+}
+
+impl TextStorage for std::sync::Arc<str> {
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl TextStorage for std::rc::Rc<str> {
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl TextStorage for String {
+    fn as_str(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl TextStorage for &'static str {
+    fn as_str(&self) -> &str {
+        self
     }
 }


### PR DESCRIPTION
This is a further refinement of how we want to store the
actual text backing a layout object. The motivation here
is to allow the client maximum flexibility in terms of
how they store their text.

This moves from using `Arc<str>` everywhere to using
`Rc<dyn TextStorage>`; this introduces another layer
of pointer indirection in various cases, but saves us
needing to add a type parameter.