### PR TITLE
[cg] Fix incorrect handling of whitespace width

### DIFF
--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -234,4 +234,14 @@ fn trailing_whitespace_width() {
     assert_close!(non_ws.trailing_whitespace_width(), non_ws.size().width, 0.1);
     // the width with whitespace is ~very approximately~ twice the width without whitespace
     assert_close!(ws.trailing_whitespace_width() / ws.size().width, 2.0, 0.5);
+
+    // https://github.com/linebender/piet/pull/407
+    // check that we aren't miscalculating trailing whitespace width by (for instance)
+    // incorrectly adding it to base width
+    let text_ws_plus = "hello     +";
+    let ws_plus = factory.new_text_layout(text_ws_plus).build().unwrap();
+    assert!(
+        ws_plus.trailing_whitespace_width() > ws.trailing_whitespace_width(),
+        "trailing ws width is inclusive of other width"
+    );
 }

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -243,6 +243,7 @@ impl Line {
         self.0.get_typographic_bounds()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn get_trailing_whitespace_width(&self) -> f64 {
         unsafe { CTLineGetTrailingWhitespaceWidth(self.0.as_concrete_TypeRef()) }
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -844,8 +844,7 @@ fn build_line_metrics(
         let trailing_whitespace = count_trailing_ws(&text[start_offset..end_offset]);
 
         let typo_bounds = line.get_typographic_bounds();
-        let ws_width = line.get_trailing_whitespace_width();
-        max_width_with_ws = max_width_with_ws.max(typo_bounds.width + ws_width);
+        max_width_with_ws = max_width_with_ws.max(typo_bounds.width);
 
         // this may not be exactly right, but i'm also not sure we ever use this?
         //  see https://stackoverflow.com/questions/5511830/how-does-line-spacing-work-in-core-text-and-why-is-it-different-from-nslayoutm


### PR DESCRIPTION
It turns out that the width reported by CTLineGetTypographicBounds
*includes* whitespace width; it is just excluded from the size
returned by CTFramesetterSuggestFrameSizeWithConstraints.