### PR TITLE
Support individual corner radii for kurbo::RoundedRect

### DIFF
--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -7,7 +7,7 @@ use winapi::um::d2d1::{
     D2D1_MATRIX_3X2_F, D2D1_POINT_2F, D2D1_RECT_F, D2D1_ROUNDED_RECT, D2D1_STROKE_STYLE_PROPERTIES,
 };
 
-use piet::kurbo::{Affine, Circle, Point, Rect, RoundedRect, Vec2};
+use piet::kurbo::{Affine, Circle, Point, Rect, Vec2};
 
 use piet::{Color, Error, GradientStop, LineCap, LineJoin, RoundFrom, RoundInto, StrokeStyle};
 
@@ -98,11 +98,11 @@ pub(crate) fn rect_to_rectf(rect: Rect) -> D2D1_RECT_F {
     }
 }
 
-pub(crate) fn rounded_rect_to_d2d(round_rect: RoundedRect) -> D2D1_ROUNDED_RECT {
+pub(crate) fn rounded_rect_to_d2d(rect: Rect, radius: f64) -> D2D1_ROUNDED_RECT {
     D2D1_ROUNDED_RECT {
-        rect: rect_to_rectf(round_rect.rect()),
-        radiusX: round_rect.radius() as f32,
-        radiusY: round_rect.radius() as f32,
+        rect: rect_to_rectf(rect),
+        radiusX: radius as f32,
+        radiusY: radius as f32,
     }
 }
 

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -536,17 +536,17 @@ impl DeviceContext {
                 );
             }
         } else {
-            let half_width_floor = (rect.width() / 2.0).floor();
-            let half_height_floor = (rect.height() / 2.0).floor();
+            let half_width = rect.width() / 2.0;
+            let half_height = rect.height() / 2.0;
             let half_stroke_width = (width / 2.0) as f64;
             let radii = rect.radii();
 
             // Top-left
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0 - half_stroke_width,
-                rect.rect().y0 - half_stroke_width,
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y0 + half_height_floor,
+                (rect.rect().x0 - half_stroke_width).floor(),
+                (rect.rect().y0 - half_stroke_width).floor(),
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y0 + half_height).floor(),
             ));
             unsafe {
                 self.0.DrawRoundedRectangle(
@@ -560,10 +560,10 @@ impl DeviceContext {
 
             // Top-right
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y0 - half_stroke_width,
-                rect.rect().x1 + half_stroke_width,
-                rect.rect().y0 + half_height_floor,
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y0 - half_stroke_width).floor(),
+                (rect.rect().x1 + half_stroke_width).ceil(),
+                (rect.rect().y0 + half_height).floor(),
             ));
             unsafe {
                 self.0.DrawRoundedRectangle(
@@ -577,10 +577,10 @@ impl DeviceContext {
 
             // Bottom-right
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y0 + half_height_floor,
-                rect.rect().x1 + half_stroke_width,
-                rect.rect().y1 + half_stroke_width,
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y0 + half_height).floor(),
+                (rect.rect().x1 + half_stroke_width).ceil(),
+                (rect.rect().y1 + half_stroke_width).ceil(),
             ));
             unsafe {
                 self.0.DrawRoundedRectangle(
@@ -594,10 +594,10 @@ impl DeviceContext {
 
             // Bottom-left
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0 - half_stroke_width,
-                rect.rect().y0 + half_height_floor,
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y1 + half_stroke_width,
+                (rect.rect().x0 - half_stroke_width).floor(),
+                (rect.rect().y0 + half_height).floor(),
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y1 + half_stroke_width).ceil(),
             ));
             unsafe {
                 self.0.DrawRoundedRectangle(
@@ -651,16 +651,16 @@ impl DeviceContext {
         // for each, so that each FillRoundedRectangle call corresponds to one
         // corner of the resulting rounded rectangle.
         } else {
-            let half_width_floor = (rect.width() / 2.0).floor();
-            let half_height_floor = (rect.height() / 2.0).floor();
+            let half_width = rect.width() / 2.0;
+            let half_height = rect.height() / 2.0;
             let radii = rect.radii();
 
             // Top-left
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0,
-                rect.rect().y0,
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y0 + half_height_floor,
+                rect.rect().x0.floor(),
+                rect.rect().y0.floor(),
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y0 + half_height).floor(),
             ));
             unsafe {
                 self.0.FillRoundedRectangle(
@@ -672,10 +672,10 @@ impl DeviceContext {
 
             // Top-right
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y0,
-                rect.rect().x1,
-                rect.rect().y0 + half_height_floor,
+                (rect.rect().x0 + half_width).floor(),
+                rect.rect().y0.floor(),
+                rect.rect().x1.ceil(),
+                (rect.rect().y0 + half_height).floor(),
             ));
             unsafe {
                 self.0.FillRoundedRectangle(
@@ -687,10 +687,10 @@ impl DeviceContext {
 
             // Bottom-right
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y0 + half_height_floor,
-                rect.rect().x1,
-                rect.rect().y1,
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y0 + half_height).floor(),
+                (rect.rect().x1).ceil(),
+                (rect.rect().y1).ceil(),
             ));
             unsafe {
                 self.0.FillRoundedRectangle(
@@ -702,10 +702,10 @@ impl DeviceContext {
 
             // Bottom-left
             self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0,
-                rect.rect().y0 + half_height_floor,
-                rect.rect().x0 + half_width_floor,
-                rect.rect().y1,
+                (rect.rect().x0).floor(),
+                (rect.rect().y0 + half_height).floor(),
+                (rect.rect().x0 + half_width).floor(),
+                (rect.rect().y1).ceil(),
             ));
             unsafe {
                 self.0.FillRoundedRectangle(

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -276,7 +276,7 @@ impl D2DFactory {
                 .0
                 .deref()
                 .deref()
-                .CreateRoundedRectangleGeometry(&rounded_rect_to_d2d(rect, radius), &mut ptr); // TODO
+                .CreateRoundedRectangleGeometry(&rounded_rect_to_d2d(rect, radius), &mut ptr);
             wrap(hr, ptr, RoundedRectangleGeometry)
         }
     }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -519,95 +519,20 @@ impl DeviceContext {
 
     pub(crate) fn draw_rounded_rect(
         &mut self,
-        rect: RoundedRect,
+        rect: Rect,
+        radius: f64,
         brush: &Brush,
         width: f32,
         style: Option<&StrokeStyle>,
     ) {
-        let single_radius = rect.radii().as_single_radius();
-        if let Some(radius) = single_radius {
-            let d2d_rounded_rect = rounded_rect_to_d2d(rect.rect(), radius);
-            unsafe {
-                self.0.DrawRoundedRectangle(
-                    &d2d_rounded_rect,
-                    brush.as_raw(),
-                    width,
-                    stroke_style_to_d2d(style),
-                );
-            }
-        } else {
-            let half_width = rect.width() / 2.0;
-            let half_height = rect.height() / 2.0;
-            let half_stroke_width = (width / 2.0) as f64;
-            let radii = rect.radii();
-
-            // Top-left
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0 - half_stroke_width).floor(),
-                (rect.rect().y0 - half_stroke_width).floor(),
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y0 + half_height).floor(),
-            ));
-            unsafe {
-                self.0.DrawRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.top_left),
-                    brush.as_raw(),
-                    width,
-                    stroke_style_to_d2d(style),
-                );
-            }
-            self.pop_axis_aligned_clip();
-
-            // Top-right
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y0 - half_stroke_width).floor(),
-                (rect.rect().x1 + half_stroke_width).ceil(),
-                (rect.rect().y0 + half_height).floor(),
-            ));
-            unsafe {
-                self.0.DrawRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.top_right),
-                    brush.as_raw(),
-                    width,
-                    stroke_style_to_d2d(style),
-                );
-            }
-            self.pop_axis_aligned_clip();
-
-            // Bottom-right
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y0 + half_height).floor(),
-                (rect.rect().x1 + half_stroke_width).ceil(),
-                (rect.rect().y1 + half_stroke_width).ceil(),
-            ));
-            unsafe {
-                self.0.DrawRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.bottom_right),
-                    brush.as_raw(),
-                    width,
-                    stroke_style_to_d2d(style),
-                );
-            }
-            self.pop_axis_aligned_clip();
-
-            // Bottom-left
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0 - half_stroke_width).floor(),
-                (rect.rect().y0 + half_height).floor(),
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y1 + half_stroke_width).ceil(),
-            ));
-            unsafe {
-                self.0.DrawRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.bottom_left),
-                    brush.as_raw(),
-                    width,
-                    stroke_style_to_d2d(style),
-                );
-            }
-            self.pop_axis_aligned_clip();
+        let d2d_rounded_rect = rounded_rect_to_d2d(rect, radius);
+        unsafe {
+            self.0.DrawRoundedRectangle(
+                &d2d_rounded_rect,
+                brush.as_raw(),
+                width,
+                stroke_style_to_d2d(style),
+            );
         }
     }
 
