### PR TITLE
Use absolute index to get whitespaceless width & don't sub x coord

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -548,10 +548,9 @@ impl CairoTextLayout {
             //HACK: This check for RTL is to work around https://gitlab.gnome.org/GNOME/pango/-/issues/544
             let non_ws_width = if trailing_whitespace != 0 && !self.is_rtl {
                 //FIXME: this probably isn't correct for RTL
-                let ws_start = line.index_to_x((start_offset + trimmed_len) as i32, false);
-                ws_start.saturating_sub(logical_rect.x)
+                line.index_to_x((start_offset + trimmed_len) as i32, false)
             } else {
-                logical_rect.width - logical_rect.x
+                logical_rect.width
             };
             widest_whitespaceless_width = widest_whitespaceless_width.max(non_ws_width);
 

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -545,9 +545,10 @@ impl CairoTextLayout {
             let trimmed_len = line_text.trim_end().len();
             let trailing_whitespace = line_text[trimmed_len..].len();
 
-            let non_ws_width = if trailing_whitespace != 0 {
+            //HACK: This check for RTL is to work around https://gitlab.gnome.org/GNOME/pango/-/issues/544
+            let non_ws_width = if trailing_whitespace != 0 && !self.is_rtl {
                 //FIXME: this probably isn't correct for RTL
-                let ws_start = line.index_to_x(trimmed_len as i32, false);
+                let ws_start = line.index_to_x((start_offset + trimmed_len) as i32, false);
                 ws_start.saturating_sub(logical_rect.x)
             } else {
                 logical_rect.width - logical_rect.x


### PR DESCRIPTION
It seems that the index argument expected here is relative to the start of the text, not the start of the line. Prior to this change long lines w/trailing whitespace would not correctly affect the widest whitespaceless width as their whitespace start index would index past the first line and into part of the second line resulting in a significantly smaller value.

Addresses https://github.com/linebender/druid/issues/1753