### PR TITLE
Add `Image` trait.

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -10,8 +10,8 @@ use cairo::{Context, Filter, Format, ImageSurface, Matrix, SurfacePattern};
 
 use piet::kurbo::{Affine, PathEl, Point, QuadBez, Rect, Shape, Size};
 use piet::{
-    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, LineCap, LineJoin,
-    RenderContext, StrokeStyle, TextLayout,
+    Color, Error, FixedGradient, Image, ImageFormat, InterpolationMode, IntoBrush, LineCap,
+    LineJoin, RenderContext, StrokeStyle, TextLayout,
 };
 
 pub use crate::text::{CairoText, CairoTextLayout, CairoTextLayoutBuilder};
@@ -28,20 +28,7 @@ pub struct CairoRenderContext<'a> {
     transform_stack: Vec<Affine>,
 }
 
-impl<'a> CairoRenderContext<'a> {
-    /// Create a new Cairo back-end.
-    ///
-    /// At the moment, it uses the "toy text API" for text layout, but when
-    /// we change to a more sophisticated text layout approach, we'll probably
-    /// need a factory for that as an additional argument.
-    pub fn new(ctx: &Context) -> CairoRenderContext {
-        CairoRenderContext {
-            ctx,
-            text: CairoText::new(),
-            transform_stack: Vec::new(),
-        }
-    }
-}
+impl<'a> CairoRenderContext<'a> {}
 
 #[derive(Clone)]
 pub enum Brush {
@@ -49,6 +36,8 @@ pub enum Brush {
     Linear(cairo::LinearGradient),
     Radial(cairo::RadialGradient),
 }
+
+pub struct CairoImage(ImageSurface);
 
 // we call this with different types of gradient that have `add_color_stop_rgba` fns,
 // and there's no trait for this behaviour so we use a macro. ¯\_(ツ)_/¯
@@ -73,7 +62,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     type Text = CairoText;
     type TextLayout = CairoTextLayout;
 
-    type Image = ImageSurface;
+    type Image = CairoImage;
 
     fn status(&mut self) -> Result<(), Error> {
         Ok(())
@@ -231,7 +220,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
 
         // early-return if the image has no data in it
         if width_int == 0 || height_int == 0 {
-            return Ok(image);
+            return Ok(CairoImage(image));
         }
 
         // Confident no borrow errors because we just created it.
@@ -288,7 +277,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                 }
             }
         }
-        Ok(image)
+        Ok(CairoImage(image))
     }
 
     #[inline]
@@ -298,7 +287,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         dst_rect: impl Into<Rect>,
         interp: InterpolationMode,
     ) {
-        draw_image(self, image, None, dst_rect.into(), interp);
+        draw_image(self, &image.0, None, dst_rect.into(), interp);
     }
 
     #[inline]
@@ -309,7 +298,13 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         dst_rect: impl Into<Rect>,
         interp: InterpolationMode,
     ) {
-        draw_image(self, image, Some(src_rect.into()), dst_rect.into(), interp);
+        draw_image(
+            self,
+            &image.0,
+            Some(src_rect.into()),
+            dst_rect.into(),
+            interp,
+        );
     }
 
     fn blurred_rect(&mut self, rect: Rect, blur_radius: f64, brush: &impl IntoBrush<Self>) {
@@ -318,44 +313,6 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         self.set_brush(&*brush);
         self.ctx.mask_surface(&image, origin.x, origin.y);
     }
-}
-
-fn draw_image<'a>(
-    ctx: &mut CairoRenderContext<'a>,
-    image: &<CairoRenderContext<'a> as RenderContext>::Image,
-    src_rect: Option<Rect>,
-    dst_rect: Rect,
-    interp: InterpolationMode,
-) {
-    let src_rect = match src_rect {
-        Some(src_rect) => src_rect,
-        None => Size::new(image.get_width() as f64, image.get_height() as f64).to_rect(),
-    };
-    // Cairo returns an error if we try to paint an empty image, causing us to panic. We check if
-    // either the source or destination is empty, and early-return if so.
-    if src_rect.is_empty() || dst_rect.is_empty() {
-        return;
-    }
-
-    let _ = ctx.with_save(|rc| {
-        let surface_pattern = SurfacePattern::create(image);
-        let filter = match interp {
-            InterpolationMode::NearestNeighbor => Filter::Nearest,
-            InterpolationMode::Bilinear => Filter::Bilinear,
-        };
-        surface_pattern.set_filter(filter);
-        let scale_x = dst_rect.width() / src_rect.width();
-        let scale_y = dst_rect.height() / src_rect.height();
-        rc.clip(dst_rect);
-        rc.ctx.translate(
-            dst_rect.x0 - scale_x * src_rect.x0,
-            dst_rect.y0 - scale_y * src_rect.y0,
-        );
-        rc.ctx.scale(scale_x, scale_y);
-        rc.ctx.set_source(&surface_pattern);
-        rc.ctx.paint();
-        Ok(())
-    });
 }
 
 impl<'a> IntoBrush<CairoRenderContext<'a>> for Brush {
@@ -368,23 +325,26 @@ impl<'a> IntoBrush<CairoRenderContext<'a>> for Brush {
     }
 }
 
