### PR TITLE
Support grayscale images

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -272,7 +272,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                     }
                     ImageFormat::GrayScale => {
                         for x in 0..width {
-                            data[dst_off + x] = buf[src_off + x];
+                            data[dst_off + x] = 255 - buf[src_off + x];
                         }
                     }
                     _ => return Err(Error::NotSupported),

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -222,6 +222,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         let cairo_fmt = match format {
             ImageFormat::Rgb => Format::Rgb24,
             ImageFormat::RgbaSeparate | ImageFormat::RgbaPremul => Format::ARgb32,
+            ImageFormat::GrayScale => Format::A8,
             _ => return Err(Error::NotSupported),
         };
         let mut image = ImageSurface::create(cairo_fmt, width as i32, height as i32)
@@ -267,6 +268,11 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                             data[dst_off + x * 4 + 1] = premul(buf[src_off + x * 4 + 1], a);
                             data[dst_off + x * 4 + 2] = premul(buf[src_off + x * 4 + 0], a);
                             data[dst_off + x * 4 + 3] = a;
+                        }
+                    }
+                    ImageFormat::GrayScale => {
+                        for x in 0..width {
+                            data[dst_off + x] = buf[src_off + x];
                         }
                     }
                     _ => return Err(Error::NotSupported),

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -281,7 +281,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
                 4,
             ),
             ImageFormat::RgbaSeparate => (CGColorSpace::create_device_rgb(), kCGImageAlphaLast, 4),
-            ImgaeFormat::GrayScale => (CGColorSpace::create_device_gray(), 0, 1),
+            ImageFormat::GrayScale => (CGColorSpace::create_device_gray(), 0, 1),
             _ => unimplemented!(),
         };
         let bits_per_component = 8;

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -281,6 +281,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
                 4,
             ),
             ImageFormat::RgbaSeparate => (CGColorSpace::create_device_rgb(), kCGImageAlphaLast, 4),
+            ImgaeFormat::GrayScale => (CGColorSpace::create_device_gray(), 0, 1),
             _ => unimplemented!(),
         };
         let bits_per_component = 8;

--- a/piet/src/image.rs
+++ b/piet/src/image.rs
@@ -114,6 +114,7 @@ impl ImageBuf {
             .map(move |row| {
                 row.chunks_exact(bytes_per_pixel)
                     .map(move |p| match format {
+                        ImageFormat::GrayScale => Color::grey8(p[0]),
                         ImageFormat::Rgb => Color::rgb8(p[0], p[1], p[2]),
                         ImageFormat::RgbaSeparate => Color::rgba8(p[0], p[1], p[2], p[3]),
                         ImageFormat::RgbaPremul => {

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -22,17 +22,21 @@ pub enum InterpolationMode {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum ImageFormat {
+    /// 1 byte per pixel
+    GrayScale,
     /// 3 bytes per pixel, in RGB order.
     Rgb,
     /// 4 bytes per pixel, in RGBA order, with separate alpha.
     RgbaSeparate,
     /// 4 bytes per pixel, in RGBA order, with premultiplied alpha.
     RgbaPremul,
+
 }
 
 impl ImageFormat {
     pub fn bytes_per_pixel(self) -> usize {
         match self {
+            ImageFormat::GrayScale => 1,
             ImageFormat::Rgb => 3,
             ImageFormat::RgbaPremul | ImageFormat::RgbaSeparate => 4,
         }


### PR DESCRIPTION
This branch adds a type to the `ImageFormat` enum for grayscale support.
As well as adding support for it in the two backends: `coregraphics` and `cairo` (check below for limitations).

## Open Todos
- Other backends
- Since cairo does not support grayscale image types, I used the alpha type `A8`, as recommended by them on the mailing list. This is why I invert the pixel value (line 256 in ..cairo.../lib.rs). However, besides this it is important that the image has a white background. This may needs to be done automatically on a lower level instead of doing it when loading the image with `.background(Color::WHITE)`.

I confirmed that this works on Linux Fedora/GNOME.