### PR TITLE
Fully transparent color

### DIFF
--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -257,6 +257,9 @@ impl Color {
     /// Opaque teal.
     pub const TEAL: Color = Color::rgb8(0, 128, 128);
 
+    /// Fully transparent
+    pub const TRANSPARENT: Color = Color::rgba8(0, 0, 0, 0);
+
     /// Opaque white.
     pub const WHITE: Color = Color::grey8(255);
 


### PR DESCRIPTION
Fully transparent color is useful, e.g. clearing out certain areas of pixels