### PR TITLE
Clarify and test behaviour of hit_test_position

### DIFF
--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -399,6 +399,12 @@ pub trait TextLayout: Clone {
     ///
     /// For more on text positions, see docs for the [`TextLayout`] trait.
     ///
+    /// ## Notes:
+    ///
+    /// The user is expected to ensure that the provided index is a grapheme
+    /// boundary. If it is a character boundary but *not* a grapheme boundary,
+    /// the return value may be backend-specific.
+    ///
     /// ## Panics:
     ///
     /// This method will panic if the text position is not a character boundary,


### PR DESCRIPTION
This was motivated by the pango work; I realized that the
behaviour in the case of interior bytes was not well defined.

This adds checks to ensure backends panic when the provided
index is not a codepoint boundary, and notes that behaviour
may vary if the index is not a grapheme boundary, because
this is not a case I feel compelled to support.