### PR TITLE
Update cairo/web to xi-unicode 0.3

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -15,7 +15,7 @@ piet = { version = "0.3.0", path = "../piet" }
 
 cairo-rs = { version = "0.9.1", default-features = false } # We don't need glib
 unicode-segmentation = "1.3.0"
-xi-unicode = "0.2.0"
+xi-unicode = "0.3.0"
 
 [dev-dependencies]
 piet = { version = "0.3.0", path = "../piet", features = ["samples"] }

--- a/piet-cairo/src/text/lines.rs
+++ b/piet-cairo/src/text/lines.rs
@@ -146,6 +146,19 @@ pub(crate) fn calculate_line_metrics(text: &str, font: &ScaledFont, width: f64) 
         }
     }
 
+    // the trailing line, if there is no explicit newline.
+    if line_start != text.len() {
+        add_line_metric(
+            text,
+            line_start,
+            text.len(),
+            baseline,
+            height,
+            &mut y_offset,
+            &mut line_metrics,
+        );
+    }
+
     line_metrics
 }
 

--- a/piet-web/src/text/lines.rs
+++ b/piet-web/src/text/lines.rs
@@ -161,6 +161,19 @@ pub(crate) fn calculate_line_metrics(
         }
     }
 
+    // the trailing line, if there is no explicit newline.
+    if line_start != text.len() {
+        add_line_metric(
+            text,
+            line_start,
+            text.len(),
+            baseline,
+            height,
+            &mut y_offset,
+            &mut line_metrics,
+        );
+    }
+
     line_metrics
 }
 


### PR DESCRIPTION
We had alread bumped web and not noticed the breakage because
we don't actually run any tests; we'd noticed the breakage in
cairo and not bumped.

This standardizes on 0.3 and fixes the breakage by manually
addung the last line if there's no explicit linebreak.

This should address https://github.com/linebender/druid/issues/1488