### PR TITLE
Warn on missing docs and broken doc links

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -458,16 +458,12 @@ impl IntoBrush<RenderContext> for Brush {
 
 // RGB in hex representation
 fn fmt_color(color: &Color) -> String {
-    match color {
-        Color::Rgba32(x) => format!("#{:06x}", x >> 8),
-    }
+    format!("#{:06x}", color.as_rgba_u32() >> 8)
 }
 
 // Opacity as value from [0, 1]
 fn fmt_opacity(color: &Color) -> String {
-    match color {
-        Color::Rgba32(x) => format!("{}", (x & 0xFF) as f32 / 255.0),
-    }
+    format!("{}", color.as_rgba().3)
 }
 
 /// SVG image (unimplemented)

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -8,7 +8,9 @@ use std::fmt::{Debug, Formatter};
 /// extend to some form of wide-gamut colorspace, and in the meantime
 /// is useful for giving programs proper type.
 #[derive(Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Color {
+    #[doc(hidden)]
     Rgba32(u32),
 }
 
@@ -19,6 +21,7 @@ pub enum ColorParseError {
     WrongSize(usize),
     /// A byte in the input string is not in one of the ranges `0..=9`,
     /// `a..=f`, or `A..=F`.
+    #[allow(missing_docs)]
     NotHex { idx: usize, byte: u8 },
 }
 

--- a/piet/src/conv.rs
+++ b/piet/src/conv.rs
@@ -12,6 +12,7 @@ use kurbo::Vec2;
 /// we should adopt a similar trait (it has some similarity to AsPrimitive
 /// from num_traits).
 pub trait RoundFrom<T> {
+    /// Performs the conversion.
     fn round_from(x: T) -> Self;
 }
 
