### PR TITLE
[cairo] Fix for big-endian systems

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -245,9 +245,14 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                 match format {
                     ImageFormat::Rgb => {
                         for x in 0..width {
-                            data[dst_off + x * 4 + 0] = buf[src_off + x * 3 + 2];
-                            data[dst_off + x * 4 + 1] = buf[src_off + x * 3 + 1];
-                            data[dst_off + x * 4 + 2] = buf[src_off + x * 3 + 0];
+                            write_rgb(
+                                &mut data,
+                                dst_off,
+                                x,
+                                buf[src_off + x * 3 + 0],
+                                buf[src_off + x * 3 + 1],
+                                buf[src_off + x * 3 + 2],
+                            );
                         }
                     }
                     ImageFormat::RgbaPremul => {
@@ -255,10 +260,15 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                         // hope that LLVM generates pretty good code for this.
                         // TODO: consider adding BgraPremul format.
                         for x in 0..width {
-                            data[dst_off + x * 4 + 0] = buf[src_off + x * 4 + 2];
-                            data[dst_off + x * 4 + 1] = buf[src_off + x * 4 + 1];
-                            data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
-                            data[dst_off + x * 4 + 3] = buf[src_off + x * 4 + 3];
+                            write_rgba(
+                                &mut data,
+                                dst_off,
+                                x,
+                                buf[src_off + x * 4 + 0],
+                                buf[src_off + x * 4 + 1],
+                                buf[src_off + x * 4 + 2],
+                                buf[src_off + x * 4 + 3],
+                            );
                         }
                     }
                     ImageFormat::RgbaSeparate => {
@@ -268,17 +278,27 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
                         }
                         for x in 0..width {
                             let a = buf[src_off + x * 4 + 3];
-                            data[dst_off + x * 4 + 0] = premul(buf[src_off + x * 4 + 2], a);
-                            data[dst_off + x * 4 + 1] = premul(buf[src_off + x * 4 + 1], a);
-                            data[dst_off + x * 4 + 2] = premul(buf[src_off + x * 4 + 0], a);
-                            data[dst_off + x * 4 + 3] = a;
+                            write_rgba(
+                                &mut data,
+                                dst_off,
+                                x,
+                                premul(buf[src_off + x * 4 + 0], a),
+                                premul(buf[src_off + x * 4 + 1], a),
+                                premul(buf[src_off + x * 4 + 2], a),
+                                a,
+                            );
                         }
                     }
                     ImageFormat::Grayscale => {
                         for x in 0..width {
-                            data[dst_off + x * 4 + 0] = buf[src_off + x];
-                            data[dst_off + x * 4 + 1] = buf[src_off + x];
-                            data[dst_off + x * 4 + 2] = buf[src_off + x];
+                            write_rgb(
+                                &mut data,
+                                dst_off,
+                                x,
+                                buf[src_off + x],
+                                buf[src_off + x],
+                                buf[src_off + x],
+                            );
                         }
                     }
                     _ => return Err(Error::NotSupported),
@@ -498,4 +518,21 @@ fn compute_blurred_rect(rect: Rect, radius: f64) -> (ImageSurface, Point) {
     std::mem::drop(data);
     let origin = rect_exp.origin();
     (image, origin)
+}
+
+fn write_rgba(data: &mut [u8], offset: usize, x: usize, r: u8, g: u8, b: u8, a: u8) {
+    // From the cairo docs for CAIRO_FORMAT_ARGB32:
+    // > each pixel is a 32-bit quantity, with alpha in the upper 8 bits, then red,
+    // > then green, then blue. The 32-bit quantities are stored native-endian.
+    let (a, r, g, b) = (u32::from(a), u32::from(r), u32::from(g), u32::from(b));
+    let pixel = a << 24 | r << 16 | g << 8 | b;
+
+    let pixel_offset = offset + 4 * x;
+    data[pixel_offset..pixel_offset + 4].copy_from_slice(&pixel.to_ne_bytes());
+}
+
+fn write_rgb(data: &mut [u8], offset: usize, x: usize, r: u8, g: u8, b: u8) {
+    // From the cairo docs for CAIRO_FORMAT_RGB24:
+    //  each pixel is a 32-bit quantity, with the upper 8 bits unused.
+    write_rgba(data, offset, x, r, g, b, 0);
 }

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -516,18 +516,18 @@ fn compute_blurred_rect(rect: Rect, radius: f64) -> (ImageSurface, Point) {
     (image, origin)
 }
 
-fn write_rgba(data: &mut [u8], x: usize, r: u8, g: u8, b: u8, a: u8) {
+fn write_rgba(data: &mut [u8], column: usize, r: u8, g: u8, b: u8, a: u8) {
     // From the cairo docs for CAIRO_FORMAT_ARGB32:
     // > each pixel is a 32-bit quantity, with alpha in the upper 8 bits, then red,
     // > then green, then blue. The 32-bit quantities are stored native-endian.
     let (a, r, g, b) = (u32::from(a), u32::from(r), u32::from(g), u32::from(b));
     let pixel = a << 24 | r << 16 | g << 8 | b;
 
-    data[4 * x..4 * (x + 1)].copy_from_slice(&pixel.to_ne_bytes());
+    data[4 * column..4 * (column + 1)].copy_from_slice(&pixel.to_ne_bytes());
 }
 
-fn write_rgb(data: &mut [u8], x: usize, r: u8, g: u8, b: u8) {
+fn write_rgb(data: &mut [u8], column: usize, r: u8, g: u8, b: u8) {
     // From the cairo docs for CAIRO_FORMAT_RGB24:
     //  each pixel is a 32-bit quantity, with the upper 8 bits unused.
-    write_rgba(data, x, r, g, b, 0);
+    write_rgba(data, column, r, g, b, 0);
 }


### PR DESCRIPTION
Cairo defines pixels as "a 32-bit quantity [...] stored in
native-endian". However, the existing code was treating a pixel as four
8-bit quantities. Put differently, it was hardcoding little endian.

This commit changes the code to first calculate the pixel value as an
u32 and then use u32::to_ne_bytes() to get back to "the world of bytes".
For readability, this is done in a new helper function.

I did not actually check if this fixes anything on big endian, but at
least it does not change anything for little endian according to the
test-pictures examples.
    
Fixes: https://github.com/linebender/piet/issues/224
Signed-off-by: Uli Schlachter <psychon@znc.in>