### PR TITLE
Rework the StrokeStyle type

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -332,31 +332,32 @@ impl Attrs<'_> {
                 node.assign("stroke-width", width);
             }
             match style.line_join {
-                None | Some(LineJoin::Miter) => {}
-                Some(LineJoin::Round) => {
+                LineJoin::Miter { limit } if limit == LineJoin::DEFAULT_MITER_LIMIT => (),
+                LineJoin::Miter { limit } => {
+                    node.assign("stroke-miterlimit", limit);
+                }
+                LineJoin::Round => {
                     node.assign("stroke-linejoin", "round");
                 }
-                Some(LineJoin::Bevel) => {
+                LineJoin::Bevel => {
                     node.assign("stroke-linejoin", "bevel");
                 }
             }
             match style.line_cap {
-                None | Some(LineCap::Butt) => {}
-                Some(LineCap::Round) => {
+                LineCap::Round => {
                     node.assign("stroke-linecap", "round");
                 }
-                Some(LineCap::Square) => {
+                #[allow(deprecated)]
+                LineCap::Square => {
                     node.assign("stroke-linecap", "square");
                 }
+                LineCap::Butt => (),
             }
-            if let Some((ref array, offset)) = style.dash {
-                node.assign("stroke-dasharray", array.clone());
-                if offset != 0.0 {
-                    node.assign("stroke-dashoffset", offset);
-                }
+            if !style.dash_pattern.is_empty() {
+                node.assign("stroke-dasharray", style.dash_pattern.clone().into_owned());
             }
-            if let Some(limit) = style.miter_limit {
-                node.assign("stroke-miterlimit", limit);
+            if style.dash_offset != 0.0 {
+                node.assign("stroke-dashoffset", style.dash_offset);
             }
         }
     }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -101,6 +101,7 @@ impl<T> WrapError<T> for Result<T, JsValue> {
 }
 
 fn convert_line_cap(line_cap: LineCap) -> &'static str {
+    #[allow(deprecated)]
     match line_cap {
         LineCap::Butt => "butt",
         LineCap::Round => "round",
@@ -110,10 +111,24 @@ fn convert_line_cap(line_cap: LineCap) -> &'static str {
 
 fn convert_line_join(line_join: LineJoin) -> &'static str {
     match line_join {
-        LineJoin::Miter => "miter",
+        LineJoin::Miter { .. } => "miter",
         LineJoin::Round => "round",
         LineJoin::Bevel => "bevel",
     }
+}
+
+fn convert_dash_pattern(pattern: &[f64]) -> Float64Array {
+    let len = pattern.len() as u32;
+    let array = Float64Array::new_with_length(len);
+    for (i, elem) in pattern.iter().enumerate() {
+        Reflect::set(
+            array.as_ref(),
+            &JsValue::from(i as u32),
+            &JsValue::from(*elem),
+        )
+        .unwrap();
+    }
+    array
 }
 
 impl RenderContext for WebRenderContext<'_> {
@@ -459,40 +474,19 @@ impl WebRenderContext<'_> {
     /// TODO(performance): this is probably expensive enough it makes sense
     /// to at least store the last version and only reset if it's changed.
     fn set_stroke(&mut self, width: f64, style: Option<&StrokeStyle>) {
+        let default_style = StrokeStyle::default();
+        let style = style.unwrap_or(&default_style);
+
         self.ctx.set_line_width(width);
+        self.ctx.set_line_join(convert_line_join(style.line_join));
+        self.ctx.set_line_cap(convert_line_cap(style.line_cap));
+        if let Some(limit) = style.miter_limit() {
+            self.ctx.set_miter_limit(limit);
+        }
 
-        let line_join = style
-            .and_then(|style| style.line_join)
-            .unwrap_or(LineJoin::Miter);
-        self.ctx.set_line_join(convert_line_join(line_join));
-
-        let line_cap = style
-            .and_then(|style| style.line_cap)
-            .unwrap_or(LineCap::Butt);
-        self.ctx.set_line_cap(convert_line_cap(line_cap));
-
-        let miter_limit = style.and_then(|style| style.miter_limit).unwrap_or(10.0);
-        self.ctx.set_miter_limit(miter_limit);
-
-        let (dash_segs, dash_offset) = style
-            .and_then(|style| style.dash.as_ref())
-            .map(|dash| {
-                let len = dash.0.len() as u32;
-                let array = Float64Array::new_with_length(len);
-                for (i, elem) in dash.0.iter().enumerate() {
-                    Reflect::set(
-                        array.as_ref(),
-                        &JsValue::from(i as u32),
-                        &JsValue::from(*elem),
-                    )
-                    .unwrap();
-                }
-                (array, dash.1)
-            })
-            .unwrap_or((Float64Array::new_with_length(0), 0.0));
-
+        let dash_segs = convert_dash_pattern(&style.dash_pattern);
         self.ctx.set_line_dash(dash_segs.as_ref()).unwrap();
-        self.ctx.set_line_dash_offset(dash_offset);
+        self.ctx.set_line_dash_offset(style.dash_offset);
     }
 
     fn set_path(&mut self, shape: impl Shape) {

--- a/piet/src/samples/picture_3.rs
+++ b/piet/src/samples/picture_3.rs
@@ -16,7 +16,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let brush = rc.solid_brush(Color::rgb8(0x00, 0x00, 0xC0));
     for line_cap in &[LineCap::Butt, LineCap::Round, LineCap::Square] {
         let mut x = 5.0;
-        for line_join in &[LineJoin::Bevel, LineJoin::Miter, LineJoin::Round] {
+        for line_join in &[LineJoin::Bevel, LineJoin::default(), LineJoin::Round] {
             let width = 5.0;
             let mut style = StrokeStyle::new();
             rc.with_save(|rc| {
@@ -37,7 +37,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     for i in 0..8 {
         let mut style = StrokeStyle::new();
         dashes.push((i + 1) as f64);
-        style.set_dash(dashes.clone(), 0.0);
+        style.set_dash_pattern(dashes.clone());
         rc.stroke_styled(Line::new((x, y), (x + 50.0, y)), &brush, 2.0, &style);
         y += 10.0;
     }

--- a/piet/src/samples/picture_6.rs
+++ b/piet/src/samples/picture_6.rs
@@ -14,7 +14,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let mut stroke_style = StrokeStyle::new();
     stroke_style.set_line_cap(LineCap::Round);
     stroke_style.set_line_join(LineJoin::Round);
-    stroke_style.set_dash(vec![10.0, 7.0, 8.0, 6.0], 0.0);
+    stroke_style.set_dash_pattern(vec![10.0, 7.0, 8.0, 6.0]);
 
     // Shape rendering with radial gradient
     let radial_gradient = rc.gradient(FixedGradient::Radial(FixedRadialGradient {

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -1,69 +1,184 @@
 //! Options for drawing paths.
 
+use std::borrow::Cow;
+
 /// Options for drawing stroked lines.
-/// Most of these are self explanatory, but some aren't.
 ///
-/// `dash` has two parts. The Vec<f64> pattern array and an offset. The array
-/// represents alternating lengths to be drawn and undrawn repeatedly. The offset
-/// specifes how far into the pattern it should start. On platforms that do not
-/// support an odd number of lengths in the array, the implementation may
-/// concatenate two copies of the array to reach an even count.
+/// You may configure particular aspects of the style by using the
+/// methods described below.
 ///
-/// `miter_limit` controls how corners are drawn when `line_join` is set to
-/// Miter. Will draw corners as `Bevel` instead of `Miter` if the limit is
-/// reached. See the reference below on how `miter_limit` is calculated.
+/// ## Defaults
 ///
-/// See
-/// https://www.adobe.com/content/dam/acom/en/devnet/actionscript/articles/psrefman.pdf
-/// for more information and examples
-#[derive(Clone, PartialEq, Debug)]
+/// Currently, the style (and its various consituent parts) have [`Default`]
+/// impls that conform to the defaults described in the
+/// [Postscript Language Manual, 3rd Edition][PLRMv3]; that document is the
+/// basis for the choice of these types, and can be consulted for detailed
+/// explanations and illustrations.
+///
+/// It is possible that in the future certain of these defaults may change;
+/// if you are particular about your style you can create the various types
+/// explicitly instead of relying on the default impls.
+///
+/// [PLRMv3]: https://www.adobe.com/content/dam/acom/en/devnet/actionscript/articles/PLRM.pdf
+#[derive(Clone, PartialEq, Debug, Default)]
 pub struct StrokeStyle {
-    pub line_join: Option<LineJoin>,
-    pub line_cap: Option<LineCap>,
-    pub dash: Option<(Vec<f64>, f64)>,
-    pub miter_limit: Option<f64>,
+    /// How to join segments of the path.
+    ///
+    /// By default, this is [`LineJoin::Miter`] with a `limit` of `10.0`.
+    pub line_join: LineJoin,
+    /// How to terminate open paths.
+    ///
+    /// (closed paths do not have ends.)
+    ///
+    /// by default, this is [`LineCap::Butt`].
+    pub line_cap: LineCap,
+    /// The sequence of alternating dashes and gaps uses to draw the line.
+    ///
+    /// If the sequence is not empty, all numbers should be finite and
+    /// non-negative, and the sequence should not be all zeros.
+    ///
+    /// On platforms that do not support an odd number of lengths in the array,
+    /// the implementation may concatenate two copies of the array to reach
+    /// an even count.
+    ///
+    /// By default, this is empty (`&[]`), indicating a solid line.
+    pub dash_pattern: Cow<'static, [f64]>,
+    /// The distance into the `dash_pattern` at which drawing begins.
+    ///
+    /// By default, this is `0.0`.
+    pub dash_offset: f64,
 }
 
 /// Options for angled joins in strokes.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum LineJoin {
-    Miter,
+    /// The outer edges of the two paths are extended until they intersect.
+    ///
+    /// Because the miter length can be extreme for small angles, you must supply
+    /// a 'limit' at which we will fallback on [`LineJoin::Bevel`].
+    ///
+    /// This limit is the distance from the point where the inner edges of the
+    /// stroke meet to the point where the outer edges meet.
+    ///
+    /// The default limit is `10.0`.
+    ///
+    /// This is also currently the default `LineJoin`; you should only need to
+    /// construct it if you need to customize the `limit`.
+    Miter { limit: f64 },
+    /// The two lines are joined by a circular arc.
     Round,
+    /// The two segments are capped with [`LineCap::Butt`], and the notch is filled.
     Bevel,
+}
+
+impl LineJoin {
+    /// The default maximum length for a [`LineJoin::Miter`].
+    ///
+    /// This is defined in the [Postscript Language Reference][PLRMv3] (pp 676).
+    ///
+    /// [PLRMv3]: https://www.adobe.com/content/dam/acom/en/devnet/actionscript/articles/PLRM.pdf
+    pub const DEFAULT_MITER_LIMIT: f64 = 10.0;
 }
 
 /// Options for the cap of stroked lines.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum LineCap {
+    /// The stroke is squared off at the endpoint of the path.
     Butt,
+    /// The stroke ends in a semicircular arc with a diameter equal to the line width.
     Round,
+    /// The stroke projects past the end of the path, and is squared off.
+    ///
+    /// The stroke projects for a distance equal to half the width of the line.
     Square,
 }
 
 impl StrokeStyle {
-    #[allow(clippy::new_without_default)]
+    /// Create a new, default `StrokeStyle`.
+    ///
+    /// To create a `StrokeStyle` in a `const` setting, use [`StrokeStyle::new_with_pattern`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    ///  use piet::{LineJoin, StrokeStyle};
+    ///
+    ///  let pattern = vec![4.0, 8.0, 2.0, 8.0];
+    ///
+    ///  let style = StrokeStyle::new()
+    ///     .line_join(LineJoin::Round)
+    ///     .dash_pattern(pattern);
+    ///
+    /// ```
     pub fn new() -> StrokeStyle {
         StrokeStyle {
-            line_join: None,
-            line_cap: None,
-            dash: None,
-            miter_limit: None,
+            line_join: Default::default(),
+            line_cap: Default::default(),
+            dash_offset: 0.0,
+            dash_pattern: Cow::Borrowed(&[]),
+        }
+    }
+
+    /// Create a `StrokeStyle` with a pattern.
+    ///
+    /// This constructor is `const`; if you don't want a pattern you may pass
+    /// an empty slice.
+    ///
+    /// # Example
+    ///
+    /// ```
+    ///  use piet::{LineCap, StrokeStyle};
+    ///
+    ///  const DASHED_STYLE: StrokeStyle = StrokeStyle::new_with_pattern(&[8.0, 12.0])
+    ///     .dash_offset(8.0)
+    ///     .line_cap(LineCap::Square);
+    ///
+    /// ```
+    pub const fn new_with_pattern(pattern: &'static [f64]) -> Self {
+        StrokeStyle {
+            dash_pattern: Cow::Borrowed(pattern),
+            line_join: LineJoin::Miter {
+                limit: LineJoin::DEFAULT_MITER_LIMIT,
+            },
+            line_cap: LineCap::Butt,
+            dash_offset: 0.0,
         }
     }
 
     /// Builder-style method to set the [`LineJoin`].
     ///
     /// [`LineJoin`]: enum.LineJoin.html
-    pub fn line_join(mut self, line_join: LineJoin) -> Self {
-        self.line_join = Some(line_join);
+    pub const fn line_join(mut self, line_join: LineJoin) -> Self {
+        self.line_join = line_join;
         self
     }
 
     /// Builder-style method to set the [`LineCap`].
     ///
     /// [`LineCap`]: enum.LineCap.html
-    pub fn line_cap(mut self, line_cap: LineCap) -> Self {
-        self.line_cap = Some(line_cap);
+    pub const fn line_cap(mut self, line_cap: LineCap) -> Self {
+        self.line_cap = line_cap;
+        self
+    }
+
+    /// Builder-style method to set the [`dash_offset`].
+    ///
+    /// [`dash_offset`]: StrokeStyle#structfield.dash_offset
+    pub const fn dash_offset(mut self, offset: f64) -> Self {
+        self.dash_offset = offset;
+        self
+    }
+
+    /// Builder-style method to set the [`dash_pattern`].
+    ///
+    /// You may provide either a `Vec<f64>` or a `&'static [f64]`.
+    ///
+    /// This method is not available in a const context; use
+    /// [`StrokeStyle::new_with_pattern`] instead.
+    ///
+    /// [`dash_pattern`]: StrokeStyle#structfield.dash_pattern
+    pub fn dash_pattern(mut self, lengths: impl Into<Cow<'static, [f64]>>) -> Self {
+        self.dash_pattern = lengths.into();
         self
     }
 
@@ -71,30 +186,61 @@ impl StrokeStyle {
     ///
     /// Dash style is represented as a vector of alternating on-off lengths,
     /// and an offset length.
-    pub fn dash(mut self, dashes: Vec<f64>, offest: f64) -> Self {
-        self.dash = Some((dashes, offest));
-        self
+    #[deprecated(since = "0.4.0", note = "Use dash_offset and dash_lengths instead")]
+    #[doc(hidden)]
+    pub fn dash(self, dashes: Vec<f64>, offset: f64) -> Self {
+        self.dash_pattern(dashes).dash_offset(offset)
     }
 
-    /// Builder-style method to set the miter limit.
-    pub fn miter_limit(mut self, miter_limit: f64) -> Self {
-        self.miter_limit = Some(miter_limit);
-        self
-    }
-
+    /// Set the [`LineJoin`].
     pub fn set_line_join(&mut self, line_join: LineJoin) {
-        self.line_join = Some(line_join);
+        self.line_join = line_join;
     }
 
+    /// Set the [`LineCap`].
     pub fn set_line_cap(&mut self, line_cap: LineCap) {
-        self.line_cap = Some(line_cap);
+        self.line_cap = line_cap;
     }
 
+    #[deprecated(
+        since = "0.4.0",
+        note = "Use set_dash_offset and set_dash_pattern instead"
+    )]
+    #[doc(hidden)]
     pub fn set_dash(&mut self, dashes: Vec<f64>, offset: f64) {
-        self.dash = Some((dashes, offset));
+        self.dash_offset = offset;
+        self.dash_pattern = dashes.into();
     }
 
-    pub fn set_miter_limit(&mut self, miter_limit: f64) {
-        self.miter_limit = Some(miter_limit);
+    /// Set the dash offset.
+    pub fn set_dash_offset(&mut self, offset: f64) {
+        self.dash_offset = offset;
+    }
+
+    /// Set the dash pattern.
+    pub fn set_dash_pattern(&mut self, lengths: impl Into<Cow<'static, [f64]>>) {
+        self.dash_pattern = lengths.into();
+    }
+
+    /// If the current [`LineJoin`] is [`LineJoin::Miter`] return the miter limit.
+    pub fn miter_limit(&self) -> Option<f64> {
+        match self.line_join {
+            LineJoin::Miter { limit } => Some(limit),
+            _ => None,
+        }
+    }
+}
+
+impl Default for LineJoin {
+    fn default() -> Self {
+        LineJoin::Miter {
+            limit: LineJoin::DEFAULT_MITER_LIMIT,
+        }
+    }
+}
+
+impl Default for LineCap {
+    fn default() -> Self {
+        LineCap::Butt
     }
 }


### PR DESCRIPTION
This started out as my just wanting to fix #416 while it was
on my mind, and then, well, things got a little out of hand.

I realized I wasn't familiar with some of the terminology used,
so I patched up the docs based on the postscript manual. Then
I noticed there were a few areas where the API seemed confusing,
and where the backends had to duplicate a bunch of code in order
to set defaults, so I went through and implemented `Default`,
using the defaults mentioned in the spec.

Highlights:

- 'dash' is replaced with separate 'dash_pattern' and 'dash_offset'
  methods
- StrokeStyle can now be constructed in a const context
- dash pattern can now be represented with a static &[f64] slice
- miter limit is now a member of the LineJoin::Miter variant.
- LineCap::Square is replaced with LineCap::ProjectingSquare, which
  more closely matches the naming in postscript and hopefully helps
  to differentiate it from LineCap::Butt.