### PR TITLE
Simplify selection of backend in piet-common

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -9,20 +9,12 @@ edition = "2018"
 keywords = ["graphics", "2d"]
 
 [features]
-d2d = ["piet-direct2d"]
-cairo = ["piet-cairo", "cairo-rs", "cairo-sys-rs"]
 web = ["piet-web"]
 
 [dependencies]
 piet = { version = "0.2.0-pre5", path = "../piet" }
-piet-cairo = { version = "0.2.0-pre5", path = "../piet-cairo", optional = true }
-piet-coregraphics = { version = "0.2.0-pre5", path = "../piet-coregraphics", optional = true }
-piet-direct2d = { version = "0.2.0-pre5", path = "../piet-direct2d", optional = true }
 piet-web = { version = "0.2.0-pre5", path = "../piet-web", optional = true }
-
 cfg-if = "0.1.10"
-cairo-rs = { version = "0.9.1", default_features = false, optional = true }
-cairo-sys-rs = { version = "0.10.0", optional = true }
 png = { version = "0.16.1", optional = true }
 
 [target.'cfg(target_os="linux")'.dependencies]

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -32,8 +32,10 @@ pub use piet::*;
 pub use piet::kurbo;
 
 cfg_if::cfg_if! {
-    // if we have explicitly asked for cairo *or* we are not wasm, web, or windows:
-    if #[cfg(any(feature = "cairo", not(any(target_arch = "wasm32", feature="web", target_os="macos", target_os = "windows"))))] {
+     if #[cfg(any(feature = "web", target_arch = "wasm32"))] {
+        #[path = "web_back.rs"]
+        mod backend;
+    } else if #[cfg(target_os = "linux")] {
         #[path = "cairo_back.rs"]
         mod backend;
     } else if #[cfg(target_os = "macos")] {
@@ -41,9 +43,6 @@ cfg_if::cfg_if! {
         mod backend;
     } else if #[cfg(target_os = "windows")] {
         #[path = "direct2d_back.rs"]
-        mod backend;
-    } else if #[cfg(any(feature = "web", target_arch = "wasm32"))] {
-        #[path = "web_back.rs"]
         mod backend;
     } else {
         compile_error!("could not select an appropriate backend");


### PR DESCRIPTION
Previously you could optionally use cairo on macOS, but that
does not seem useful anymore.