### PR TITLE
Fix basic drawing of text on web

### DIFF
--- a/piet-web/examples/basic/src/lib.rs
+++ b/piet-web/examples/basic/src/lib.rs
@@ -7,6 +7,9 @@ use web_sys::{window, HtmlCanvasElement};
 use piet::{samples, RenderContext};
 use piet_web::WebRenderContext;
 
+//TODO: figure out how to dynamically select the sample?
+const SAMPLE_PICTURE_NO: usize = 11;
+
 #[wasm_bindgen]
 pub fn run() {
     #[cfg(feature = "console_error_panic_hook")]
@@ -27,6 +30,7 @@ pub fn run() {
         .dyn_into::<web_sys::CanvasRenderingContext2d>()
         .unwrap();
 
+    let sample = samples::get::<WebRenderContext>(SAMPLE_PICTURE_NO);
     let dpr = window.device_pixel_ratio();
     canvas.set_width((canvas.offset_width() as f64 * dpr) as u32);
     canvas.set_height((canvas.offset_height() as f64 * dpr) as u32);
@@ -34,7 +38,6 @@ pub fn run() {
 
     let mut piet_context = WebRenderContext::new(context, window);
 
-    // TODO: make the test picture selectable
-    samples::get(0).draw(&mut piet_context).unwrap();
+    sample.draw(&mut piet_context).unwrap();
     piet_context.finish().unwrap();
 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -218,16 +218,21 @@ impl RenderContext for WebRenderContext<'_> {
 
     fn draw_text(&mut self, layout: &Self::TextLayout, pos: impl Into<Point>) {
         // TODO: bounding box for text
+        self.ctx.save();
         self.ctx.set_font(&layout.font.get_font_string());
+        let brush = layout.color().make_brush(self, || layout.size().to_rect());
+        self.set_brush(&brush, true);
         let pos = pos.into();
         for lm in &layout.line_metrics {
             let line_text = &layout.text[lm.range()];
-            let draw_line = self.ctx.fill_text(line_text, pos.x, pos.y).wrap();
+            let line_y = lm.y_offset + lm.baseline + pos.y;
+            let draw_line = self.ctx.fill_text(line_text, pos.x, line_y).wrap();
 
             if let Err(e) = draw_line {
                 self.err = Err(e);
             }
         }
+        self.ctx.restore();
     }
 
     fn save(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
This doesn't support alignment, soft breaks, or style spans, but
it does support basic default styles and drawing of multiline,
when those lines are hard breaks.


- closes #311

before:

<img width="536" alt="Screen Shot 2020-10-21 at 11 53 24 AM" src="https://user-images.githubusercontent.com/3330916/96745336-0979d900-1394-11eb-8705-80490f01e515.png">
after:

<img width="559" alt="Screen Shot 2020-10-21 at 11 52 39 AM" src="https://user-images.githubusercontent.com/3330916/96745243-ec450a80-1393-11eb-9ae5-97d9241df098.png">
