### PR TITLE
Clarify and rename some error types

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -310,7 +310,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
     }
 
     fn capture_image_area(&mut self, _src_rect: impl Into<Rect>) -> Result<Self::Image, Error> {
-        Err(Error::MissingFeature)
+        Err(Error::Unimplemented)
     }
 
     fn blurred_rect(&mut self, rect: Rect, blur_radius: f64, brush: &impl IntoBrush<Self>) {

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -195,6 +195,6 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(piet::Error::MissingFeature)
+        Err(piet::Error::Unimplemented)
     }
 }

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -176,6 +176,6 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(Error::MissingFeature)
+        Err(Error::MissingFeature("png"))
     }
 }

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -221,7 +221,7 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(piet::Error::MissingFeature)
+        Err(piet::Error::MissingFeature("png"))
     }
 }
 

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -174,7 +174,7 @@ impl<'a> BitmapTarget<'a> {
     /// Stub for feature is missing
     #[cfg(not(feature = "png"))]
     pub fn save_to_file<P: AsRef<Path>>(self, _path: P) -> Result<(), piet::Error> {
-        Err(piet::Error::MissingFeature)
+        Err(piet::Error::MissingFeature("png"))
     }
 }
 

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -282,7 +282,7 @@ impl piet::RenderContext for RenderContext {
     }
 
     fn capture_image_area(&mut self, _src_rect: impl Into<Rect>) -> Result<Self::Image> {
-        Err(Error::MissingFeature)
+        Err(Error::Unimplemented)
     }
 
     fn blurred_rect(&mut self, _rect: Rect, _blur_radius: f64, _brush: &impl IntoBrush<Self>) {

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -361,7 +361,7 @@ impl RenderContext for WebRenderContext<'_> {
     }
 
     fn capture_image_area(&mut self, _rect: impl Into<Rect>) -> Result<Self::Image, Error> {
-        Err(Error::MissingFeature)
+        Err(Error::Unimplemented)
     }
 
     fn blurred_rect(&mut self, rect: Rect, blur_radius: f64, brush: &impl IntoBrush<Self>) {

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -67,7 +67,7 @@ impl Text for WebText {
     }
 
     fn load_font(&mut self, _data: &[u8]) -> Result<FontFamily, Error> {
-        Err(Error::MissingFeature)
+        Err(Error::Unimplemented)
     }
 
     fn new_text_layout(&mut self, text: impl TextStorage) -> Self::TextLayoutBuilder {

--- a/piet/src/error.rs
+++ b/piet/src/error.rs
@@ -6,13 +6,23 @@ use std::fmt;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
+    /// A function was passed an invalid input.
     InvalidInput,
+    /// Something is impossible on the current platform.
     NotSupported,
+    /// Something is possible, but not yet implemented.
+    Unimplemented,
+    /// Piet was compiled without a required feature.
+    MissingFeature(&'static str),
+    /// A stack pop failed.
     StackUnbalance,
+    /// The backend failed unexpectedly.
     BackendError(Box<dyn std::error::Error>),
-    MissingFeature,
+    /// A font could not be found.
     MissingFont,
+    /// Font data could not be loaded.
     FontLoadingFailed,
+    /// The arguments provided to the CLI were invalid.
     #[cfg(feature = "samples")]
     InvalidSampleArgs,
 }
@@ -21,11 +31,15 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::InvalidInput => write!(f, "Invalid input"),
-            Error::NotSupported => write!(f, "Option not supported"),
+            Error::NotSupported => write!(f, "Not supported on the current backend"),
             Error::StackUnbalance => write!(f, "Stack unbalanced"),
             Error::MissingFont => write!(f, "A font could not be found"),
             Error::FontLoadingFailed => write!(f, "A font could not be loaded"),
-            Error::MissingFeature => write!(f, "A feature is not implemented on this backend"),
+            Error::Unimplemented => write!(
+                f,
+                "This functionality is not yet implemented for this backend"
+            ),
+            Error::MissingFeature(feature) => write!(f, "Missing feature '{}'", feature),
             Error::BackendError(e) => {
                 write!(f, "Backend error: ")?;
                 e.fmt(f)


### PR DESCRIPTION
This tries to better differentiate three possible error conditions:
when something is impossible, when something is unimplemented,
and when something requires a missing cargo feature.