### PR TITLE
Rework dash representation in StrokeStyle

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -358,7 +358,7 @@ impl Attrs<'_> {
                 LineCap::Butt => (),
             }
             if !style.dash_pattern.is_empty() {
-                node.assign("stroke-dasharray", style.dash_pattern.clone().into_owned());
+                node.assign("stroke-dasharray", style.dash_pattern.to_vec());
             }
             if style.dash_offset != 0.0 {
                 node.assign("stroke-dashoffset", style.dash_offset);


### PR DESCRIPTION
This is all about ergonomics. I have two goals: to allow
StrokeStyle to be created in a const context, and to make
StrokeStyle cheaply cloneable.

This was a *giant headache*. I tried a Cow, but that didn't work,
because you can't set it in a const context, because it might
call a destructor.

This solution hacks around that. We have separate fields for the
const and non-const case; the non-const case overrides the const
case, but in practice they are unlikely to be used together.