### PR TITLE
Standardize handling of newline at EOF

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -253,12 +253,26 @@ impl CairoTextLayout {
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 
         self.line_metrics = lines::calculate_line_metrics(&self.text, &self.font, new_width);
-        if self.line_metrics.is_empty() {
+        if self.text.is_empty() {
             self.line_metrics.push(LineMetric {
                 baseline: self.font.extents().ascent,
                 height: self.font.extents().height,
                 ..Default::default()
             })
+        } else if self.text.as_bytes().last() == Some(&b'\n') {
+            let newline_eof = self
+                .line_metrics
+                .last()
+                .map(|lm| LineMetric {
+                    start_offset: self.text.len(),
+                    end_offset: self.text.len(),
+                    height: lm.height,
+                    baseline: lm.baseline,
+                    y_offset: lm.y_offset + lm.height,
+                    trailing_whitespace: 0,
+                })
+                .unwrap();
+            self.line_metrics.push(newline_eof);
         }
 
         let width = self

--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -1,5 +1,6 @@
 //! Basic conformance testing for text.
 
+use kurbo::Point;
 use piet_common::*;
 
 macro_rules! assert_close {
@@ -60,6 +61,51 @@ fn empty_layout_size() {
     assert_close!(
         empty_layout.size().height,
         non_empty_layout.size().height,
+        1.0
+    );
+}
+
+/// Text with a newline at EOF should have one more line reported than
+/// the same text without the newline.
+#[test]
+fn newline_eof() {
+    let mut factory = make_factory();
+    let text = "A";
+    let layout = factory.new_text_layout(text).build().unwrap();
+    assert_eq!(layout.line_count(), 1);
+
+    let text = "\n";
+    let layout = factory.new_text_layout(text).build().unwrap();
+    assert_eq!(layout.line_count(), 2);
+    assert_eq!(layout.line_text(0), Some("\n"));
+    assert_eq!(layout.line_text(1), Some(""));
+    assert!(layout.line_text(2).is_none());
+
+    let hit0 = layout.hit_test_text_position(0);
+    let hit1 = layout.hit_test_text_position(1);
+    assert_close!(hit0.point.y * 2., hit1.point.y, 5.0);
+    assert_eq!(hit0.line, 0);
+    assert_eq!(hit1.line, 1);
+
+    let hit1 = layout.hit_test_point(Point::new(50., 50.));
+    assert_eq!(hit1.idx, 1);
+
+    //TODO: the right of the first line should result in an insert before the newline
+    //let hit = layout.hit_test_point(Point::new(20., 1.));
+    //assert_eq!(hit.idx, 0)
+
+    let text = "AA";
+    let layout = factory.new_text_layout(text).build().unwrap();
+    assert_eq!(layout.line_count(), 1);
+
+    let text = "AA\n";
+    let layout_newline = factory.new_text_layout(text).build().unwrap();
+    assert_eq!(layout_newline.line_count(), 2);
+
+    // newline should be reported in size
+    assert_close!(
+        layout.size().height * 2.0,
+        layout_newline.size().height,
         1.0
     );
 }

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -291,7 +291,7 @@ impl TextLayout for D2DTextLayout {
     fn line_text(&self, line_number: usize) -> Option<&str> {
         self.line_metrics
             .get(line_number)
-            .map(|lm| &self.text[lm.start_offset..(lm.end_offset - lm.trailing_whitespace)])
+            .map(|lm| &self.text[lm.range()])
     }
 
     fn line_metric(&self, line_number: usize) -> Option<LineMetric> {
@@ -497,6 +497,17 @@ mod test {
         assert_close!(pos.point.y, 10.0, 3.0);
         let line = layout.line_metric(0).unwrap();
         assert_close!(line.height, 14.0, 3.0);
+    }
+
+    #[test]
+    fn newline_text() {
+        let layout = D2DText::new_for_test()
+            .new_text_layout("A\nB")
+            .build()
+            .unwrap();
+        assert_eq!(layout.line_count(), 2);
+        assert_eq!(layout.line_text(0), Some("A\n"));
+        assert_eq!(layout.line_text(1), Some("B"));
     }
 
     #[test]
@@ -787,9 +798,9 @@ mod test {
             .unwrap();
 
         assert_eq!(layout.line_count(), 4);
-        assert_eq!(layout.line_text(0), Some("piet"));
-        assert_eq!(layout.line_text(1), Some("text"));
-        assert_eq!(layout.line_text(2), Some("most"));
+        assert_eq!(layout.line_text(0), Some("piet "));
+        assert_eq!(layout.line_text(1), Some("text "));
+        assert_eq!(layout.line_text(2), Some("most "));
         assert_eq!(layout.line_text(3), Some("best"));
         assert_eq!(layout.line_text(4), None);
     }

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -345,6 +345,8 @@ pub trait TextLayout: Clone {
     fn text(&self) -> &str;
 
     /// Given a line number, return a reference to that line's underlying string.
+    ///
+    /// This will include any trailing whitespace.
     fn line_text(&self, line_number: usize) -> Option<&str>;
 
     /// Given a line number, return a reference to that line's metrics, if the line exists.


### PR DESCRIPTION
- this should be included in the layout's reported size
- this should be reported as an additional line (count_lines())
- this should be a valid cursor position during hit testing