### PR TITLE
Change clear signature, do preliminary impl work

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -68,7 +68,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         Ok(())
     }
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, _region: impl Into<Option<Rect>>, color: Color) {
         let rgba = color.as_rgba_u32();
         self.ctx.set_source_rgba(
             byte_to_frac(rgba >> 24),

--- a/piet-common/examples/png.rs
+++ b/piet-common/examples/png.rs
@@ -17,7 +17,7 @@ fn main() {
         let height = 480;
         let mut bitmap = device.bitmap_target(width, height, 1.0).unwrap();
         let mut rc = bitmap.render_context();
-        rc.clear(Color::WHITE);
+        rc.clear(None, Color::WHITE);
         let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0x80));
         rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &brush, 1.0);
         rc.finish().unwrap();

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -18,6 +18,7 @@ use core_graphics::data_provider::CGDataProvider;
 use core_graphics::geometry::{CGAffineTransform, CGPoint, CGRect, CGSize};
 use core_graphics::gradient::CGGradientDrawingOptions;
 use core_graphics::image::CGImage;
+use foreign_types::ForeignTypeRef;
 
 use piet::kurbo::{Affine, PathEl, Point, QuadBez, Rect, Shape, Size};
 
@@ -134,12 +135,30 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
     type Text = CoreGraphicsText;
     type TextLayout = CoreGraphicsTextLayout;
     type Image = CoreGraphicsImage;
-    //type StrokeStyle = StrokeStyle;
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, region: impl Into<Option<Rect>>, color: Color) {
+        // save cannot fail
+        let _ = self.save();
+        // remove any existing clip
+        unsafe {
+            CGContextResetClip(self.ctx.as_ptr());
+        }
+        // remove the current transform
+        let current_xform = self.current_transform();
+        let xform = current_xform.inverse();
+        self.transform(xform);
+
+        let region = region
+            .into()
+            .map(to_cgrect)
+            .unwrap_or_else(|| self.ctx.clip_bounding_box());
         let (r, g, b, a) = color.as_rgba();
+        self.ctx
+            .set_blend_mode(core_graphics::context::CGBlendMode::Copy);
         self.ctx.set_rgb_fill_color(r, g, b, a);
-        self.ctx.fill_rect(self.ctx.clip_bounding_box());
+        self.ctx.fill_rect(region);
+        // restore cannot fail, because we saved at the start of the method
+        self.restore().unwrap();
     }
 
     fn solid_brush(&mut self, color: Color) -> Brush {
@@ -547,6 +566,11 @@ pub fn unpremultiply_rgba(data: &mut [u8]) {
             }
         }
     }
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGContextResetClip(c: core_graphics::sys::CGContextRef);
 }
 
 #[cfg(test)]

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -189,7 +189,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         std::mem::replace(&mut self.err, Ok(()))
     }
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, _region: impl Into<Option<Rect>>, color: Color) {
         self.rt.clear(color_to_colorf(color));
     }
 

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -68,12 +68,21 @@ impl piet::RenderContext for RenderContext {
         Ok(())
     }
 
