### PR TITLE
Remove deprecations

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -477,7 +477,6 @@ impl<'a> CairoRenderContext<'a> {
     }
 }
 
-#[allow(deprecated)]
 fn convert_line_cap(line_cap: LineCap) -> cairo::LineCap {
     match line_cap {
         LineCap::Butt => cairo::LineCap::Butt,

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -148,7 +148,6 @@ pub(crate) fn gradient_stop_to_d2d(stop: &GradientStop) -> D2D1_GRADIENT_STOP {
     }
 }
 
-#[allow(deprecated)]
 fn convert_line_cap(line_cap: LineCap) -> D2D1_CAP_STYLE {
     match line_cap {
         LineCap::Butt => D2D1_CAP_STYLE_FLAT,

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -94,13 +94,6 @@ pub struct D2DTextLayoutBuilder {
 }
 
 impl D2DText {
-    /// Create a new factory that satisfies the piet `Text` trait given
-    /// the (platform-specific) dwrite factory.
-    #[deprecated(since = "0.4.1", note = "Use new_with_shared_fonts instead")]
-    pub fn new(dwrite: DwriteFactory) -> D2DText {
-        D2DText::new_with_shared_fonts(dwrite, None)
-    }
-
     /// Create a new text factory.
     ///
     /// The `loaded_fonts` object is optional; if you pass `None` we will create a

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -351,7 +351,6 @@ impl Attrs<'_> {
                 LineCap::Round => {
                     node.assign("stroke-linecap", "round");
                 }
-                #[allow(deprecated)]
                 LineCap::Square => {
                     node.assign("stroke-linecap", "square");
                 }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -101,7 +101,6 @@ impl<T> WrapError<T> for Result<T, JsValue> {
 }
 
 fn convert_line_cap(line_cap: LineCap) -> &'static str {
-    #[allow(deprecated)]
     match line_cap {
         LineCap::Butt => "butt",
         LineCap::Round => "round",

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -190,17 +190,6 @@ impl StrokeStyle {
         self
     }
 
-    /// Builder-style method to set the line dash.
-    ///
-    /// Dash style is represented as a vector of alternating on-off lengths,
-    /// and an offset length.
-    #[deprecated(since = "0.4.0", note = "Use dash_offset and dash_lengths instead")]
-    #[doc(hidden)]
-    pub fn dash(mut self, dashes: Vec<f64>, offset: f64) -> Self {
-        self.dash_pattern.alloc = Some(dashes.into());
-        self.dash_offset(offset)
-    }
-
     /// Set the [`LineJoin`].
     pub fn set_line_join(&mut self, line_join: LineJoin) {
         self.line_join = line_join;
@@ -209,16 +198,6 @@ impl StrokeStyle {
     /// Set the [`LineCap`].
     pub fn set_line_cap(&mut self, line_cap: LineCap) {
         self.line_cap = line_cap;
-    }
-
-    #[deprecated(
-        since = "0.4.0",
-        note = "Use set_dash_offset and set_dash_pattern instead"
-    )]
-    #[doc(hidden)]
-    pub fn set_dash(&mut self, dashes: Vec<f64>, offset: f64) {
-        self.dash_offset = offset;
-        self.dash_pattern.alloc = Some(dashes.into());
     }
 
     /// Set the dash offset.


### PR DESCRIPTION
These were marked as deprecated in 0.4.1 and can now be removed.