### PR TITLE
Add Color::from_hex_str for parsing CSS-style colors

### DIFF
--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -12,10 +12,14 @@ pub enum Color {
     Rgba32(u32),
 }
 
-impl Debug for Color {
-    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "#{:08x}", self.as_rgba_u32())
-    }
+/// Errors that can occur when parsing a hex color.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ColorParseError {
+    /// The input string has an incorrect length
+    WrongSize(usize),
+    /// A byte in the input string is not in one of the ranges `0..=9`,
+    /// `a..=f`, or `A..=F`.
+    NotHex { idx: usize, byte: u8 },
 }
 
 impl Color {
@@ -34,6 +38,25 @@ impl Color {
     /// Create a color from a 32-bit rgba value (alpha as least significant byte).
     pub const fn from_rgba32_u32(rgba: u32) -> Color {
         Color::Rgba32(rgba)
+    }
+
+    /// Attempt to create a color from a CSS-style hex string.
+    ///
+    /// This will accept strings in the following formats, *with or without*
+    /// the leading `#`:
+    ///
+    /// - `rrggbb`
+    /// - `rrggbbaa`
+    /// - `rbg`
+    /// - `rbga`
+    ///
+    /// This method returns a [`ColorParseError`] if the color cannot be parsed.
+    pub const fn from_hex_str(hex: &str) -> Result<Color, ColorParseError> {
+        // can't use `map()` in a const function
+        match get_4bit_hex_channels(hex) {
+            Ok(channels) => Ok(color_from_4bit_hex(channels)),
+            Err(e) => Err(e),
+        }
     }
 
     /// Create a color from a grey value.
@@ -242,4 +265,91 @@ impl Color {
 
     /// Opaque yellow.
     pub const YELLOW: Color = Color::rgb8(255, 255, 0);
+}
+
+const fn get_4bit_hex_channels(hex_str: &str) -> Result<[u8; 8], ColorParseError> {
+    let mut four_bit_channels = match hex_str.as_bytes() {
+        &[b'#', r, g, b] | &[r, g, b] => [r, r, g, g, b, b, b'f', b'f'],
+        &[b'#', r, g, b, a] | &[r, g, b, a] => [r, r, g, g, b, b, a, a],
+        &[b'#', r0, r1, g0, g1, b0, b1] | &[r0, r1, g0, g1, b0, b1] => {
+            [r0, r1, g0, g1, b0, b1, b'f', b'f']
+        }
+        &[b'#', r0, r1, g0, g1, b0, b1, a0, a1] | &[r0, r1, g0, g1, b0, b1, a0, a1] => {
+            [r0, r1, g0, g1, b0, b1, a0, a1]
+        }
+        other => return Err(ColorParseError::WrongSize(other.len())),
+    };
+
+    // convert to hex in-place
+    // this is written without a for loop to satisfy `const`
+    let mut i = 0;
+    while i < four_bit_channels.len() {
+        let ascii = four_bit_channels[i];
+        let as_hex = match hex_from_ascii_byte(ascii) {
+            Ok(hex) => hex,
+            Err(byte) => return Err(ColorParseError::NotHex { idx: i, byte }),
+        };
+        four_bit_channels[i] = as_hex;
+        i += 1;
+    }
+    Ok(four_bit_channels)
+}
+
+const fn color_from_4bit_hex(components: [u8; 8]) -> Color {
+    let [r0, r1, g0, g1, b0, b1, a0, a1] = components;
+    Color::rgba8(r0 << 4 | r1, g0 << 4 | g1, b0 << 4 | b1, a0 << 4 | a1)
+}
+
+const fn hex_from_ascii_byte(b: u8) -> Result<u8, u8> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        _ => Err(b),
+    }
+}
+
+impl Debug for Color {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "#{:08x}", self.as_rgba_u32())
+    }
+}
+
+impl std::fmt::Display for ColorParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ColorParseError::WrongSize(n) => write!(f, "Input string has invalid length {}", n),
+            ColorParseError::NotHex { idx, byte } => {
+                write!(f, "byte {:X} at index {} is not valid hex digit", byte, idx)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ColorParseError {}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn color_from_hex() {
+        assert_eq!(Color::from_hex_str("#BAD"), Color::from_hex_str("BBAADD"));
+        assert_eq!(
+            Color::from_hex_str("#BAD"),
+            Ok(Color::from_rgba32_u32(0xBBAADDFF))
+        );
+        assert_eq!(Color::from_hex_str("BAD"), Color::from_hex_str("BBAADD"));
+        assert_eq!(Color::from_hex_str("#BADF"), Color::from_hex_str("BAD"));
+        assert_eq!(Color::from_hex_str("#BBAADDFF"), Color::from_hex_str("BAD"));
+        assert_eq!(Color::from_hex_str("BBAADDFF"), Color::from_hex_str("BAD"));
+        assert_eq!(Color::from_hex_str("bBAadDfF"), Color::from_hex_str("BAD"));
+        assert_eq!(Color::from_hex_str("#0f6"), Ok(Color::rgb8(0, 0xff, 0x66)));
+        assert_eq!(
+            Color::from_hex_str("#0f6a"),
+            Ok(Color::rgba8(0, 0xff, 0x66, 0xaa))
+        );
+        assert!(Color::from_hex_str("#0f6aa").is_err());
+        assert!(Color::from_hex_str("#0f").is_err());
+        assert!(Color::from_hex_str("x0f").is_err());
+        assert!(Color::from_hex_str("#0afa1").is_err());
+    }
 }


### PR DESCRIPTION
This code is a bit idiosyncratic because I wanted it to
work in const contexts.

Question: should we have a `FromStr` impl? This might make sense,
but it's not 100% clear since there are any number of ways to
parse a string into a color. Would this cause problems in practice?

- closes #348

reference: https://github.com/linebender/druid/issues/1471