### PR TITLE
Fixup snapshots

### DIFF
--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -2,6 +2,7 @@
 
 use std::fs::File;
 use std::path::Path;
+use std::process::Command;
 
 use cairo::{Context, Format, ImageSurface};
 
@@ -12,7 +13,8 @@ const HIDPI: f64 = 2.0;
 const FILE_PREFIX: &str = "cairo-test-";
 
 fn main() {
-    samples::samples_main(run_sample, FILE_PREFIX)
+    let sys_info = additional_system_info();
+    samples::samples_main(run_sample, FILE_PREFIX, Some(&sys_info));
 }
 
 fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -34,4 +36,45 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
     let mut file = File::create(path)?;
 
     surface.write_to_png(&mut file).map_err(Into::into)
+}
+
+fn additional_system_info() -> String {
+    let mut r = String::new();
+    append_lib_version("libpango1.0", &mut r);
+    append_lib_version("libcairo2", &mut r);
+    r
+}
+
+fn append_lib_version(package_name: &str, buf: &mut String) {
+    let version = get_version_from_apt(package_name);
+    buf.push_str(&format!("{:16}", package_name));
+    buf.push_str(version.as_deref().unwrap_or("not found"));
+    buf.push('\n')
+}
+
+fn get_version_from_apt(package: &str) -> Option<String> {
+    let output = match Command::new("aptitude")
+        .arg("show")
+        .arg(package)
+        .output()
+        .or_else(|_| Command::new("apt-cache").arg("show").arg(package).output())
+    {
+        Ok(output) => output,
+        Err(e) => {
+            eprintln!("failed to get package version: '{}'", e);
+            return None;
+        }
+    };
+
+    let output = if output.status.success() {
+        String::from_utf8(output.stdout).expect("malformed utf8")
+    } else {
+        eprintln!("apt-cache failed {:?}", &output);
+        return None;
+    };
+
+    output
+        .lines()
+        .find(|s| s.trim().starts_with("Version"))
+        .and_then(|line| line.split(':').last().map(|s| s.trim().to_owned()))
 }

--- a/piet-coregraphics/examples/test-picture.rs
+++ b/piet-coregraphics/examples/test-picture.rs
@@ -15,7 +15,7 @@ const SCALE: f64 = 2.0;
 const FILE_PREFIX: &str = "coregraphics-test-";
 
 fn main() {
-    samples::samples_main(run_sample, FILE_PREFIX);
+    samples::samples_main(run_sample, FILE_PREFIX, None);
 }
 
 fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/piet-direct2d/examples/test-picture.rs
+++ b/piet-direct2d/examples/test-picture.rs
@@ -11,7 +11,7 @@ const HIDPI: f32 = 2.0;
 const FILE_PREFIX: &str = "d2d-test-";
 
 fn main() {
-    samples::samples_main(run_sample, FILE_PREFIX);
+    samples::samples_main(run_sample, FILE_PREFIX, None);
 }
 
 fn run_sample(number: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
The linux CI image has changed, which has caused some breakage with the snapshots; this updates the snapshots and also now tries to record the version of `pango` used if we're on linux. (This requires `apt-cache`, so may only work on debian-based systems? In any case, that is enough for our needs.)