### PR TITLE
Correct rtl alignment

### DIFF
--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -18,7 +18,6 @@ core-graphics = "0.22.0"
 core-text = "19.0.0"
 core-foundation = "0.9"
 core-foundation-sys = "0.8"
-unic-bidi = "0.9"
 
 [dev-dependencies]
 piet = { version = "=0.2.0-pre6", path = "../piet", features = ["samples"] }

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -36,10 +36,9 @@ use core_text::{
     string_attributes,
 };
 use foreign_types::ForeignType;
-use unic_bidi::bidi_class::{BidiClass, BidiClassCategory};
 
 use piet::kurbo::{Affine, Rect};
-use piet::{Color, FontFamily, FontFamilyInner, TextAlignment};
+use piet::{util, Color, FontFamily, FontFamilyInner, TextAlignment};
 
 #[derive(Clone)]
 pub(crate) struct AttributedString {
@@ -129,7 +128,7 @@ impl AttributedString {
         let range = CFRange::init(0, 0);
         let cf_string = CFString::new(text);
         inner.replace_str(&cf_string, range);
-        let rtl = first_strong_rtl(text);
+        let rtl = util::first_strong_rtl(text);
         AttributedString { inner, rtl }
     }
 
@@ -336,21 +335,6 @@ pub(crate) fn add_font(font_data: &[u8]) -> Result<String, ()> {
 }
 
 //TODO: this will probably be shared at some point?
-/// A heurstic for text direction; returns `true` if, while enumerating characters
-/// in this string, a character in the 'R' (strong right-to-left) category is
-/// encountered before any character in the 'L' (strong left-to-right) category is.
-///
-/// See [Unicode technical report 9](https://unicode.org/reports/tr9/#Table_Bidirectional_Character_Types).
-fn first_strong_rtl(text: &str) -> bool {
-    text.chars()
-        // an upper bound on how many chars we'll check
-        .take(200)
-        .map(BidiClass::of)
-        .find(|c| c.category() == BidiClassCategory::Strong)
-        .map(|c| c.is_rtl())
-        .unwrap_or(false)
-}
-
 impl FontCollection {
     pub(crate) fn new_with_all_fonts() -> FontCollection {
         FontCollection(font_collection::create_for_all_families())

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -20,8 +20,9 @@ use winapi::um::dwrite::{
     DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE, DWRITE_FONT_STYLE_ITALIC,
     DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT, DWRITE_FONT_WEIGHT_NORMAL,
     DWRITE_HIT_TEST_METRICS, DWRITE_LINE_METRICS, DWRITE_OVERHANG_METRICS,
-    DWRITE_TEXT_ALIGNMENT_CENTER, DWRITE_TEXT_ALIGNMENT_JUSTIFIED, DWRITE_TEXT_ALIGNMENT_LEADING,
-    DWRITE_TEXT_ALIGNMENT_TRAILING, DWRITE_TEXT_METRICS, DWRITE_TEXT_RANGE,
+    DWRITE_READING_DIRECTION_RIGHT_TO_LEFT, DWRITE_TEXT_ALIGNMENT_CENTER,
+    DWRITE_TEXT_ALIGNMENT_JUSTIFIED, DWRITE_TEXT_ALIGNMENT_LEADING, DWRITE_TEXT_ALIGNMENT_TRAILING,
+    DWRITE_TEXT_METRICS, DWRITE_TEXT_RANGE,
 };
 use winapi::um::unknwnbase::IUnknown;
 use winapi::um::winnls::GetUserDefaultLocaleName;
@@ -250,6 +251,7 @@ impl TextFormat {
         factory: &DwriteFactory,
         family: impl AsRef<[u16]>,
         size: f32,
+        rtl: bool,
     ) -> Result<TextFormat, Error> {
         let family = family.as_ref();
 
@@ -268,6 +270,9 @@ impl TextFormat {
             );
 
             let r = wrap(hr, ptr, TextFormat)?;
+            if rtl {
+                r.0.SetReadingDirection(DWRITE_READING_DIRECTION_RIGHT_TO_LEFT);
+            }
             Ok(r)
         }
     }

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -110,7 +110,8 @@ impl Text for D2DText {
         let text = Rc::new(text);
         let width = f32::INFINITY;
         let wide_str = ToWide::to_wide(&text.as_str());
-        let layout = TextFormat::new(&self.dwrite, &[], util::DEFAULT_FONT_SIZE as f32)
+        let is_rtl = util::first_strong_rtl(text.as_str());
+        let layout = TextFormat::new(&self.dwrite, &[], util::DEFAULT_FONT_SIZE as f32, is_rtl)
             .and_then(|format| dwrite::TextLayout::new(&self.dwrite, format, width, &wide_str))
             .map_err(Into::into);
 

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -16,6 +16,7 @@ kurbo = "0.7.0"
 pico-args =  { version = "0.3.3", optional = true }
 png = {version = "0.16.2", optional = true }
 os_info = { version = "3.0.0", optional = true, default-features = false }
+unic-bidi = "0.9"
 
 [features]
 samples = ["pico-args", "png", "os_info"]


### PR DESCRIPTION
I had failed to notice that text alignment was not behaving as expected for RTL scripts on windows; it turns out that you *do* need to explicitly set the `DWRITE_READING_DIRECTION` in order for `DWRITE_TEXT_ALIGNMENT_LEADING` to correspond to the right edge in a RTL script.

In the examples below, the first two columns of arabic text should be aligned to the opposite edge than the corresponding columns of english text.

### Before:
![d2d-test-7](https://user-images.githubusercontent.com/3330916/98039882-69896a00-1ded-11eb-989b-94ce2b6e87b3.png)
### After:
![d2d-test-7](https://user-images.githubusercontent.com/3330916/98039868-62faf280-1ded-11eb-812a-6eced722288c.png)