@@ -20,6 +21,7 @@ pub trait RoundFrom<T> {
 /// As with `From` and `Into`, a blanket implementation is provided;
 /// for the most part, implement `RoundFrom`.
 pub trait RoundInto<T> {
+    /// Performs the conversion.
     fn round_into(self) -> T;
 }
 

--- a/piet/src/font.rs
+++ b/piet/src/font.rs
@@ -77,6 +77,7 @@ impl FontFamily {
         FontFamily(FontFamilyInner::Named(s.into()))
     }
 
+    /// The name of the font family.
     pub fn name(&self) -> &str {
         match &self.0 {
             FontFamilyInner::Serif => "serif",
@@ -100,27 +101,40 @@ impl FontFamily {
 }
 
 impl FontWeight {
+    /// 100
     pub const THIN: FontWeight = FontWeight(100);
+    /// 100
     pub const HAIRLINE: FontWeight = FontWeight::THIN;
 
+    /// 200
     pub const EXTRA_LIGHT: FontWeight = FontWeight(200);
 
+    /// 300
     pub const LIGHT: FontWeight = FontWeight(300);
 
+    /// 400
     pub const REGULAR: FontWeight = FontWeight(400);
+    /// 400
     pub const NORMAL: FontWeight = FontWeight::REGULAR;
 
+    /// 500
     pub const MEDIUM: FontWeight = FontWeight(500);
 
+    /// 600
     pub const SEMI_BOLD: FontWeight = FontWeight(600);
 
+    /// 700
     pub const BOLD: FontWeight = FontWeight(700);
 
+    /// 800
     pub const EXTRA_BOLD: FontWeight = FontWeight(800);
 
+    /// 900
     pub const BLACK: FontWeight = FontWeight(900);
+    /// 900
     pub const HEAVY: FontWeight = FontWeight::BLACK;
 
+    /// 950
     pub const EXTRA_BLACK: FontWeight = FontWeight(950);
 
     /// Create a new `FontWeight` with a custom value.

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -244,14 +244,23 @@ impl<'a> GradientStops for (Color, Color, Color, Color, Color, Color) {
 }
 
 impl UnitPoint {
+    /// `(0.0, 0.0)`
     pub const TOP_LEFT: UnitPoint = UnitPoint::new(0.0, 0.0);
+    /// `(0.5, 0.0)`
     pub const TOP: UnitPoint = UnitPoint::new(0.5, 0.0);
+    /// `(1.0, 0.0)`
     pub const TOP_RIGHT: UnitPoint = UnitPoint::new(1.0, 0.0);
+    /// `(0.0, 0.5)`
     pub const LEFT: UnitPoint = UnitPoint::new(0.0, 0.5);
+    /// `(0.5, 0.5)`
     pub const CENTER: UnitPoint = UnitPoint::new(0.5, 0.5);
+    /// `(1.0, 0.5)`
     pub const RIGHT: UnitPoint = UnitPoint::new(1.0, 0.5);
+    /// `(0.0, 1.0)`
     pub const BOTTOM_LEFT: UnitPoint = UnitPoint::new(0.0, 1.0);
+    /// `(0.5, 1.0)`
     pub const BOTTOM: UnitPoint = UnitPoint::new(0.5, 1.0);
+    /// `(1.0, 1.0)`
     pub const BOTTOM_RIGHT: UnitPoint = UnitPoint::new(1.0, 1.0);
 
     /// Create a new UnitPoint.

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -12,6 +12,7 @@
 //! [`piet-coregraphics`]: https://crates.io/crates/piet-coregraphics
 //! [`piet-direct2d`]: https://crates.io/crates/piet-direct2d
 
+#![warn(missing_docs, broken_intra_doc_links)]
 #![deny(clippy::trivially_copy_pass_by_ref)]
 
 pub use kurbo;

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -36,6 +36,7 @@ pub struct NullTextLayoutBuilder;
 
 impl NullRenderContext {
     #[allow(clippy::new_without_default)]
+    #[doc(hidden)]
     pub fn new() -> NullRenderContext {
         NullRenderContext(NullText)
     }

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -33,6 +33,7 @@ pub enum ImageFormat {
 }
 
 impl ImageFormat {
+    /// The number of bytes required to represent a pixel in this format.
     pub fn bytes_per_pixel(self) -> usize {
         match self {
             ImageFormat::Grayscale => 1,
@@ -64,6 +65,8 @@ where
 
     /// An associated factory for creating text layouts and related resources.
     type Text: Text<TextLayout = Self::TextLayout>;
+
+    /// The type use to represent text layout objects.
     type TextLayout: TextLayout;
 
     /// The associated type of an image.
@@ -131,6 +134,9 @@ where
     /// are clipped by the shape.
     fn clip(&mut self, shape: impl Shape);
 
+    /// Returns a reference to a shared [`Text`] object.
+    ///
+    /// This provides access to the text API.
     fn text(&mut self) -> &mut Self::Text;
 
     /// Draw a text layout.
@@ -240,6 +246,7 @@ pub trait IntoBrush<P: RenderContext>
 where
     P: ?Sized,
 {
+    #[doc(hidden)]
     fn make_brush<'a>(&'a self, piet: &mut P, bbox: impl FnOnce() -> Rect) -> Cow<'a, P::Brush>;
 }
 
@@ -280,9 +287,13 @@ impl<P: RenderContext> IntoBrush<P> for Color {
 /// ```
 #[derive(Debug, Clone)]
 pub enum PaintBrush {
+    /// A [`Color`].
     Color(Color),
+    /// A [`LinearGradient`].
     Linear(LinearGradient),
+    /// A [`RadialGradient`].
     Radial(RadialGradient),
+    /// A [`FixedGradient`].
     Fixed(FixedGradient),
 }
 

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -64,7 +64,10 @@ pub enum LineJoin {
     ///
     /// This is also currently the default `LineJoin`; you should only need to
     /// construct it if you need to customize the `limit`.
-    Miter { limit: f64 },
+    Miter {
+        /// The maximum distance between the inner and outer stroke edges before beveling.
+        limit: f64,
+    },
     /// The two lines are joined by a circular arc.
     Round,
     /// The two segments are capped with [`LineCap::Butt`], and the notch is filled.

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -163,6 +163,7 @@ pub enum TextAttribute {
 
 /// A trait for laying out text.
 pub trait TextLayoutBuilder: Sized {
+    /// The type of the generated [`TextLayout`].
     type Out: TextLayout;
 
     /// Set a max width for this layout.
@@ -274,6 +275,9 @@ pub trait TextLayoutBuilder: Sized {
         attribute: impl Into<TextAttribute>,
     ) -> Self;
 
+    /// Attempt to build the [`TextLayout`].
+    ///
+    /// This should only fail in exceptional circumstances.
     fn build(self) -> Result<Self::Out, Error>;
 }
 
@@ -288,7 +292,12 @@ pub enum TextAlignment {
     /// Text is aligned to the right edge in left-to-right scripts, and the
     /// left edge in right-to-left scripts.
     End,
+    /// Lines are centered in the available space.
     Center,
+    /// Line width is increased to fill available space.
+    ///
+    /// This may be achieved through increases in word or character spacing,
+    /// or through ligatures where available.
     Justified,
 }
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -102,6 +102,7 @@ pub fn resolve_range(range: impl RangeBounds<usize>, len: usize) -> Range<usize>
 /// Extent to which to expand the blur.
 const BLUR_EXTENT: f64 = 2.5;
 
+/// Calculate the size required paint a blurred rect.
 pub fn size_for_blurred_rect(rect: Rect, radius: f64) -> Size {
     let padding = BLUR_EXTENT * radius;
     let rect_padded = rect.inflate(padding, padding);
@@ -150,6 +151,7 @@ fn compute_erf7(x: f64) -> f64 {
 
 /// A type backends can use to represent the default values for a `TextLayout`
 #[non_exhaustive]
+#[allow(missing_docs)]
 pub struct LayoutDefaults {
     pub font: FontFamily,
     pub font_size: f64,


### PR DESCRIPTION
This also adds docs or explicit #[allow(missing_docs)] as
appropriate, and a few small, related fixups.