### PR TITLE
[cairo] Add a simple criterion benchmark

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -24,3 +24,8 @@ xi-unicode = "0.3.0"
 [dev-dependencies]
 piet = { version = "0.4.0", path = "../piet", features = ["samples"] }
 cairo-rs = { version = "0.9.1", default-features = false, features = ["png"] }
+criterion = "0.3"
+
+[[bench]]
+name = "make_image"
+harness = false

--- a/piet-cairo/benches/make_image.rs
+++ b/piet-cairo/benches/make_image.rs
@@ -1,8 +1,8 @@
-use std::convert::{TryFrom, TryInto};
-use piet::{ImageFormat, RenderContext};
-use piet_cairo::CairoRenderContext;
 use cairo::{Context, Format, ImageSurface};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use piet::{ImageFormat, RenderContext};
+use piet_cairo::CairoRenderContext;
+use std::convert::{TryFrom, TryInto};
 
 fn fill_random(data: &mut [u8]) {
     // A simple LCG with parameters from Wikipedia. See glibc/ ANSI C, CodeWarrior, ... in
@@ -36,7 +36,8 @@ pub fn bench_make_image(c: &mut Criterion) {
         fill_random(&mut data[..]);
 
         c.bench_function(&format!("make_image_{}_{:?}", name, format), |b| {
-            let unused_surface = ImageSurface::create(Format::ARgb32, 1, 1).expect("Can't create surface");
+            let unused_surface =
+                ImageSurface::create(Format::ARgb32, 1, 1).expect("Can't create surface");
             let cr = Context::new(&unused_surface);
             let mut piet_context = CairoRenderContext::new(&cr);
 

--- a/piet-cairo/benches/make_image.rs
+++ b/piet-cairo/benches/make_image.rs
@@ -4,6 +4,23 @@ use piet_cairo::CairoRenderContext;
 use cairo::{Context, Format, ImageSurface};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+fn fill_random(data: &mut [u8]) {
+    // A simple LCG with parameters from Wikipedia. See glibc/ ANSI C, CodeWarrior, ... in
+    // https://en.wikipedia.org/w/index.php?title=Linear_congruential_generator&oldid=1028647893#Parameters_in_common_use
+    let mut state: u32 = 123456789;
+    let m: u32 = 1 << 31;
+    let a: u32 = 1103515245;
+    let c: u32 = 12345;
+
+    let mut next_number = || {
+        state = (a * state + c) % m;
+        // Take a higher byte since it is more random than the low bytes
+        (state >> 16) as u8
+    };
+
+    data.iter_mut().for_each(|b| *b = next_number());
+}
+
 pub fn bench_make_image(c: &mut Criterion) {
     let formats = [
         (1, ImageFormat::Grayscale),
@@ -15,7 +32,8 @@ pub fn bench_make_image(c: &mut Criterion) {
         let (name, width, height) = ("2160p", 3840, 2160);
         let bytes = width * height * bpp;
 
-        let data = vec![0; usize::try_from(bytes).expect("Should fit into usize")];
+        let mut data = vec![0; usize::try_from(bytes).expect("Should fit into usize")];
+        fill_random(&mut data[..]);
 
         c.bench_function(&format!("make_image_{}_{:?}", name, format), |b| {
             let unused_surface = ImageSurface::create(Format::ARgb32, 1, 1).expect("Can't create surface");

--- a/piet-cairo/benches/make_image.rs
+++ b/piet-cairo/benches/make_image.rs
@@ -1,0 +1,36 @@
+use std::convert::{TryFrom, TryInto};
+use piet::{ImageFormat, RenderContext};
+use piet_cairo::CairoRenderContext;
+use cairo::{Context, Format, ImageSurface};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+pub fn bench_make_image(c: &mut Criterion) {
+    let formats = [
+        (1, ImageFormat::Grayscale),
+        (3, ImageFormat::Rgb),
+        (4, ImageFormat::RgbaSeparate),
+        (4, ImageFormat::RgbaPremul),
+    ];
+    for &(bpp, format) in formats.iter() {
+        let (name, width, height) = ("2160p", 3840, 2160);
+        let bytes = width * height * bpp;
+
+        let data = vec![0; usize::try_from(bytes).expect("Should fit into usize")];
+
+        c.bench_function(&format!("make_image_{}_{:?}", name, format), |b| {
+            let unused_surface = ImageSurface::create(Format::ARgb32, 1, 1).expect("Can't create surface");
+            let cr = Context::new(&unused_surface);
+            let mut piet_context = CairoRenderContext::new(&cr);
+
+            let width = black_box(width.try_into().unwrap());
+            let height = black_box(height.try_into().unwrap());
+            let data = black_box(&data);
+            let format = black_box(format);
+
+            b.iter(|| piet_context.make_image(width, height, data, format));
+        });
+    }
+}
+
+criterion_group!(benches, bench_make_image);
+criterion_main!(benches);


### PR DESCRIPTION
This adds a simple benchmark for piet-cairo's make_image function.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

Here is the output when I run this locally (`cargo bench`):
```
     Running /tmp/piet/target/release/deps/make_image-e4985702849e1350
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

make_image_2160p_Grayscale                                                                            
                        time:   [35.601 ms 35.607 ms 35.614 ms]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

make_image_2160p_Rgb    time:   [35.986 ms 35.989 ms 35.993 ms]                                 
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking make_image_2160p_RgbaSeparate: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.9s, or reduce sample count to 80.
make_image_2160p_RgbaSeparate                                                                            
                        time:   [59.307 ms 59.318 ms 59.331 ms]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

Benchmarking make_image_2160p_RgbaPremul: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.1s, or reduce sample count to 90.
make_image_2160p_RgbaPremul                                                                            
                        time:   [50.457 ms 50.478 ms 50.500 ms]
```
And this is what I get when I afterwards run this with the code from #448:
```
     Running /tmp/piet/target/release/deps/make_image-e4985702849e1350
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the 'html_reports' feature in your Cargo.toml.

make_image_2160p_Grayscale                                                                            
                        time:   [14.113 ms 14.119 ms 14.127 ms]
                        change: [-60.366% -60.348% -60.325%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

make_image_2160p_Rgb    time:   [20.809 ms 20.857 ms 20.918 ms]                                 
                        change: [-42.177% -42.047% -41.879%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

make_image_2160p_RgbaSeparate                                                                            
                        time:   [33.815 ms 33.868 ms 33.937 ms]
                        change: [-42.987% -42.905% -42.797%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

make_image_2160p_RgbaPremul                                                                            
                        time:   [28.981 ms 28.989 ms 28.997 ms]
                        change: [-42.601% -42.572% -42.542%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```
That should settle any worries for performance regressions. :-)

The output talks about html reports that will be disabled in a future version. Here is an excerpt from one of these reports (RgbaSeparate; blue are the measurements for my PR and red are for `master`):

![foo](https://user-images.githubusercontent.com/89482/123507423-866afa00-d669-11eb-9e8b-31e406d89830.png)

Note: I have no mentionable experience with criterion and just "bolted this together" from the docs. The benchmark only feeds this all-zero pixels. No idea if that makes a difference nor what a good alternative would be (is "all `0x80` better? Why?).