### PR TITLE
Always include LineMetric for line 0

### DIFF
--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -314,8 +314,15 @@ impl WebTextLayout {
         self.ctx.set_font(&self.font.get_font_string());
         let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
 
-        let line_metrics =
-            lines::calculate_line_metrics(&self.text, &self.ctx, new_width, self.font.size);
+        let line_metrics = if self.text.is_empty() {
+            vec![LineMetric {
+                baseline: self.font.size * 0.2,
+                height: self.font.size * 1.2,
+                ..Default::default()
+            }]
+        } else {
+            lines::calculate_line_metrics(&self.text, &self.ctx, new_width, self.font.size)
+        };
 
         let max_width = line_metrics
             .iter()


### PR DESCRIPTION
This matches the behaviour of other backends and fixes a bunch
of broken druid examples.

- closes #366