### PR TITLE
Fix errors when drawing empty image.

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -224,8 +224,16 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
             ImageFormat::RgbaSeparate | ImageFormat::RgbaPremul => Format::ARgb32,
             _ => return Err(Error::NotSupported),
         };
-        let mut image = ImageSurface::create(cairo_fmt, width as i32, height as i32)
+        let width_int = width as i32;
+        let height_int = height as i32;
+        let mut image = ImageSurface::create(cairo_fmt, width_int, height_int)
             .map_err(|e| Error::BackendError(Box::new(e)))?;
+
+        // early-return if the image has no data in it
+        if width_int == 0 || height_int == 0 {
+            return Ok(image);
+        }
+
         // Confident no borrow errors because we just created it.
         let bytes_per_pixel = format.bytes_per_pixel();
         let bytes_per_row = width * bytes_per_pixel;

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -333,11 +333,7 @@ fn draw_image<'a>(
     };
     // Cairo returns an error if we try to paint an empty image, causing us to panic. We check if
     // either the source or destination is empty, and early-return if so.
-    if src_rect.width() == 0.
-        || src_rect.height() == 0.
-        || dst_rect.width() == 0.
-        || dst_rect.height() == 0.
-    {
+    if src_rect.is_empty() || dst_rect.is_empty() {
         return;
     }
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -319,6 +319,20 @@ fn draw_image<'a>(
     dst_rect: Rect,
     interp: InterpolationMode,
 ) {
+    let src_rect = match src_rect {
+        Some(src_rect) => src_rect,
+        None => Size::new(image.get_width() as f64, image.get_height() as f64).to_rect(),
+    };
+    // Cairo returns an error if we try to paint an empty image, causing us to panic. We check if
+    // either the source or destination is empty, and early-return if so.
+    if src_rect.width() == 0.
+        || src_rect.height() == 0.
+        || dst_rect.width() == 0.
+        || dst_rect.height() == 0.
+    {
+        return;
+    }
+
     let _ = ctx.with_save(|rc| {
         let surface_pattern = SurfacePattern::create(image);
         let filter = match interp {
@@ -326,10 +340,6 @@ fn draw_image<'a>(
             InterpolationMode::Bilinear => Filter::Bilinear,
         };
         surface_pattern.set_filter(filter);
-        let src_rect = match src_rect {
-            Some(src_rect) => src_rect,
-            None => Size::new(image.get_width() as f64, image.get_height() as f64).to_rect(),
-        };
         let scale_x = dst_rect.width() / src_rect.width();
         let scale_y = dst_rect.height() / src_rect.height();
         rc.clip(dst_rect);

--- a/piet-common/tests/image.rs
+++ b/piet-common/tests/image.rs
@@ -1,0 +1,49 @@
+use kurbo::Rect;
+use piet_common::*;
+
+fn with_context(cb: impl FnOnce(&mut Piet)) {
+    let mut device = Device::new().unwrap();
+    let mut target = device.bitmap_target(400, 400, 2.0).unwrap();
+    let mut ctx = target.render_context();
+    cb(&mut ctx);
+}
+
+#[test]
+fn empty_image_should_not_panic() {
+    let image = ImageBuf::empty();
+    with_context(|ctx| {
+        let image = image.to_image(ctx);
+        ctx.draw_image(
+            &image,
+            Rect::new(0., 0., 400., 400.),
+            InterpolationMode::Bilinear,
+        );
+    })
+}
+
+#[test]
+fn empty_image_dest_should_not_panic() {
+    let image = ImageBuf::from_raw(&[0, 0, 0, 0][..], ImageFormat::RgbaSeparate, 1, 1);
+    with_context(|ctx| {
+        let image = image.to_image(ctx);
+        ctx.draw_image(
+            &image,
+            Rect::new(0., 0., 0., 0.),
+            InterpolationMode::Bilinear,
+        );
+    })
+}
+
+#[test]
+fn empty_image_area_should_not_panic() {
+    let image = ImageBuf::from_raw(&[0, 0, 0, 0][..], ImageFormat::RgbaSeparate, 1, 1);
+    with_context(|ctx| {
+        let image = image.to_image(ctx);
+        ctx.draw_image_area(
+            &image,
+            Rect::new(0., 0., 0., 0.),
+            Rect::new(0., 0., 1., 1.),
+            InterpolationMode::Bilinear,
+        );
+    })
+}

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -271,7 +271,11 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
-        let data = Arc::new(buf.to_owned());
+        let data: Arc<[u8]> = if buf.is_empty() {
+            Arc::new([0])
+        } else {
+            Arc::new(buf.to_owned())
+        };
         let data_provider = CGDataProvider::from_buffer(data);
         let (colorspace, bitmap_info, bytes) = match format {
             ImageFormat::Rgb => (CGColorSpace::create_device_rgb(), 0, 3),

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -271,8 +271,9 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
-        let data: Arc<[u8]> = if buf.is_empty() {
-            Arc::new([0])
+        // todo use Arc<[u8]> when core-foundation-rs suports it
+        let data: Arc<Vec<u8>> = if buf.is_empty() {
+            Arc::new(vec![0])
         } else {
             Arc::new(buf.to_owned())
         };

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -330,6 +330,18 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
+        // CreateBitmap will fail if we try to make an empty image. To solve this, we change an
+        // empty image into 1x1 transparent image. Not ideal, but prevents a crash. TODO find a
+        // better solution.
+        if width == 0 || height == 0 {
+            return Ok(self.rt.create_bitmap(
+                1,
+                1,
+                &[0, 0, 0, 0][..],
+                D2D1_ALPHA_MODE_PREMULTIPLIED,
+            )?);
+        }
+
         // TODO: this method _really_ needs error checking, so much can go wrong...
         let alpha_mode = match format {
             ImageFormat::Rgb | ImageFormat::Grayscale => D2D1_ALPHA_MODE_IGNORE,
@@ -532,6 +544,15 @@ fn draw_image<'a>(
     dst_rect: Rect,
     interp: InterpolationMode,
 ) {
+    let src_size = image.get_size();
+    if dst_rect.width() == 0.
+        || dst_rect.height() == 0.
+        || src_size.width == 0.
+        || src_size.height == 0.
+    {
+        // source or destination are empty
+        return;
+    }
     let interp = match interp {
         InterpolationMode::NearestNeighbor => D2D1_BITMAP_INTERPOLATION_MODE_NEAREST_NEIGHBOR,
         InterpolationMode::Bilinear => D2D1_BITMAP_INTERPOLATION_MODE_LINEAR,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -545,11 +545,7 @@ fn draw_image<'a>(
     interp: InterpolationMode,
 ) {
     let src_size = image.get_size();
-    if dst_rect.width() == 0.
-        || dst_rect.height() == 0.
-        || src_size.width == 0.
-        || src_size.height == 0.
-    {
+    if dst_rect.is_empty() || src_size.width == 0. || src_size.height == 0. {
         // source or destination are empty
         return;
     }


### PR DESCRIPTION
# Implement empty images

Whilst making an image viewer, I wanted a default value for the image to display. What I found is that if I used the default constructor `ImageBuf::empty` I was hitting a panic.

Even worse than this, when I then made tests for empty images and tried out the CI, I found that on macos it led to a segmentation fault. This would always be caught, since I think that pointers that don't point anywhere (to zero-sized types) are set to point so some rediculous memory address that tells the operating system/processor to issue a memory page fault, but still it's UB which in the Rust world is *bad*. I raised an [issue with core-foundations-rs](https://github.com/servo/core-foundation-rs/issues/431) where they said the would do an `assert` to check for empty `[u8]`s, but still that would be a panic in our code, like Windows and Cairo.

This patch adds code to handle the case where an empty image is both created and drawn, and essentially does nothing in both cases. I argue that this is expected behaviour, and that the empty image is a useful placeholder where you have an image that is optionally present (you avoid needing to use things like the `Either` widget). An alternative would be to check the image dimensions and panic when they are incorrect, but I think this is a less pleasant user experience. (If you disagree please say so on the comments below)