-    fn clear(&mut self, color: Color) {
-        let mut rect = svg::node::element::Rectangle::new()
-            .set("width", "100%")
-            .set("height", "100%")
-            .set("fill", fmt_color(&color))
-            .set("fill-opacity", fmt_opacity(&color));
+    fn clear(&mut self, rect: impl Into<Option<Rect>>, color: Color) {
+        let rect = rect.into();
+        let mut rect = match rect {
+            Some(rect) => svg::node::element::Rectangle::new()
+                .set("width", rect.width())
+                .set("height", rect.height())
+                .set("x", rect.x0)
+                .set("y", rect.y0),
+            None => svg::node::element::Rectangle::new()
+                .set("width", "100%")
+                .set("height", "100%"),
+        }
+        .set("fill", fmt_color(&color))
+        .set("fill-opacity", fmt_opacity(&color));
+        //FIXME: I don't think we should be clipping, here?
         if let Some(id) = self.state.clip {
             rect.assign("clip-path", format!("url(#{})", id.to_string()));
         }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -129,16 +129,18 @@ impl RenderContext for WebRenderContext<'_> {
         std::mem::replace(&mut self.err, Ok(()))
     }
 
-    fn clear(&mut self, color: Color) {
+    fn clear(&mut self, region: impl Into<Option<Rect>>, color: Color) {
         let (width, height) = match self.ctx.canvas() {
             Some(canvas) => (canvas.offset_width(), canvas.offset_height()),
             None => return,
             /* Canvas might be null if the dom node is not in
              * the document; do nothing. */
         };
-        let shape = Rect::new(0.0, 0.0, width as f64, height as f64);
+        let rect = region
+            .into()
+            .unwrap_or_else(|| Rect::new(0.0, 0.0, width as f64, height as f64));
         let brush = self.solid_brush(color);
-        self.fill(shape, &brush);
+        self.fill(rect, &brush);
     }
 
     fn solid_brush(&mut self, color: Color) -> Brush {

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -59,7 +59,7 @@ impl RenderContext for NullRenderContext {
         Ok(NullBrush)
     }
 
-    fn clear(&mut self, _color: Color) {}
+    fn clear(&mut self, _: impl Into<Option<Rect>>, _color: Color) {}
 
     fn stroke(&mut self, _shape: impl Shape, _brush: &impl IntoBrush<Self>, _width: f64) {}
 

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -88,10 +88,22 @@ where
     /// Create a new gradient brush.
     fn gradient(&mut self, gradient: impl Into<FixedGradient>) -> Result<Self::Brush, Error>;
 
-    /// Clear the canvas with the given color.
+    /// Replace a region of the canvas with the provided [`Color`].
     ///
-    /// Note: only opaque colors are meaningful.
-    fn clear(&mut self, color: Color);
+    /// The region can be omitted, in which case it will apply to the entire
+    /// canvas.
+    ///
+    /// This operation ignores any existing clipping and transforations.
+    ///
+    /// # Note:
+    ///
+    /// You probably don't want to call this. It is essentially a specialized
+    /// fill method that can be used in GUI contexts for things like clearing
+    /// damage regions. It does not have a good cross-platform implementation,
+    /// and eventually should be deprecated when support is added for blend
+    /// modes, at which point it will be easier to just use [`fill`] for
+    /// everything.
+    fn clear(&mut self, region: impl Into<Option<Rect>>, color: Color);
 
     /// Stroke a shape.
     fn stroke(&mut self, shape: impl Shape, brush: &impl IntoBrush<Self>, width: f64);

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -26,11 +26,12 @@ mod picture_11;
 mod picture_12;
 mod picture_13;
 mod picture_14;
+mod picture_15;
 
 type BoxErr = Box<dyn std::error::Error>;
 
 /// The total number of samples in this module.
-pub const SAMPLE_COUNT: usize = 15;
+pub const SAMPLE_COUNT: usize = 16;
 
 /// file we save an os fingerprint to
 pub const GENERATED_BY: &str = "GENERATED_BY";
@@ -53,6 +54,7 @@ pub fn get<R: RenderContext>(number: usize) -> Result<SamplePicture<R>, BoxErr> 
         12 => SamplePicture::new(picture_12::SIZE, picture_12::draw),
         13 => SamplePicture::new(picture_13::SIZE, picture_13::draw),
         14 => SamplePicture::new(picture_14::SIZE, picture_14::draw),
+        15 => SamplePicture::new(picture_15::SIZE, picture_15::draw),
         _ => return Err(format!("No sample #{} exists", number).into()),
     })
 }

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -15,7 +15,7 @@ const YELLOW_ALPHA: Color = Color::rgba8(0xCF, 0xCF, 0x00, 0x60);
 pub const SIZE: Size = Size::new(400., 200.);
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     rc.stroke(Line::new((10.0, 10.0), (100.0, 50.0)), &BLUE, 1.0);
 
     let georgia = rc.text().font_family("Georgia").ok_or(Error::MissingFont)?;

