### PR TITLE
Add piet-common reference to main documentation

### DIFF
--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -13,6 +13,11 @@
 //! to be reused in an approximately consistent way. Various such implementations
 //! exist, such as [`piet-cairo`], [`piet-coregraphics`], and [`piet-direct2d`].
 //!
+//! If you are interested in using piet to target multiple platforms,
+//! [`piet-common`] is a utility crate that re-exports an appropriate
+//! backend based on the compile target, and provides convenience
+//! types and methods for setting up a [`RenderContext`].
+//!
 //! [`PostScript`]: https://en.wikipedia.org/wiki/PostScript
 //! [`piet-common`]: https://docs.rs/piet-common
 //! [`piet-cairo`]: https://crates.io/crates/piet-cairo

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -4,13 +4,17 @@
 //! graphics API, in the tradition of [`PostScript`]. It is built on top of
 //! [`kurbo`], a 2D geometry library.
 //!
-//! The main interface is the [`RenderContext`] trait.
+//! The main interface is the [`RenderContext`] trait. Another useful place
+//! to look at if you're getting started would be the `Device` and
+//! `BitmapTarget` documentation on [`piet-common`], to create `RenderContext`
+//! objects and extract rendered pixels from them.
 //!
 //! This API can be implemented on various platforms, allowing drawing code
 //! to be reused in an approximately consistent way. Various such implementations
 //! exist, such as [`piet-cairo`], [`piet-coregraphics`], and [`piet-direct2d`].
 //!
 //! [`PostScript`]: https://en.wikipedia.org/wiki/PostScript
+//! [`piet-common`]: https://docs.rs/piet-common
 //! [`piet-cairo`]: https://crates.io/crates/piet-cairo
 //! [`piet-coregraphics`]: https://crates.io/crates/piet-coregraphics
 //! [`piet-direct2d`]: https://crates.io/crates/piet-direct2d

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -4,10 +4,7 @@
 //! graphics API, in the tradition of [`PostScript`]. It is built on top of
 //! [`kurbo`], a 2D geometry library.
 //!
-//! The main interface is the [`RenderContext`] trait. Another useful place
-//! to look at if you're getting started would be the `Device` and
-//! `BitmapTarget` documentation on [`piet-common`], to create `RenderContext`
-//! objects and extract rendered pixels from them.
+//! The main interface is the [`RenderContext`] trait.
 //!
 //! This API can be implemented on various platforms, allowing drawing code
 //! to be reused in an approximately consistent way. Various such implementations


### PR DESCRIPTION
Currently there is no direct link to `piet-common`'s documentation from
the main docs page, and that is quite annoying to navigate if you're
referencing both a lot.

This adds that, along with some newbie guidance for how to create
`RenderContext`s for those who are getting started.