### PR TITLE
bump core-graphics to 0.22.2

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -45,7 +45,7 @@ cairo-sys-rs = { version = "0.10.0" }
 
 [target.'cfg(target_os="macos")'.dependencies]
 piet-coregraphics = { version = "0.3.0", path = "../piet-coregraphics" }
-core-graphics = { version = "0.22.0" }
+core-graphics = { version = "0.22.2" }
 
 [target.'cfg(target_os="windows")'.dependencies]
 piet-direct2d = { version = "0.3.0", path = "../piet-direct2d" }

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["rendering::graphics-api"]
 piet = { version = "0.3.0", path = "../piet" }
 
 foreign-types = "0.3.2"
-core-graphics = "0.22.0"
+core-graphics = "0.22.2"
 core-text = "19.0.0"
 core-foundation = "0.9"
 core-foundation-sys = "0.8"


### PR DESCRIPTION
There is an issue on core-graphics backend that RenderContext.blurred_rect can cause memory leak because of an issue that was fixed by https://github.com/servo/core-foundation-rs/commit/dc588497db727a3ba943aaecc83d2a07dc6d6b0a