--- a/piet/src/samples/picture_1.rs
+++ b/piet/src/samples/picture_1.rs
@@ -60,6 +60,6 @@ fn draw_cubic_bezier<V: Into<Point>>(
 }
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     draw_cubic_bezier(rc, (70.0, 80.0), (140.0, 10.0), (60.0, 10.0), (90.0, 80.0))
 }

--- a/piet/src/samples/picture_10.rs
+++ b/piet/src/samples/picture_10.rs
@@ -11,7 +11,7 @@ static SAMPLE_EN: &str = r#"ḧ́ͥm̾ͭpͭ̒ͦ̎ḧ̐̈̾̆͊
 const LIGHT_GREY: Color = Color::grey8(0xc0);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(LIGHT_GREY);
+    rc.clear(None, LIGHT_GREY);
     let text = rc.text();
 
     let layout = text

--- a/piet/src/samples/picture_11.rs
+++ b/piet/src/samples/picture_11.rs
@@ -16,7 +16,7 @@ const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(LIGHT_GREY);
+    rc.clear(None, LIGHT_GREY);
     let layout_en_start = rc
         .text()
         .new_text_layout(TEXT_EN)

--- a/piet/src/samples/picture_12.rs
+++ b/piet/src/samples/picture_12.rs
@@ -13,7 +13,7 @@ const SELECTION_COLOR: Color = Color::rgb8(165, 205, 255);
 const HILIGHT_COLOR: Color = Color::rgba8(255, 242, 54, 96);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let text = rc.text();
     let font2 = text.font_family("Courier New").unwrap();
     let layout = text

