### PR TITLE
Build on OpenBSD

### DIFF
--- a/piet-cairo/README.md
+++ b/piet-cairo/README.md
@@ -26,6 +26,12 @@ On macOS with Homebrew, the following should work:
 brew install cairo
 ```
 
+On OpenBSD, the library can be installed from official packages:
+```shell
+pkg_add cairo
+```
+A pkg-config file is provided as usual and cairo-rs will build as expected.
+
 TODO: nicer installation instructions (contributions welcome)
 
 [Cairo]: https://www.cairographics.org/

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -623,7 +623,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "openbsd"))]
     fn test_hit_test_point_complex_1() {
         // this input caused an infinite loop in the binary search when test position
         // > 21.0 && < 28.0

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -38,7 +38,7 @@ piet-web = { version = "=0.5.0-pre1", path = "../piet-web", optional = true }
 cfg-if = "1.0"
 png = { version = "0.17", optional = true }
 
-[target.'cfg(target_os="linux")'.dependencies]
+[target.'cfg(any(target_os="linux", target_os="openbsd"))'.dependencies]
 piet-cairo = { version = "=0.5.0-pre1", path = "../piet-cairo" }
 cairo-rs = { version = "0.14.0", default_features = false }
 cairo-sys-rs = { version = "0.14.0" }

--- a/piet-common/README.md
+++ b/piet-common/README.md
@@ -4,8 +4,8 @@
 [Piet][] 2D graphics API, for the current platform.
 
 On Windows, the backend will be [piet-direct2d][], on macOS
-[piet-coregraphics][], and on linux [piet-cairo][]. The [piet-web][] backend
-can be selected with the `web` feature.
+[piet-coregraphics][], and on linux as well as OpenBSD [piet-cairo][].
+The [piet-web][] backend can be selected with the `web` feature.
 
 [Piet]: https://crates.io/crates/piet
 [piet-direct2d]: https://crates.io/crates/piet-direct2d

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -35,7 +35,7 @@ cfg_if::cfg_if! {
      if #[cfg(any(feature = "web", target_arch = "wasm32"))] {
         #[path = "web_back.rs"]
         mod backend;
-    } else if #[cfg(target_os = "linux")] {
+    } else if #[cfg(any(target_os = "linux", target_os = "openbsd"))] {
         #[path = "cairo_back.rs"]
         mod backend;
     } else if #[cfg(target_os = "macos")] {


### PR DESCRIPTION
The cairo backend works without any platform specific modifications,
just like on Linux.