### PR TITLE
Add TextLayout::trailing_whitespace_width

### DIFF
--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -190,3 +190,17 @@ fn debug_impl_exists() {
     let layout = factory.new_text_layout(text).build().unwrap();
     let _args = format_args!("{:?} {:?} {:?}", text, layout_builder, layout);
 }
+
+#[test]
+fn trailing_whitespace_width() {
+    let mut factory = make_factory();
+    let text = "hello";
+    let text_ws = "hello     ";
+    let non_ws = factory.new_text_layout(text).build().unwrap();
+    let ws = factory.new_text_layout(text_ws).build().unwrap();
+
+    assert_close!(non_ws.size().width, ws.size().width, 0.1);
+    assert_close!(non_ws.trailing_whitespace_width(), non_ws.size().width, 0.1);
+    // the width with whitespace is ~very approximately~ twice the width without whitespace
+    assert_close!(ws.trailing_whitespace_width() / ws.size().width, 2.0, 0.5);
+}

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -243,6 +243,10 @@ impl Line {
         self.0.get_typographic_bounds()
     }
 
+    pub(crate) fn get_trailing_whitespace_width(&self) -> f64 {
+        unsafe { CTLineGetTrailingWhitespaceWidth(self.0.as_concrete_TypeRef()) }
+    }
+
     pub(crate) fn get_image_bounds(&self) -> Rect {
         unsafe {
             let r = CTLineGetImageBounds(self.0.as_concrete_TypeRef(), std::ptr::null_mut());
@@ -399,6 +403,7 @@ extern "C" {
         count: usize,
     ) -> CTParagraphStyleRef;
     fn CTLineGetImageBounds(line: CTLineRef, ctx: *mut c_void) -> CGRect;
+    fn CTLineGetTrailingWhitespaceWidth(line: CTLineRef) -> f64;
     fn CTFontCollectionCreateMatchingFontDescriptorsForFamily(
         collection: CTFontCollectionRef,
         family: CFStringRef,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -49,6 +49,7 @@ pub struct D2DTextLayout {
     // currently calculated on build
     line_metrics: Rc<[LineMetric]>,
     size: Size,
+    trailing_ws_width: f64,
     /// insets that, when applied to our layout rect, generates our inking/image rect.
     inking_insets: Insets,
     // this is in a refcell because we need to mutate it to set colors on first draw
@@ -200,6 +201,7 @@ impl TextLayoutBuilder for D2DTextLayoutBuilder {
             line_metrics: Rc::new([]),
             layout: Rc::new(RefCell::new(layout)),
             size: Size::ZERO,
+            trailing_ws_width: 0.0,
             inking_insets: Insets::ZERO,
             default_line_height,
             default_baseline,
@@ -299,6 +301,10 @@ impl fmt::Debug for D2DTextLayout {
 impl TextLayout for D2DTextLayout {
     fn size(&self) -> Size {
         self.size
+    }
+
+    fn trailing_whitespace_width(&self) -> f64 {
+        self.trailing_ws_width
     }
 
     fn image_bounds(&self) -> Rect {
@@ -406,6 +412,7 @@ impl D2DTextLayout {
         );
 
         self.size = size;
+        self.trailing_ws_width = text_metrics.widthIncludingTrailingWhitespace as f64;
         if self.text.is_empty() {
             self.size.height = self.default_line_height;
         }

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -77,6 +77,10 @@ impl piet::TextLayout for TextLayout {
         unimplemented!()
     }
 
+    fn trailing_whitespace_width(&self) -> f64 {
+        unimplemented!()
+    }
+
     fn image_bounds(&self) -> Rect {
         unimplemented!()
     }

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -193,6 +193,11 @@ impl TextLayout for WebTextLayout {
         self.size
     }
 
+    fn trailing_whitespace_width(&self) -> f64 {
+        //FIXME this should be calculated separately like in other backends
+        self.size.width
+    }
+
     fn image_bounds(&self) -> Rect {
         //FIXME: figure out actual image bounds on web?
         self.size.to_rect()

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -177,6 +177,10 @@ impl TextLayout for NullTextLayout {
         Size::ZERO
     }
 
+    fn trailing_whitespace_width(&self) -> f64 {
+        0.0
+    }
+
     fn image_bounds(&self) -> Rect {
         Rect::ZERO
     }

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -339,6 +339,16 @@ pub trait TextLayout: Clone {
     /// behaviour, but it is out of scope for the time being.
     fn size(&self) -> Size;
 
+    /// The width of this layout, including the width of any trailing whitespace.
+    ///
+    /// In many situations you do not want to include the width of trailing
+    /// whitespace when measuring width; for instance when word-wrap is enabled,
+    /// trailing whitespace is ignored. In other circumstances, however, this
+    /// width is important, such as when editing a single line of text; in these
+    /// cases you want to use this method to ensure you account for the actual
+    /// size of any trailing whitespace.
+    fn trailing_whitespace_width(&self) -> f64;
+
     /// Returns a `Rect` representing the bounding box of the glyphs in this layout,
     /// relative to the top-left of the layout object.
     ///


### PR DESCRIPTION
Another little oversight. This will probably require us to go
to 0.3.0, but that will also let us get the greyscale image stuff
landed.

closes #357

I've only tested on mac, so i'm sure this will fail somewhere in CI. Also it looks like the cairo backend *was* including ws width, maybe? We'll find out shortly... 😬 