### PR TITLE
Standardize behaviour of empty TextLayout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
   test-stable:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [macOS-latest, windows-2019, ubuntu-latest]
     name: cargo clippy+test

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -177,15 +177,7 @@ impl TextLayout for CairoTextLayout {
     }
 
     fn line_metric(&self, line_number: usize) -> Option<LineMetric> {
-        if line_number == 0 && self.text.is_empty() {
-            Some(LineMetric {
-                baseline: self.font.extents().ascent,
-                height: self.font.extents().height,
-                ..Default::default()
-            })
-        } else {
-            self.line_metrics.get(line_number).cloned()
-        }
+        self.line_metrics.get(line_number).cloned()
     }
 
     fn line_count(&self) -> usize {
@@ -261,6 +253,13 @@ impl CairoTextLayout {
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 
         self.line_metrics = lines::calculate_line_metrics(&self.text, &self.font, new_width);
+        if self.line_metrics.is_empty() {
+            self.line_metrics.push(LineMetric {
+                baseline: self.font.extents().ascent,
+                height: self.font.extents().height,
+                ..Default::default()
+            })
+        }
 
         let width = self
             .line_metrics

--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -42,6 +42,16 @@ fn empty_layout() {
 }
 
 #[test]
+fn ws_only_layout() {
+    let mut factory = make_factory();
+    let text = " ";
+    let layout = factory.new_text_layout(text).build().unwrap();
+    assert_eq!(layout.line_count(), 1);
+    assert!(layout.line_metric(0).is_some());
+    assert!(layout.line_text(0).is_some());
+}
+
+#[test]
 fn empty_layout_size() {
     let mut factory = make_factory();
     let empty_layout = factory.new_text_layout("").build().unwrap();

--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -1,0 +1,55 @@
+//! Basic conformance testing for text.
+
+use piet_common::*;
+
+macro_rules! assert_close {
+    ($val:expr, $target:expr, $tolerance:expr) => {{
+        let min = $target - $tolerance;
+        let max = $target + $tolerance;
+        if $val < min || $val > max {
+            panic!(
+                "value {} outside target {} with tolerance {}",
+                $val, $target, $tolerance
+            );
+        }
+    }};
+
+    ($val:expr, $target:expr, $tolerance:expr,) => {{
+        assert_close!($val, $target, $tolerance)
+    }};
+}
+
+fn make_factory() -> PietText {
+    let mut device = Device::new().unwrap();
+    let mut target = device.bitmap_target(400, 400, 2.0).unwrap();
+    let mut ctx = target.render_context();
+    let text = ctx.text().to_owned();
+    let _ = ctx.finish();
+    text
+}
+
+#[test]
+fn empty_layout() {
+    let mut factory = make_factory();
+    let text = "";
+    let layout = factory.new_text_layout(text).build().unwrap();
+    // this has one reported line
+    assert_eq!(layout.line_count(), 1);
+    // you can get line metrics for the first line
+    assert!(layout.line_metric(0).is_some());
+    // and the text
+    assert!(layout.line_text(0).is_some());
+}
+
+#[test]
+fn empty_layout_size() {
+    let mut factory = make_factory();
+    let empty_layout = factory.new_text_layout("").build().unwrap();
+    let non_empty_layout = factory.new_text_layout("-").build().unwrap();
+    assert!(empty_layout.size().height > 0.0);
+    assert_close!(
+        empty_layout.size().height,
+        non_empty_layout.size().height,
+        1.0
+    );
+}

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -319,6 +319,10 @@ pub trait TextLayout: Clone {
     /// This is the size required to draw this `TextLayout`, as provided by the
     /// platform text system.
     ///
+    /// If the layout is empty (the text is the empty string) the returned
+    /// `Size` will have the height required to draw a cursor in the layout's
+    /// default font.
+    ///
     /// # Note
     ///
     /// This is not currently defined very rigorously; in particular we do not
@@ -354,6 +358,9 @@ pub trait TextLayout: Clone {
     fn line_metric(&self, line_number: usize) -> Option<LineMetric>;
 
     /// Returns total number of lines in the text layout.
+    ///
+    /// The return value will always be greater than 0; a layout of the empty
+    /// string is considered to have a single line.
     fn line_count(&self) -> usize;
 
     /// Given a `Point`, return a [`HitTestPoint`] describing the corresponding


### PR DESCRIPTION
This includes some of the conformance testing stuff from #326, which I will close. It is an attempt to unify the behaviour of a layout object when the layout text is the empty string.

This changes piet-coregraphics and piet-cairo to behave
like piet-d2d in this regard:

- An empty layout is considered to have a single line
- the text for this line (empty string) can be retrieved
- the LineMetric for this line can be retrieved; it will
be synthesized as needed (this was already in place)

This also adds conformance tests to piet-common that
check the consistency of this across implementations.