### PR TITLE
Make rects_for_range return nothing for empty range

### DIFF
--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -52,6 +52,14 @@ fn ws_only_layout() {
 }
 
 #[test]
+fn rects_for_empty_range() {
+    let mut factory = make_factory();
+    let text = "";
+    let layout = factory.new_text_layout(text).build().unwrap();
+    assert!(layout.rects_for_range(0..0).is_empty());
+}
+
+#[test]
 fn empty_layout_size() {
     let mut factory = make_factory();
     let empty_layout = factory.new_text_layout("").build().unwrap();

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -622,35 +622,6 @@ impl TextLayout for CoreGraphicsTextLayout {
         let y_pos = metric.y_offset + metric.baseline;
         HitTestPosition::new(Point::new(x_pos, y_pos), line_num)
     }
-
-    fn rects_for_range(&self, range: impl RangeBounds<usize>) -> Vec<Rect> {
-        let range = util::resolve_range(range, self.text.len());
-        let first_line = self.line_number_for_utf8_offset(range.start);
-        let last_line = self.line_number_for_utf8_offset(range.end);
-
-        let mut result = Vec::new();
-
-        for line in first_line..=last_line {
-            let metrics = self.line_metric(line).unwrap();
-            let y0 = metrics.y_offset;
-            let y1 = y0 + metrics.height;
-            let line_range_start = if line == first_line {
-                range.start
-            } else {
-                metrics.start_offset
-            };
-
-            let line_range_end = if line == last_line {
-                range.end
-            } else {
-                metrics.end_offset - metrics.trailing_whitespace
-            };
-            let start_point = self.hit_test_text_position(line_range_start);
-            let end_point = self.hit_test_text_position(line_range_end);
-            result.push(Rect::new(start_point.point.x, y0, end_point.point.x, y1));
-        }
-        result
-    }
 }
 
 impl CoreGraphicsTextLayout {

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -411,6 +411,10 @@ pub trait TextLayout: Clone {
         range.start = range.start.min(text_len);
         range.end = range.end.min(text_len);
 
+        if range.start >= range.end {
+            return Vec::new();
+        }
+
         let first_line = self.hit_test_text_position(range.start).line;
         let last_line = self.hit_test_text_position(range.end).line;
 


### PR DESCRIPTION
Previously it would return a rect with zero size.

This also removes a duplicate implementation of this
method in piet-coregraphics.

This is based off of #328 