### PR TITLE
This adds a ptr_eq method for ImageBuf

### DIFF
--- a/piet/src/image.rs
+++ b/piet/src/image.rs
@@ -137,7 +137,7 @@ impl ImageBuf {
             .unwrap()
     }
 
-    /// Checks whether two ImageBufs point to the same image data in memory.
+    /// Returns `true` if the two `ImageBuf`s refer to the same memory location.
     pub fn ptr_eq(&self, other: &ImageBuf) -> bool {
         Arc::ptr_eq(&self.raw_pixels_shared(), &other.raw_pixels_shared())
     }

--- a/piet/src/image.rs
+++ b/piet/src/image.rs
@@ -136,6 +136,11 @@ impl ImageBuf {
         ctx.make_image(self.width(), self.height(), &self.pixels, self.format)
             .unwrap()
     }
+
+    /// Checks whether two ImageBufs point to the same image data in memory.
+    pub fn ptr_eq(&self, other: &ImageBuf) -> bool {
+        Arc::ptr_eq(&self.raw_pixels_shared(), &other.raw_pixels_shared())
+    }
 }
 
 impl Default for ImageBuf {


### PR DESCRIPTION
- this method will be used to implement the Data trait in druid for ImageBuf like this:
```rust
impl Data for ImageBuf {
    fn same(&self, other: &Self) -> bool {
        self.ptr_eq(other)
    }
}
```