@@ -634,86 +559,11 @@ impl DeviceContext {
         }
     }
 
-    pub(crate) fn fill_rounded_rect(&mut self, rect: RoundedRect, brush: &Brush) {
-        let single_radius = rect.radii().as_single_radius();
-        // If the radii are all equal, then draw with a single
-        // FillRoundedRectangle call. FillRoundedRectangle only takes a single
-        // radius, so we need something more complex when corners have varying
-        // radii.
-        if let Some(radius) = single_radius {
-            let d2d_rounded_rect = rounded_rect_to_d2d(rect.rect(), radius);
-            unsafe {
-                self.0
-                    .FillRoundedRectangle(&d2d_rounded_rect, brush.as_raw());
-            }
-        // If the radii aren't equal, then this code block will draw four
-        // rounded rectangles. When drawing, it will set a clipping rectangle
-        // for each, so that each FillRoundedRectangle call corresponds to one
-        // corner of the resulting rounded rectangle.
-        } else {
-            let half_width = rect.width() / 2.0;
-            let half_height = rect.height() / 2.0;
-            let radii = rect.radii();
-
-            // Top-left
-            self.push_axis_aligned_clip(&Rect::new(
-                rect.rect().x0.floor(),
-                rect.rect().y0.floor(),
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y0 + half_height).floor(),
-            ));
-            unsafe {
-                self.0.FillRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.top_left),
-                    brush.as_raw(),
-                );
-            }
-            self.pop_axis_aligned_clip();
-
-            // Top-right
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0 + half_width).floor(),
-                rect.rect().y0.floor(),
-                rect.rect().x1.ceil(),
-                (rect.rect().y0 + half_height).floor(),
-            ));
-            unsafe {
-                self.0.FillRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.top_right),
-                    brush.as_raw(),
-                );
-            }
-            self.pop_axis_aligned_clip();
-
-            // Bottom-right
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y0 + half_height).floor(),
-                (rect.rect().x1).ceil(),
-                (rect.rect().y1).ceil(),
-            ));
-            unsafe {
-                self.0.FillRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.bottom_right),
-                    brush.as_raw(),
-                );
-            }
-            self.pop_axis_aligned_clip();
-
-            // Bottom-left
-            self.push_axis_aligned_clip(&Rect::new(
-                (rect.rect().x0).floor(),
-                (rect.rect().y0 + half_height).floor(),
-                (rect.rect().x0 + half_width).floor(),
-                (rect.rect().y1).ceil(),
-            ));
-            unsafe {
-                self.0.FillRoundedRectangle(
-                    &rounded_rect_to_d2d(rect.rect(), radii.bottom_left),
-                    brush.as_raw(),
-                );
-            }
-            self.pop_axis_aligned_clip();
+    pub(crate) fn fill_rounded_rect(&mut self, rect: Rect, radius: f64, brush: &Brush) {
+        let d2d_rounded_rect = rounded_rect_to_d2d(rect, radius);
+        unsafe {
+            self.0
+                .FillRoundedRectangle(&d2d_rounded_rect, brush.as_raw());
         }
     }
 