-fn convert_line_cap(line_cap: LineCap) -> cairo::LineCap {
-    match line_cap {
-        LineCap::Butt => cairo::LineCap::Butt,
-        LineCap::Round => cairo::LineCap::Round,
-        LineCap::Square => cairo::LineCap::Square,
-    }
-}
-
-fn convert_line_join(line_join: LineJoin) -> cairo::LineJoin {
-    match line_join {
-        LineJoin::Miter => cairo::LineJoin::Miter,
-        LineJoin::Round => cairo::LineJoin::Round,
-        LineJoin::Bevel => cairo::LineJoin::Bevel,
+impl Image for CairoImage {
+    fn size(&self) -> Size {
+        Size::new(self.0.get_width().into(), self.0.get_height().into())
     }
 }
 
 impl<'a> CairoRenderContext<'a> {
+    /// Create a new Cairo back-end.
+    ///
+    /// At the moment, it uses the "toy text API" for text layout, but when
+    /// we change to a more sophisticated text layout approach, we'll probably
+    /// need a factory for that as an additional argument.
+    pub fn new(ctx: &Context) -> CairoRenderContext {
+        CairoRenderContext {
+            ctx,
+            text: CairoText::new(),
+            transform_stack: Vec::new(),
+        }
+    }
+
     /// Set the source pattern to the brush.
     ///
     /// Cairo is super stateful, and we're trying to have more retained stuff.
@@ -454,6 +414,60 @@ impl<'a> CairoRenderContext<'a> {
                 PathEl::ClosePath => self.ctx.close_path(),
             }
         }
+    }
+}
+
+fn draw_image<'a>(
+    ctx: &mut CairoRenderContext<'a>,
+    image: &ImageSurface,
+    src_rect: Option<Rect>,
+    dst_rect: Rect,
+    interp: InterpolationMode,
+) {
+    let src_rect = match src_rect {
+        Some(src_rect) => src_rect,
+        None => Size::new(image.get_width() as f64, image.get_height() as f64).to_rect(),
+    };
+    // Cairo returns an error if we try to paint an empty image, causing us to panic. We check if
+    // either the source or destination is empty, and early-return if so.
+    if src_rect.is_empty() || dst_rect.is_empty() {
+        return;
+    }
+
+    let _ = ctx.with_save(|rc| {
+        let surface_pattern = SurfacePattern::create(image);
+        let filter = match interp {
+            InterpolationMode::NearestNeighbor => Filter::Nearest,
+            InterpolationMode::Bilinear => Filter::Bilinear,
+        };
+        surface_pattern.set_filter(filter);
+        let scale_x = dst_rect.width() / src_rect.width();
+        let scale_y = dst_rect.height() / src_rect.height();
+        rc.clip(dst_rect);
+        rc.ctx.translate(
+            dst_rect.x0 - scale_x * src_rect.x0,
+            dst_rect.y0 - scale_y * src_rect.y0,
+        );
+        rc.ctx.scale(scale_x, scale_y);
+        rc.ctx.set_source(&surface_pattern);
+        rc.ctx.paint();
+        Ok(())
+    });
+}
+
+fn convert_line_cap(line_cap: LineCap) -> cairo::LineCap {
+    match line_cap {
+        LineCap::Butt => cairo::LineCap::Butt,
+        LineCap::Round => cairo::LineCap::Round,
+        LineCap::Square => cairo::LineCap::Square,
+    }
+}
+
+fn convert_line_join(line_join: LineJoin) -> cairo::LineJoin {
+    match line_join {
+        LineJoin::Miter => cairo::LineJoin::Miter,
+        LineJoin::Round => cairo::LineJoin::Round,
+        LineJoin::Bevel => cairo::LineJoin::Bevel,
     }
 }
 

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -43,7 +43,7 @@ pub type PietTextLayoutBuilder = CairoTextLayoutBuilder;
 /// The associated image type for this backend.
 ///
 /// This type matches `RenderContext::Image`
