### PR TITLE
Impl TextStorage for Arc<String> & Rc<String>

### DIFF
--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -594,6 +594,18 @@ impl TextStorage for String {
     }
 }
 
+impl TextStorage for std::sync::Arc<String> {
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
+impl TextStorage for std::rc::Rc<String> {
+    fn as_str(&self) -> &str {
+        self
+    }
+}
+
 impl TextStorage for &'static str {
     fn as_str(&self) -> &str {
         self


### PR DESCRIPTION
I have some aspirations to use Arc<String> as a simple
editable text type in druid, and orphan rules oblige me
to have this impl'd for that to work.