### PR TITLE
Move snapshots into piet directory

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path=piet-cairo/Cargo.toml --example=test-picture -- --all --out=cairo_samples --compare=./snapshots/cairo
+          args: --manifest-path=piet-cairo/Cargo.toml --example=test-picture -- --all --out=cairo_samples --compare=./piet/snapshots/cairo
         if: contains(matrix.os, 'ubuntu')
 
       - name: upload failures (ubuntu+cairo)
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path=piet-coregraphics/Cargo.toml --example=test-picture -- --all --out=coregraphics_samples --compare=./snapshots/coregraphics
+          args: --manifest-path=piet-coregraphics/Cargo.toml --example=test-picture -- --all --out=coregraphics_samples --compare=./piet/snapshots/coregraphics
         if: contains(matrix.os, 'macOS')
 
       - name: upload failures (macOS)
@@ -59,7 +59,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path=piet-direct2d/Cargo.toml --example=test-picture -- --all --out=d2d_samples --compare=./snapshots/d2d
+          args: --manifest-path=piet-direct2d/Cargo.toml --example=test-picture -- --all --out=d2d_samples --compare=./piet/snapshots/d2d
         if: contains(matrix.os, 'windows')
 
       - name: upload failures (d2d)

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "snapshots"]
-	path = snapshots
+	path = piet/snapshots
 	url = https://github.com/linebender/piet-snapshots.git

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -9,6 +9,7 @@ readme = "../README.md"
 edition = "2018"
 keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
+include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
 image = { version = "0.23.10", optional = true, default-features = false }

--- a/piet/src/samples/picture_13.rs
+++ b/piet/src/samples/picture_13.rs
@@ -14,12 +14,10 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(Color::WHITE);
     let text = rc.text();
     let _ = text.load_font(include_bytes!(
-        "../../../snapshots/resources/Anaheim-Regular.ttf"
+        "../../snapshots/resources/Anaheim-Regular.ttf"
     ));
     let font = text
-        .load_font(include_bytes!(
-            "../../../snapshots/resources/Anaheim-Bold.ttf"
-        ))
+        .load_font(include_bytes!("../../snapshots/resources/Anaheim-Bold.ttf"))
         .unwrap_or(FontFamily::SYSTEM_UI);
 
     let layout = text

--- a/piet/src/samples/picture_14.rs
+++ b/piet/src/samples/picture_14.rs
@@ -15,7 +15,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let text = rc.text();
     let font = text
         .load_font(include_bytes!(
-            "../../../snapshots/resources/Inconsolata-variable.ttf"
+            "../../snapshots/resources/Inconsolata-variable.ttf"
         ))
         .unwrap_or(FontFamily::SYSTEM_UI);
 


### PR DESCRIPTION
This lets us include the fonts in the snapshots in our package,
which fixes problems when packaging crates that depend on piet.
We can work around that but it feels best to just include these
files.


This is a bit of bookkeeping I've wanted to get done for a while, and is worth doing before a release.