### PR TITLE
Make gradient stops hashable

### DIFF
--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 /// Currently this is only a 32 bit RGBA value, but it will likely
 /// extend to some form of wide-gamut colorspace, and in the meantime
 /// is useful for giving programs proper type.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Color {
     #[doc(hidden)]

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -25,6 +25,7 @@
 //! [unit square]: https://en.wikipedia.org/wiki/Unit_square
 
 use std::borrow::Cow;
+use std::hash::{Hash, Hasher};
 
 use kurbo::{Point, Rect, Size, Vec2};
 
@@ -450,4 +451,19 @@ fn equalize_sides_preserving_center(rect: Rect, new_len: f64) -> Rect {
     let size = Size::new(new_len, new_len);
     let origin = rect.center() - size.to_vec2() / 2.;
     Rect::from_origin_size(origin, size)
+}
+
+impl PartialEq for GradientStop {
+    fn eq(&self, other: &GradientStop) -> bool {
+        self.color == other.color && self.pos.to_bits() == other.pos.to_bits()
+    }
+}
+
+impl Eq for GradientStop {}
+
+impl Hash for GradientStop {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.color.hash(state);
+        self.pos.to_bits().hash(state);
+    }
 }


### PR DESCRIPTION
Implement Hash and Eq traits on gradient stops, which implies doing the
same for colors. This facilitates creating a cache of baked gradient
ramps.

Closes #450