### PR TITLE
Always disable font smoothing when creating a CoreGraphicsContext

### DIFF
--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -87,6 +87,7 @@ impl<'a> CoreGraphicsContext<'a> {
         text: Option<CoreGraphicsText>,
     ) -> CoreGraphicsContext {
         ctx.save();
+        ctx.set_allows_font_smoothing(false);
         if let Some(height) = height {
             let xform = Affine::FLIP_Y * Affine::translate((0.0, -height));
             ctx.concat_ctm(to_cgaffine(xform));


### PR DESCRIPTION
This makes all text rendered match the rendering used by Sketch. There's also [this blog post](https://tonsky.me/blog/monitors/#turn-off-font-smoothing) by Tonsky that discusses it.

To me this seems reasonable to just disable for all apps. But could also make changing this a custom option that people can opt-in to? (Although I'd maybe still argue for defaulting to false)

Here are some `@2x` screenshots taken in Pages (which uses font smoothing if it's turned on system-wide) and Sketch (which always turns it off)
![Artboard](https://user-images.githubusercontent.com/1976330/139597621-34c5bf93-fa06-43a0-a2e5-3742bcab132d.png)