-pub type Image = ImageSurface;
+pub type PietImage = CairoImage;
 
 /// A struct that can be used to create bitmap render contexts.
 ///

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 #[cfg(feature = "png")]
 use std::{fs::File, io::BufWriter};
 
-use core_graphics::{color_space::CGColorSpace, context::CGContext, image::CGImage};
+use core_graphics::{color_space::CGColorSpace, context::CGContext};
 #[cfg(feature = "png")]
 use png::{ColorType, Encoder};
 
@@ -42,7 +42,7 @@ pub type PietTextLayoutBuilder = CoreGraphicsTextLayoutBuilder;
 /// The associated image type for this backend.
 ///
 /// This type matches `RenderContext::Image`
-pub type Image = CGImage;
+pub type PietImage = CoreGraphicsImage;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -44,7 +44,7 @@ pub type PietTextLayoutBuilder = D2DTextLayoutBuilder;
 /// The associated image type for this backend.
 ///
 /// This type matches `RenderContext::Image`
-pub type Image = Bitmap;
+pub type PietImage = Bitmap;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -65,7 +65,7 @@ mod test {
         piet_text: PietText,
         piet_text_layout: PietTextLayout,
         piet_text_layout_builder: PietTextLayoutBuilder,
-        image: Image,
+        image: PietImage,
     }
 
     sa::assert_impl_all!(Device: Send);

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -42,7 +42,7 @@ pub type PietTextLayoutBuilder = WebTextLayoutBuilder;
 /// The associated image type for this backend.
 ///
 /// This type matches `RenderContext::Image`
-pub type Image = WebImage;
+pub type PietImage = WebImage;
 
 /// A struct that can be used to create bitmap render contexts.
 pub struct Device {

--- a/piet-common/tests/image.rs
+++ b/piet-common/tests/image.rs
@@ -1,4 +1,4 @@
-use kurbo::Rect;
+use kurbo::{Rect, Size};
 use piet_common::*;
 
 fn with_context(cb: impl FnOnce(&mut Piet) -> Result<(), String>) {
@@ -63,6 +63,22 @@ fn empty_image_area_should_not_panic() {
             Rect::new(0., 0., 1., 1.),
             InterpolationMode::Bilinear,
         );
+        Ok(())
+    })
+}
+
+#[test]
+fn image_size() {
+    let image = ImageBuf::from_raw(&[0, 0, 0, 0][..], ImageFormat::RgbaSeparate, 1, 1);
+    with_context(|ctx| {
+        let image = image.to_image(ctx);
+        if image.size() != Size::new(1., 1.) {
+            return Err(format!(
+                "expected {:?}, found {:?}",
+                Size::new(1., 1.),
+                image.size()
+            ));
+        }
         Ok(())
     })
 }

--- a/piet-common/tests/image.rs
+++ b/piet-common/tests/image.rs
@@ -80,5 +80,19 @@ fn image_size() {
             ));
         }
         Ok(())
-    })
+    });
+
+    // try an empty image
+    let image = ImageBuf::empty();
+    with_context(|ctx| {
+        let image = image.to_image(ctx);
+        if image.size() != Size::new(0., 0.) {
+            return Err(format!(
+                "expected {:?}, found {:?}",
+                Size::new(0., 0.),
+                image.size()
+            ));
+        }
+        Ok(())
+    });
 }

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -350,7 +350,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.ctx.translate(rect.min_x(), rect.max_y());
         self.ctx.scale(1.0, -1.0);
         self.ctx
-            .draw_image(to_cgrect(rect.with_origin(Point::ZERO)), &image.0);
+            .draw_image(to_cgrect(rect.with_origin(Point::ZERO)), image);
         self.ctx.restore();
     }
 
@@ -402,7 +402,12 @@ impl Image for CoreGraphicsImage {
         // `size_t` (which could be 64 bits wide) does not losslessly convert to `f64`. In
         // reality, the image you're working with would have to be pretty big to be an issue, and
         // the issue would only be accuracy of the size.
-        Size::new(self.0.width() as f64, self.0.height() as f64)
+        match self {
+            CoreGraphicsImage::Empty => Size::new(0., 0.),
+            CoreGraphicsImage::NonEmpty(image) => {
+                Size::new(image.width() as f64, image.height() as f64)
+            }
+        }
     }
 }
 

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -23,8 +23,8 @@ use piet::kurbo::{Affine, PathEl, Point, QuadBez, Rect, Shape, Size};
 
 use piet::util::unpremul;
 use piet::{
-    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, LineCap, LineJoin,
-    RenderContext, RoundInto, StrokeStyle,
+    Color, Error, FixedGradient, Image, ImageFormat, InterpolationMode, IntoBrush, LineCap,
+    LineJoin, RenderContext, RoundInto, StrokeStyle,
 };
 
 pub use crate::text::{CoreGraphicsText, CoreGraphicsTextLayout, CoreGraphicsTextLayoutBuilder};