@@ -752,26 +602,9 @@ impl DeviceContext {
         }
     }
 
-    // Rectangle mask
-    pub(crate) fn push_axis_aligned_clip(&mut self, clip: &Rect) {
-        let rectf = &rect_to_rectf(*clip);
-        unsafe {
-            self.0
-                .deref()
-                .deref()
-                .PushAxisAlignedClip(rectf, D2D1_ANTIALIAS_MODE_PER_PRIMITIVE)
-        }
-    }
-
     pub(crate) fn pop_layer(&mut self) {
         unsafe {
             self.0.PopLayer();
-        }
-    }
-
-    pub(crate) fn pop_axis_aligned_clip(&mut self) {
-        unsafe {
-            self.0.PopAxisAlignedClip();
         }
     }
 

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -123,7 +123,10 @@ fn geometry_from_shape(
         .filter(|r| r.radii().as_single_radius().is_some())
     {
         Ok(d2d
-            .create_round_rect_geometry(round_rect.rect(), round_rect.as_single_radius().unwrap())?
+            .create_round_rect_geometry(
+                round_rect.rect(),
+                round_rect.radii().as_single_radius().unwrap(),
+            )?
             .into())
     } else if let Some(circle) = shape.as_circle() {
         Ok(d2d.create_circle_geometry(circle)?.into())

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -118,17 +118,13 @@ fn geometry_from_shape(
     // TODO: Do something special for line?
     if let Some(rect) = shape.as_rect() {
         Ok(d2d.create_rect_geometry(rect)?.into())
-    } else if let Some(round_rect) = shape.as_rounded_rect() {
-        // Direct2D's rounded rectangle geometry only supports a single radius
-        // value for the whole rectangle, so we can only use that geometry if
-        // all radius values are the same.
-        if let Some(radius) = round_rect.radii().as_single_radius() {
-            Ok(d2d
-                .create_round_rect_geometry(round_rect.rect(), radius)?
-                .into())
-        } else {
-            path_from_shape(d2d, is_filled, shape, fill_rule)
-        }
+    } else if let Some(round_rect) = shape
+        .as_rounded_rect()
+        .filter(|r| r.radii().as_single_radius().is_some())
+    {
+        Ok(d2d
+            .create_round_rect_geometry(round_rect.rect(), round_rect.as_single_radius().unwrap())?
+            .into())
     } else if let Some(circle) = shape.as_circle() {
         Ok(d2d.create_circle_geometry(circle)?.into())
     } else {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -119,7 +119,16 @@ fn geometry_from_shape(
     if let Some(rect) = shape.as_rect() {
         Ok(d2d.create_rect_geometry(rect)?.into())
     } else if let Some(round_rect) = shape.as_rounded_rect() {
-        Ok(d2d.create_round_rect_geometry(round_rect)?.into())
+        // Direct2D's rounded rectangle geometry only supports a single radius
+        // value for the whole rectangle, so we can only use that geometry if
+        // all radius values are the same.
+        if let Some(radius) = round_rect.radii().as_single_radius() {
+            Ok(d2d
+                .create_round_rect_geometry(round_rect.rect(), radius)?
+                .into())
+        } else {
+            path_from_shape(d2d, is_filled, shape, fill_rule)
+        }
     } else if let Some(circle) = shape.as_circle() {
         Ok(d2d.create_circle_geometry(circle)?.into())
     } else {

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -370,20 +370,19 @@ fn add_shape(node: &mut impl Node, shape: impl Shape, attrs: &Attrs) {
             .set("r", circle.radius);
         attrs.apply_to(&mut x);
         node.append(x);
-        return;
-    } else if let Some(rect) = shape.as_rounded_rect() {
-        if let Some(radius) = rect.radii().as_single_radius() {
-            let mut x = svg::node::element::Rectangle::new()
-                .set("x", rect.origin().x)
-                .set("y", rect.origin().y)
-                .set("width", rect.width())
-                .set("height", rect.height())
-                .set("rx", radius)
-                .set("ry", radius);
-            attrs.apply_to(&mut x);
-            node.append(x);
-            return;
-        }
+    } else if let Some(round_rect) = shape
+        .as_rounded_rect()
+        .filter(|r| r.radii().as_single_radius().is_some())
+    {
+        let mut x = svg::node::element::Rectangle::new()
+            .set("x", round_rect.origin().x)
+            .set("y", round_rect.origin().y)
+            .set("width", round_rect.width())
+            .set("height", round_rect.height())
+            .set("rx", round_rect.radii().as_single_radius().unwrap())
+            .set("ry", round_rect.radii().as_single_radius().unwrap());
+        attrs.apply_to(&mut x);
+        node.append(x);
     } else if let Some(rect) = shape.as_rect() {
         let mut x = svg::node::element::Rectangle::new()
             .set("x", rect.origin().x)
@@ -392,12 +391,11 @@ fn add_shape(node: &mut impl Node, shape: impl Shape, attrs: &Attrs) {
             .set("height", rect.height());
         attrs.apply_to(&mut x);
         node.append(x);
-        return;
+    } else {
+        let mut path = svg::node::element::Path::new().set("d", shape.into_path(1e-3).to_svg());
+        attrs.apply_to(&mut path);
+        node.append(path);
     }
-
-    let mut path = svg::node::element::Path::new().set("d", shape.into_path(1e-3).to_svg());
-    attrs.apply_to(&mut path);
-    node.append(path);
 }
 
 #[derive(Debug, Clone, Default)]

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -370,16 +370,20 @@ fn add_shape(node: &mut impl Node, shape: impl Shape, attrs: &Attrs) {
             .set("r", circle.radius);
         attrs.apply_to(&mut x);
         node.append(x);
+        return;
     } else if let Some(rect) = shape.as_rounded_rect() {
-        let mut x = svg::node::element::Rectangle::new()
-            .set("x", rect.origin().x)
-            .set("y", rect.origin().y)
-            .set("width", rect.width())
-            .set("height", rect.height())
-            .set("rx", rect.radius())
-            .set("ry", rect.radius());
-        attrs.apply_to(&mut x);
-        node.append(x);
+        if let Some(radius) = rect.radii().as_single_radius() {
+            let mut x = svg::node::element::Rectangle::new()
+                .set("x", rect.origin().x)
+                .set("y", rect.origin().y)
+                .set("width", rect.width())
+                .set("height", rect.height())
+                .set("rx", radius)
+                .set("ry", radius);
+            attrs.apply_to(&mut x);
+            node.append(x);
+            return;
+        }
     } else if let Some(rect) = shape.as_rect() {
         let mut x = svg::node::element::Rectangle::new()
             .set("x", rect.origin().x)
@@ -388,11 +392,12 @@ fn add_shape(node: &mut impl Node, shape: impl Shape, attrs: &Attrs) {
             .set("height", rect.height());
         attrs.apply_to(&mut x);
         node.append(x);
-    } else {
-        let mut path = svg::node::element::Path::new().set("d", shape.into_path(1e-3).to_svg());
-        attrs.apply_to(&mut path);
-        node.append(path)
+        return;
     }
+
+    let mut path = svg::node::element::Path::new().set("d", shape.into_path(1e-3).to_svg());
+    attrs.apply_to(&mut path);
+    node.append(path);
 }
 
 #[derive(Debug, Clone, Default)]

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
 image = { version = "0.23.10", optional = true, default-features = false }
-kurbo = { git = "https://github.com/SecondFlight/kurbo.git", branch = "rounded-rect-corners" }
+kurbo = "0.8.0"
 pico-args = { version = "0.3.3", optional = true }
 png = { version = "0.16.2", optional = true }
 os_info = { version = "3.0.0", optional = true, default-features = false }

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -13,9 +13,9 @@ include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
 image = { version = "0.23.10", optional = true, default-features = false }
-kurbo = "0.7.0"
-pico-args =  { version = "0.3.3", optional = true }
-png = {version = "0.16.2", optional = true }
+kurbo = { git = "https://github.com/SecondFlight/kurbo.git", branch = "rounded-rect-corners" }
+pico-args = { version = "0.3.3", optional = true }
+png = { version = "0.16.2", optional = true }
 os_info = { version = "3.0.0", optional = true, default-features = false }
 unic-bidi = "0.9"
 

--- a/piet/src/samples/picture_6.rs
+++ b/piet/src/samples/picture_6.rs
@@ -42,7 +42,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         stops: create_gradient_stops(),
     }))?;
     rc.stroke_styled(
-        RoundedRect::new(60.0, 0.0, 100.0, 30.0, 7.0),
+        RoundedRect::new(60.0, 0.0, 100.0, 30.0, (7.0, 7.0, 7.0, 15.0)),
         &linear_gradient,
         5.0,
         &stroke_style,
@@ -55,6 +55,17 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         &stroke_style,
     );
     rc.stroke(Rect::new(60.0, 80.0, 100.0, 100.0), &linear_gradient, 4.0);
+
+    rc.fill(
+        RoundedRect::new(115.0, 10.0, 165.0, 40.0, (15.0, 2.0, 2.0, 2.0)),
+        &linear_gradient,
+    );
+
+    rc.stroke(
+        RoundedRect::new(115.0, 50.0, 165.0, 80.0, (2.0, 2.0, 15.0, 2.0)),
+        &linear_gradient,
+        4.0,
+    );
 
     Ok(())
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6700184/106690435-cdaffb80-659f-11eb-9bfe-bda356ae38bc.png)

This PR adds support for [this Kurbo patch](https://github.com/linebender/kurbo/pull/166). This PR points directly at my Kurbo fork, so it probably shouldn't be merged until the Kurbo PR is merged and a new Kurbo version is published.

`piet-coregraphics` and `piet-cairo` both get this feature for free, because both platforms use paths for rounded rectangles. I have tested both platforms and verified this.

`piet-web` should get this feature for free as well, for the same reason. I have not explicitly tested this, but I feel confident about it since `to_path` is well-tested and is not platform-specific, and RoundedRect is not mentioned in the code.

In `piet-svg`, this has been implemented by simply using a bezier curve if the corner radii aren't all equal, and a rounded rectangle if they are. Rounded rectangles in SVG can only have a single radius, and while it's possible to use some clipping magic, I don't think it's worth the effort.

~~In `piet-direct2d`, this has been implemented by drawing four rounded rectangles, one for each corner. They are clipped using an [axis-aligned clip](https://docs.microsoft.com/en-us/windows/win32/direct2d/how-to-clip-with-axis-aligned-rects), which is faster than masking with a shape. If all corner radii are equal, a single rounded rectangle is drawn.~~

`piet-direct2d` has a similar implementation to `piet-svg`.