### PR TITLE
[d2d] Use default line height as height when text is empty

### DIFF
--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -63,8 +63,16 @@ fn rects_for_empty_range() {
 #[test]
 fn empty_layout_size() {
     let mut factory = make_factory();
-    let empty_layout = factory.new_text_layout("").build().unwrap();
-    let non_empty_layout = factory.new_text_layout("-").build().unwrap();
+    let empty_layout = factory
+        .new_text_layout("")
+        .font(FontFamily::SYSTEM_UI, 24.0)
+        .build()
+        .unwrap();
+    let non_empty_layout = factory
+        .new_text_layout("-")
+        .font(FontFamily::SYSTEM_UI, 24.0)
+        .build()
+        .unwrap();
     assert!(empty_layout.size().height > 0.0);
     assert_close!(
         empty_layout.size().height,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -385,6 +385,9 @@ impl D2DTextLayout {
         );
 
         self.size = size;
+        if self.text.is_empty() {
+            self.size.height = self.default_line_height;
+        }
         self.line_metrics = line_metrics.into();
         self.inking_insets = inking_insets;
     }
@@ -479,6 +482,24 @@ mod test {
         ($val:expr, $target:expr, $tolerance:expr,) => {{
             assert_close!($val, $target, $tolerance)
         }};
+    }
+
+    #[test]
+    fn layout_size() {
+        let a_font = FontFamily::new_unchecked("Segoe UI");
+        let mut factory = D2DText::new_for_test();
+        let empty_layout = factory
+            .new_text_layout("")
+            .font(a_font.clone(), 22.0)
+            .build()
+            .unwrap();
+        let layout = factory
+            .new_text_layout("hello")
+            .font(a_font, 22.0)
+            .build()
+            .unwrap();
+
+        assert_close!(empty_layout.size().height, layout.size().height, 1e-6);
     }
 
     #[test]


### PR DESCRIPTION
This is a less principled approach to fixing #339 than is
outlined in that issue, but is less invasive and works just as well.

This also fixes a test in piet-common that was intended to catch
this, but that was using a layout with a default font size, which
doesn't manifest this problem.

- fixes #339
- fixes https://github.com/linebender/druid/issues/1309