@@ -350,7 +350,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.ctx.translate(rect.min_x(), rect.max_y());
         self.ctx.scale(1.0, -1.0);
         self.ctx
-            .draw_image(to_cgrect(rect.with_origin(Point::ZERO)), image);
+            .draw_image(to_cgrect(rect.with_origin(Point::ZERO)), &image.0);
         self.ctx.restore();
     }
 
@@ -394,6 +394,15 @@ impl<'a> IntoBrush<CoreGraphicsContext<'a>> for Brush {
         _bbox: impl FnOnce() -> Rect,
     ) -> std::borrow::Cow<'b, Brush> {
         Cow::Borrowed(self)
+    }
+}
+
+impl Image for CoreGraphicsImage {
+    fn size(&self) -> Size {
+        // `size_t` (which could be 64 bits wide) does not losslessly convert to `f64`. In
+        // reality, the image you're working with would have to be pretty big to be an issue, and
+        // the issue would only be accuracy of the size.
+        Size::new(self.0.width() as f64, self.0.height() as f64)
     }
 }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -23,10 +23,10 @@ use winapi::um::d2d1::{
 use winapi::um::d2d1_1::{D2D1_COMPOSITE_MODE_SOURCE_OVER, D2D1_INTERPOLATION_MODE_LINEAR};
 use winapi::um::dcommon::{D2D1_ALPHA_MODE_IGNORE, D2D1_ALPHA_MODE_PREMULTIPLIED};
 
-use piet::kurbo::{Affine, PathEl, Point, Rect, Shape};
+use piet::kurbo::{Affine, PathEl, Point, Rect, Shape, Size};
 
 use piet::{
-    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, RenderContext,
+    Color, Error, FixedGradient, Image, ImageFormat, InterpolationMode, IntoBrush, RenderContext,
     StrokeStyle,
 };
 
@@ -573,5 +573,12 @@ impl<'a> IntoBrush<D2DRenderContext<'a>> for Brush {
         _bbox: impl FnOnce() -> Rect,
     ) -> std::borrow::Cow<'b, Brush> {
         Cow::Borrowed(self)
+    }
+}
+
+impl Image for Bitmap {
+    fn size(&self) -> Size {
+        let inner = self.get_size();
+        Size::new(inner.width.into(), inner.height.into())
     }
 }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -334,12 +334,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         // empty image into 1x1 transparent image. Not ideal, but prevents a crash. TODO find a
         // better solution.
         if width == 0 || height == 0 {
-            return Ok(self.rt.create_bitmap(
-                1,
-                1,
-                &[0, 0, 0, 0][..],
-                D2D1_ALPHA_MODE_PREMULTIPLIED,
-            )?);
+            return Ok(self.rt.create_empty_bitmap()?);
         }
 
         // TODO: this method _really_ needs error checking, so much can go wrong...
