### PR TITLE
[d2d] D2DRenderContext takes D2DText object at construction

### DIFF
--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -141,7 +141,8 @@ impl<'a> BitmapTarget<'a> {
     /// Note: caller is responsible for calling `finish` on the render
     /// context at the end of rendering.
     pub fn render_context(&mut self) -> D2DRenderContext {
-        D2DRenderContext::new(self.d2d, self.dwrite.clone(), &mut self.context)
+        let text = D2DText::new(self.dwrite.clone());
+        D2DRenderContext::new(self.d2d, text, &mut self.context)
     }
 
     /// Get an in-memory pixel buffer from the bitmap.

--- a/piet-direct2d/examples/test-picture.rs
+++ b/piet-direct2d/examples/test-picture.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use winapi::shared::dxgi::DXGI_MAP_READ;
 
 use piet::{samples, RenderContext};
-use piet_direct2d::D2DRenderContext;
+use piet_direct2d::{D2DRenderContext, D2DText};
 
 const HIDPI: f32 = 2.0;
 const FILE_PREFIX: &str = "d2d-test-";
@@ -24,6 +24,7 @@ fn run_sample(number: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::
     // Create the D2D factory
     let d2d = piet_direct2d::D2DFactory::new()?;
     let dwrite = piet_direct2d::DwriteFactory::new()?;
+    let text = D2DText::new(dwrite);
 
     // Initialize a D3D Device
     let (d3d, d3d_ctx) = piet_direct2d::d3d::D3D11Device::create()?;
@@ -47,7 +48,7 @@ fn run_sample(number: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::
     context.set_target(&target);
     context.set_dpi_scale(HIDPI);
     context.begin_draw();
-    let mut piet_context = D2DRenderContext::new(&d2d, dwrite, &mut context);
+    let mut piet_context = D2DRenderContext::new(&d2d, text, &mut context);
     // TODO: report errors more nicely than these unwraps.
     match sample.draw(&mut piet_context) {
         Ok(()) => (),

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -71,13 +71,12 @@ impl<'b, 'a: 'b> D2DRenderContext<'a> {
     /// TODO: check signature.
     pub fn new(
         factory: &'a D2DFactory,
-        dwrite: DwriteFactory,
+        text: D2DText,
         rt: &'b mut DeviceContext,
     ) -> D2DRenderContext<'b> {
-        let inner_text = D2DText::new(dwrite);
         D2DRenderContext {
             factory,
-            inner_text,
+            inner_text: text,
             rt,
             layers: vec![],
             ctx_stack: vec![CtxState::default()],


### PR DESCRIPTION
This will allow users (such as druid) to reuse a given D2DText
object across the multiple render contexts, allow them to share
loaded fonts.

This will let us fix https://github.com/linebender/druid/issues/1622