--- a/piet/src/samples/picture_13.rs
+++ b/piet/src/samples/picture_13.rs
@@ -11,7 +11,7 @@ pub const SIZE: Size = Size::new(480., 560.);
 static TEXT: &str = r#"Philosophers often behave like little children who scribble some marks on a piece of paper at random and then ask the grown-up "What's that?" — It happened like this: the grown-up had drawn pictures for the child several times and said "this is a man," "this is a house," etc. And then the child makes some marks too and asks: what's this then?"#;
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let text = rc.text();
     let _ = text.load_font(include_bytes!(
         "../../snapshots/resources/Anaheim-Regular.ttf"

--- a/piet/src/samples/picture_14.rs
+++ b/piet/src/samples/picture_14.rs
@@ -11,7 +11,7 @@ static TEXT: &str = r#"100200300400500
 600700800900950"#;
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let text = rc.text();
     let font = text
         .load_font(include_bytes!(

--- a/piet/src/samples/picture_15.rs
+++ b/piet/src/samples/picture_15.rs
@@ -1,0 +1,64 @@
+//! Clipping and clearing.
+//!
+//! This tests interactions between clipping, transforms, and the clear method.
+//!
+//! 1. clear ignores clipping and transforms
+
+use crate::kurbo::{Affine, Circle, Rect, Size};
+use crate::{Color, Error, RenderContext};
+
+pub const SIZE: Size = Size::new(400., 400.);
+
+const RED: Color = Color::rgb8(255, 0, 0);
+const BLUE: Color = Color::rgb8(0, 0, 255);
+const SEMI_TRANSPARENT_GREEN: Color = Color::rgba8(0, 255, 0, 125);
+const SEMI_TRANSPARENT_WHITE: Color = Color::rgba8(255, 255, 255, 125);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(None, Color::BLACK);
+    let circle = Circle::new((100., 100.), 90.);
+    let rect = Rect::new(20., 20., 180., 180.);
+    let degrees = 45.0;
+    let radians = degrees * std::f64::consts::PI / 180.;
+
+    let rotate = Affine::translate((100., 100.))
+        * Affine::rotate(radians)
+        * Affine::translate((-100., -100.0));
+
+    rc.save().unwrap();
+    rc.clip(circle);
+    rc.transform(rotate);
+
+    // this should ignore the translation and the clipping, and clear everything
+    rc.clear(None, SEMI_TRANSPARENT_WHITE);
+
+    // this should ignore the translate and clipping and clear just the rect
+    rc.clear(rect, BLUE);
+
+    // this should respect the existing transform, and be rotated and clipped
+    rc.fill(rect, &RED);
+    rc.restore().unwrap();
+
+    // this should not be clipped at all
+    let left_circ = Circle::new((10., 100.), 10.);
+    rc.fill(left_circ, &SEMI_TRANSPARENT_GREEN);
+
+    rc.clip(circle);
+    let right_circ = Circle::new((190., 100.), 10.);
+    rc.fill(right_circ, &SEMI_TRANSPARENT_GREEN);
+
+    // nested clip: drawing after we clip this should be in the union of the two
+    // clip regions:
+    let bottom_right_rect = Rect::from_origin_size((150., 150.), (50., 50.));
+    rc.clip(bottom_right_rect);
+
+    // this should ignore that clip, and fully clear the bottom left
+    let bottom_left_rect = Rect::from_origin_size((0., 150.), (50., 50.));
+    rc.clear(bottom_left_rect, SEMI_TRANSPARENT_GREEN);
+
+    // this is filling the whole canvas, but it should be clipped to the union
+    // of `circle` and `bottom_right_rect`.
+    rc.fill(Rect::new(0., 0., 200., 200.), &SEMI_TRANSPARENT_GREEN);
+
+    Ok(())
+}

--- a/piet/src/samples/picture_2.rs
+++ b/piet/src/samples/picture_2.rs
@@ -6,7 +6,7 @@ use crate::{Color, Error, ImageFormat, InterpolationMode, RenderContext};
 pub const SIZE: Size = Size::new(400., 200.);
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
 
     let mut y = 5.0;
     for &mode in &[

--- a/piet/src/samples/picture_3.rs
+++ b/piet/src/samples/picture_3.rs
@@ -6,7 +6,7 @@ use crate::{Color, Error, LineCap, LineJoin, RenderContext, StrokeStyle};
 pub const SIZE: Size = Size::new(400., 200.);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
 
     let mut path = BezPath::new();
     path.move_to((0.0, 0.0));

--- a/piet/src/samples/picture_4.rs
+++ b/piet/src/samples/picture_4.rs
@@ -9,7 +9,7 @@ use crate::{
 pub const SIZE: Size = Size::new(400., 200.);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let stops = vec![
         GradientStop {
             pos: 0.0,

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -14,7 +14,7 @@ const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let text = rc.text();
     let courier = text
         .font_family("Courier New")

--- a/piet/src/samples/picture_6.rs
+++ b/piet/src/samples/picture_6.rs
@@ -9,7 +9,7 @@ use crate::{
 pub const SIZE: Size = Size::new(400., 200.);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::BLACK);
+    rc.clear(None, Color::BLACK);
 
     let mut stroke_style = StrokeStyle::new();
     stroke_style.set_line_cap(LineCap::Round);

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -11,7 +11,7 @@ static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه
 const LIGHT_GREY: Color = Color::grey8(0xF0);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let text = rc.text();
 
     let en_leading = text

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -11,7 +11,7 @@ pub const SIZE: Size = Size::new(400., 800.);
 static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(Color::WHITE);
+    rc.clear(None, Color::WHITE);
     let text = rc.text();
 
     let en_leading = text

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -23,7 +23,7 @@ const BLUE: Color = Color::rgb8(0, 0, 255);
 const GREEN: Color = Color::rgb8(105, 255, 0);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(LIGHT_GREY);
+    rc.clear(None, LIGHT_GREY);
     let text = rc.text();
     let courier = text
         .font_family("Courier New")


### PR DESCRIPTION
This is a working branch for upcoming changes to the `RenderContext::clear` method.

The implementations in this first patch are not expected to be correct. We will figure out a good test case before merging.

The expected behaviour of `clear`:

- completely replace the contents of the buffer specified by the provided region with the provided color.
- if the provided region is `None`, the clear applies to the entire canvas.
- ignore any applied transforms or clipping masks
- when returning from this method, any applied transforms or clipping masks should be restored.