@@ -544,8 +539,7 @@ fn draw_image<'a>(
     dst_rect: Rect,
     interp: InterpolationMode,
 ) {
-    let src_size = image.get_size();
-    if dst_rect.is_empty() || src_size.width == 0. || src_size.height == 0. {
+    if dst_rect.is_empty() || image.empty_image {
         // source or destination are empty
         return;
     }
@@ -578,7 +572,11 @@ impl<'a> IntoBrush<D2DRenderContext<'a>> for Brush {
 
 impl Image for Bitmap {
     fn size(&self) -> Size {
-        let inner = self.get_size();
-        Size::new(inner.width.into(), inner.height.into())
+        if self.empty_image {
+            Size::ZERO
+        } else {
+            let inner = self.get_size();
+            Size::new(inner.width.into(), inner.height.into())
+        }
     }
 }

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -9,10 +9,10 @@ mod text;
 use std::borrow::Cow;
 use std::{io, mem};
 
-use piet::kurbo::{Affine, Point, Rect, Shape};
+use piet::kurbo::{Affine, Point, Rect, Shape, Size};
 use piet::{
-    Color, Error, FixedGradient, ImageFormat, InterpolationMode, IntoBrush, LineCap, LineJoin,
-    StrokeStyle,
+    Color, Error, FixedGradient, Image, ImageFormat, InterpolationMode, IntoBrush, LineCap,
+    LineJoin, StrokeStyle,
 };
 use svg::node::Node;
 
@@ -62,7 +62,7 @@ impl piet::RenderContext for RenderContext {
     type Text = Text;
     type TextLayout = TextLayout;
 
-    type Image = Image;
+    type Image = SvgImage;
 
     fn status(&mut self) -> Result<()> {
         Ok(())
@@ -454,7 +454,13 @@ fn fmt_opacity(color: &Color) -> String {
 }
 
 /// SVG image (unimplemented)
-pub struct Image(());
+pub struct SvgImage(());
+
+impl Image for SvgImage {
+    fn size(&self) -> Size {
+        todo!()
+    }
+}
 
 #[derive(Debug, Copy, Clone)]
 struct Id(u64);

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -18,12 +18,12 @@ use web_sys::{
     ImageData, Window,
 };
 
-use piet::kurbo::{Affine, PathEl, Point, Rect, Shape};
+use piet::kurbo::{Affine, PathEl, Point, Rect, Shape, Size};
 
 use piet::util::unpremul;
 use piet::{
-    Color, Error, FixedGradient, GradientStop, ImageFormat, InterpolationMode, IntoBrush, LineCap,
-    LineJoin, RenderContext, StrokeStyle,
+    Color, Error, FixedGradient, GradientStop, Image, ImageFormat, InterpolationMode, IntoBrush,
+    LineCap, LineJoin, RenderContext, StrokeStyle,
 };
 
 pub use text::{WebFont, WebTextLayout, WebTextLayoutBuilder};
@@ -399,6 +399,12 @@ impl IntoBrush<WebRenderContext<'_>> for Brush {
         _bbox: impl FnOnce() -> Rect,
     ) -> std::borrow::Cow<'b, Brush> {
         Cow::Borrowed(self)
+    }
+}
+
+impl Image for WebImage {
+    fn size(&self) -> Size {
+        Size::new(self.width.into(), self.height.into())
     }
 }
 

--- a/piet/src/image.rs
+++ b/piet/src/image.rs
@@ -22,6 +22,12 @@ use crate::kurbo::Size;
 use crate::util::unpremul;
 use crate::{Color, ImageFormat, RenderContext};
 
+/// Represents an image type that knows its size.
+pub trait Image {
+    /// The size of the image
+    fn size(&self) -> Size;
+}
+
 /// An in-memory pixel buffer.
 ///
 /// Contains raw bytes, dimensions, and image format ([`piet::ImageFormat`]).

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -6,7 +6,7 @@ use std::ops::RangeBounds;
 use kurbo::{Affine, Point, Rect, Shape, Size};
 
 use crate::{
-    Color, Error, FixedGradient, FontFamily, HitTestPoint, HitTestPosition, ImageFormat,
+    Color, Error, FixedGradient, FontFamily, HitTestPoint, HitTestPosition, Image, ImageFormat,
     InterpolationMode, IntoBrush, LineMetric, RenderContext, StrokeStyle, Text, TextAttribute,
     TextLayout, TextLayoutBuilder, TextStorage,
 };
@@ -217,5 +217,11 @@ impl IntoBrush<NullRenderContext> for NullBrush {
         _bbox: impl FnOnce() -> Rect,
     ) -> std::borrow::Cow<'b, NullBrush> {
         Cow::Borrowed(self)
+    }
+}
+
+impl Image for NullImage {
+    fn size(&self) -> Size {
+        Size::ZERO
     }
 }

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use kurbo::{Affine, Point, Rect, Shape};
 
 use crate::{
-    Color, Error, FixedGradient, FixedLinearGradient, FixedRadialGradient, LinearGradient,
+    Color, Error, FixedGradient, FixedLinearGradient, FixedRadialGradient, Image, LinearGradient,
     RadialGradient, StrokeStyle, Text, TextLayout,
 };
 
@@ -67,7 +67,7 @@ where
     type TextLayout: TextLayout;
 
     /// The associated type of an image.
-    type Image;
+    type Image: Image;
 
     /// Report an internal error.
     ///


### PR DESCRIPTION
Closes #367.

The trait allows you to get an image's size in a cross-platform way.

Also renames `piet_common::Image` to `PietImage` to avoid clash. This is a breaking change, but if we want to add the `Image` trait and make the cross-platform type alias names more consistent, better to do it now than later.