### PR TITLE
Add warning about ImageFormat and backend compat

### DIFF
--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -102,6 +102,8 @@ impl<'a> BitmapTarget<'a> {
     /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were
     /// copied, returns the number of bytes written. If `buf` wasn't big enough, returns an error
     /// and doesn't write anything.
+    ///
+    /// Note: caller is responsible for making sure the requested `ImageFormat` is supported.
     pub fn copy_raw_pixels(
         &mut self,
         fmt: ImageFormat,
@@ -164,6 +166,8 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get an in-memory pixel buffer from the bitmap.
+    ///
+    /// Note: caller is responsible for making sure the requested `ImageFormat` is supported.
     // Clippy complains about a to_xxx method taking &mut self. Semantically speaking, this is not
     // really a mutation, so we'll keep the name. Consider using interior mutability in the future.
     #[allow(clippy::wrong_self_convention)]

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -104,6 +104,8 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get an in-memory pixel buffer from the bitmap.
+    ///
+    /// Note: caller is responsible for making sure the requested `ImageFormat` is supported.
     // Clippy complains about a to_xxx method taking &mut self. Semantically speaking, this is not
     // really a mutation, so we'll keep the name. Consider using interior mutability in the future.
     #[allow(clippy::wrong_self_convention)]
@@ -118,6 +120,8 @@ impl<'a> BitmapTarget<'a> {
     /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were
     /// copied, returns the number of bytes written. If `buf` wasn't big enough, returns an error
     /// and doesn't write anything.
+    ///
+    /// Note: caller is responsible for making sure the requested `ImageFormat` is supported.
     pub fn copy_raw_pixels(
         &mut self,
         fmt: ImageFormat,

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -146,6 +146,8 @@ impl<'a> BitmapTarget<'a> {
     }
 
     /// Get an in-memory pixel buffer from the bitmap.
+    ///
+    /// Note: caller is responsible for making sure the requested `ImageFormat` is supported.
     // Clippy complains about a to_xxx method taking &mut self. Semantically speaking, this is not
     // really a mutation, so we'll keep the name. Consider using interior mutability in the future.
     #[allow(clippy::wrong_self_convention)]
@@ -158,6 +160,8 @@ impl<'a> BitmapTarget<'a> {
     /// Get raw RGBA pixels from the bitmap by copying them into `buf`. If all the pixels were
     /// copied, returns the number of bytes written. If `buf` wasn't big enough, returns an error
     /// and doesn't write anything.
+    ///
+    /// Note: caller is responsible for making sure the requested `ImageFormat` is supported.
     pub fn copy_raw_pixels(
         &mut self,
         fmt: ImageFormat,


### PR DESCRIPTION
Currently, calling either of these functions will simply return `Error::NotSupported`
without any further explanation. This can lead one to believe that the function itself
is not supported on a given platform, rather than just the `ImageFormat`.

This change clarifies that this is the caller's responsibility in the documentation.