### PR TITLE
Cache CTFont handles on macOS

### DIFF
--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -18,6 +18,7 @@ core-graphics = "0.22.2"
 core-text = "19.0.0"
 core-foundation = "0.9"
 core-foundation-sys = "0.8"
+associative-cache = "1.0"
 
 [dev-dependencies]
 piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -6,7 +6,7 @@ use std::ops::{DerefMut, Range, RangeBounds};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use associative_cache::{AssociativeCache, Capacity1024, HashFourWay, RoundRobinReplacement};
+use associative_cache::{AssociativeCache, Capacity64, HashFourWay, RoundRobinReplacement};
 use core_foundation::base::TCFType;
 use core_foundation::dictionary::{CFDictionary, CFMutableDictionary};
 use core_foundation::number::CFNumber;
@@ -48,17 +48,12 @@ struct SharedTextState {
     inner: Arc<Mutex<TextState>>,
 }
 
+type Cache<K, V> = AssociativeCache<K, V, Capacity64, HashFourWay, RoundRobinReplacement>;
+
 struct TextState {
     collection: FontCollection,
-    family_cache: AssociativeCache<
-        String,
-        Option<FontFamily>,
-        Capacity1024,
-        HashFourWay,
-        RoundRobinReplacement,
-    >,
-    font_cache:
-        AssociativeCache<CoreTextFontKey, CTFont, Capacity1024, HashFourWay, RoundRobinReplacement>,
+    family_cache: Cache<String, Option<FontFamily>>,
+    font_cache: Cache<CoreTextFontKey, CTFont>,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
This implements caching of `CTFont` handles, not unlike the current font-family cache. This solves a real bottleneck I have in Psst (where creating lot of labels used to be really slow). I've used the `associative-cache` crate, because it is used in the Direct2D backend already (for caching gradients), and also switched the font family cache to it, for consistency.

Thanks!