### PR TITLE
Standardize hit_test_point on newline at EOL

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -220,6 +220,9 @@ impl TextLayout for CairoTextLayout {
 
         let mut htp = hit_test_line_point(&self.font, line, point);
         htp.idx += lm.start_offset;
+        if htp.idx == lm.end_offset {
+            htp.idx -= util::trailing_nlf(line).unwrap_or(0);
+        }
         htp.is_inside &= y_inside;
         htp
     }
@@ -259,7 +262,7 @@ impl CairoTextLayout {
                 height: self.font.extents().height,
                 ..Default::default()
             })
-        } else if self.text.as_bytes().last() == Some(&b'\n') {
+        } else if util::trailing_nlf(&self.text).is_some() {
             let newline_eof = self
                 .line_metrics
                 .last()

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -49,6 +49,25 @@ pub fn count_until_utf16(s: &str, utf16_text_position: usize) -> Option<usize> {
     None
 }
 
+/// If this string ends in a [newline function (NLF)][] (5.8), return the length
+/// of the NLF in bytes.
+///
+/// Note: this is currently just handling the newline character, `\\n`. When a
+/// line ends in a newline and a user clicks at the end of that line,
+/// you generally want to insert the cursor *before* that character.
+///
+/// In the future, we may want to respect other separators, as per the
+/// unicode spec.
+///
+/// [newline function (NLF)]: https://www.unicode.org/versions/Unicode13.0.0/ch05.pdf
+pub fn trailing_nlf(s: &str) -> Option<usize> {
+    if s.as_bytes().last() == Some(&b'\n') {
+        Some(1)
+    } else {
+        None
+    }
+}
+
 /// Returns the index of the line containing this utf8 position,
 /// or the last line index if the position is out of bounds.
 ///


### PR DESCRIPTION
When there's a newline at the end of a visual line, a hit-test
at the end of that line should return the offset of the
character preceding the newline, not the newline itself.