### PR TITLE
Implement text and bitmap images in piet-svg

### DIFF
--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 base64 = "0.13.0"
 font-kit = "0.10.1"
+image = { version = "0.23.10", default-features = false, features = ["png"] }
 piet = { version = "=0.5.0", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -9,8 +9,13 @@ repository = "https://github.com/linebender/piet"
 keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
+[features]
+default = []
+evcxr = ["evcxr_runtime"]
+
 [dependencies]
 base64 = "0.13.0"
+evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
 image = { version = "0.23.10", default-features = false, features = ["png"] }
 piet = { version = "=0.5.0", path = "../piet" }

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
+base64 = "0.13.0"
 font-kit = "0.10.1"
 piet = { version = "=0.5.0", path = "../piet" }
 rustybuzz = "0.4.0"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
+font-kit = "0.10.1"
 piet = { version = "=0.5.0", path = "../piet" }
+rustybuzz = "0.4.0"
 svg = "0.10.0"
 
 [dev-dependencies]

--- a/piet-svg/examples/basic-svg.rs
+++ b/piet-svg/examples/basic-svg.rs
@@ -9,7 +9,7 @@ fn main() {
         .nth(1)
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(0);
-    let mut piet = piet_svg::RenderContext::new();
+    let mut piet = piet_svg::RenderContext::new(None);
     samples::get(test_picture_number)
         .unwrap()
         .draw(&mut piet)

--- a/piet-svg/examples/basic-svg.rs
+++ b/piet-svg/examples/basic-svg.rs
@@ -9,11 +9,9 @@ fn main() {
         .nth(1)
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(0);
-    let mut piet = piet_svg::RenderContext::new(None);
-    samples::get(test_picture_number)
-        .unwrap()
-        .draw(&mut piet)
-        .unwrap();
+    let sample = samples::get(test_picture_number).unwrap();
+    let mut piet = piet_svg::RenderContext::new(sample.size());
+    sample.draw(&mut piet).unwrap();
     piet.finish().unwrap();
     piet.write(io::stdout()).unwrap();
 }

--- a/piet-svg/src/evcxr.rs
+++ b/piet-svg/src/evcxr.rs
@@ -6,7 +6,7 @@
 //! [`evcxr`]: https://github.com/google/evcxr
 //! [Jupyter Notebook]: https://jupyter-notebook.readthedocs.io/en/stable/notebook.html
 
-use piet::RenderContext;
+use piet::{kurbo::Size, RenderContext};
 
 impl evcxr_runtime::Display for crate::RenderContext {
     fn evcxr_display(&self) {
@@ -20,8 +20,11 @@ impl evcxr_runtime::Display for crate::RenderContext {
 /// Runs the function `f`, and displays the resulting `SVG`.
 ///
 /// For use within `evcxr_jupyter`.
-pub fn draw_evcxr(f: impl FnOnce(&mut crate::RenderContext)) -> impl evcxr_runtime::Display {
-    let mut ctx = crate::RenderContext::new();
+pub fn draw_evcxr(
+    size: Size,
+    f: impl FnOnce(&mut crate::RenderContext),
+) -> impl evcxr_runtime::Display {
+    let mut ctx = crate::RenderContext::new(size);
     f(&mut ctx);
     ctx.finish().unwrap();
     ctx

--- a/piet-svg/src/evcxr.rs
+++ b/piet-svg/src/evcxr.rs
@@ -1,0 +1,20 @@
+use piet::RenderContext;
+
+impl evcxr_runtime::Display for crate::RenderContext {
+    fn evcxr_display(&self) {
+        evcxr_runtime::mime_type("text/html").text(format!(
+            r#"<div style="display:flex;justify-content:center;">{}</div>"#,
+            self.display()
+        ))
+    }
+}
+
+/// Runs the function `f`, and displays the resulting `SVG`.
+///
+/// For use within `evcxr_jupyter`.
+pub fn draw_evcxr(f: impl FnOnce(&mut crate::RenderContext)) -> impl evcxr_runtime::Display {
+    let mut ctx = crate::RenderContext::new();
+    f(&mut ctx);
+    ctx.finish().unwrap();
+    ctx
+}

--- a/piet-svg/src/evcxr.rs
+++ b/piet-svg/src/evcxr.rs
@@ -1,3 +1,11 @@
+//! Helpers to make the SVG output of `piet-svg` easier to use from within `evcxr_jupyter`.
+//!
+//! [`evcxr`] is a Rust REPL. It also provides a Rust kernel for the [Jupyter Notebook] through
+//! `evcxr_jupyter`.
+//!
+//! [`evcxr`]: https://github.com/google/evcxr
+//! [Jupyter Notebook]: https://jupyter-notebook.readthedocs.io/en/stable/notebook.html
+
 use piet::RenderContext;
 
 impl evcxr_runtime::Display for crate::RenderContext {

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -244,13 +244,13 @@ impl piet::RenderContext for RenderContext {
         let anchor = match (layout.max_width, layout.alignment) {
             (width, TextAlignment::End) if width.is_finite() && width > 0. => {
                 x += width;
-                format!("text-anchor:end")
+                "text-anchor:end"
             }
             (width, TextAlignment::Center) if width.is_finite() && width > 0. => {
                 x += width * 0.5;
-                format!("text-anchor:middle")
+                "text-anchor:middle"
             }
-            _ => "".into(),
+            _ => "",
         };
 
         let text = svg::node::element::Text::new()

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -27,7 +27,7 @@ type Result<T> = std::result::Result<T, Error>;
 
 /// `piet::RenderContext` for generating SVG images
 pub struct RenderContext {
-    size: Option<Size>,
+    size: Size,
     stack: Vec<State>,
     state: State,
     doc: svg::Document,
@@ -37,9 +37,9 @@ pub struct RenderContext {
 
 impl RenderContext {
     /// Construct an empty `RenderContext`
-    pub fn new() -> Self {
+    pub fn new(size: Size) -> Self {
         Self {
-            size: None,
+            size,
             stack: Vec::new(),
             state: State::default(),
             doc: svg::Document::new(),
@@ -48,15 +48,10 @@ impl RenderContext {
         }
     }
 
-    /// Set the size that the SVG should render to
-    pub fn set_size(&mut self, size: Size) {
-        self.size = Some(size);
-    }
-
-    /// If a specific sized svg was requested, return that `Size`.
+    /// The size that the SVG will render at.
     ///
     /// The size is used to set the view box for the svg.
-    pub fn size(&self) -> Option<Size> {
+    pub fn size(&self) -> Size {
         self.size
     }
 
@@ -331,13 +326,12 @@ impl piet::RenderContext for RenderContext {
     }
 
     fn finish(&mut self) -> Result<()> {
-        if let Some(size) = self.size {
-            self.doc.assign("viewBox", (0, 0, size.width, size.height));
-            self.doc.assign(
-                "style",
-                format!("width:{}px;height:{}px;", size.width, size.height),
-            );
-        }
+        self.doc
+            .assign("viewBox", (0, 0, self.size.width, self.size.height));
+        self.doc.assign(
+            "style",
+            format!("width:{}px;height:{}px;", self.size.width, self.size.height),
+        );
 
         let text = (*self.text()).clone();
         let mut seen_fonts = text.seen_fonts.lock().unwrap();

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -345,8 +345,9 @@ impl piet::RenderContext for RenderContext {
         Err(Error::Unimplemented)
     }
 
-    fn blurred_rect(&mut self, _rect: Rect, _blur_radius: f64, _brush: &impl IntoBrush<Self>) {
-        unimplemented!()
+    fn blurred_rect(&mut self, rect: Rect, _blur_radius: f64, brush: &impl IntoBrush<Self>) {
+        // TODO blur (perhaps using SVG filters)
+        self.fill(rect, brush)
     }
 }
 

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -242,7 +242,7 @@ impl piet::TextLayout for TextLayout {
     }
 
     fn image_bounds(&self) -> Rect {
-        Rect::from((Point::from((0., 0.)), self.size()))
+        self.size().to_rect()
     }
 
     fn line_text(&self, line_number: usize) -> Option<&str> {

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -129,7 +129,6 @@ pub struct TextLayout {
     pub(crate) underline: bool,
     pub(crate) strikethrough: bool,
     size: Size,
-    face: (Arc<Vec<u8>>, u32),
 }
 
 impl TextLayout {
@@ -176,7 +175,6 @@ impl TextLayout {
             text_color: builder.text_color,
             underline: builder.underline,
             strikethrough: builder.strikethrough,
-            face: (face_bytes, idx),
             size,
         })
     }

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -1,11 +1,13 @@
 //! Text functionality for Piet svg backend
 
-use std::ops::RangeBounds;
+use std::{fs, ops::RangeBounds, sync::Arc};
 
 use piet::kurbo::{Point, Rect, Size};
 use piet::{
-    Error, FontFamily, HitTestPoint, HitTestPosition, LineMetric, TextAttribute, TextStorage,
+    Color, Error, FontFamily, FontStyle, FontWeight, HitTestPoint, HitTestPosition, LineMetric,
+    TextAlignment, TextAttribute, TextStorage,
 };
+use rustybuzz::{Face, UnicodeBuffer};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -32,83 +34,243 @@ impl piet::Text for Text {
         Ok(FontFamily::default())
     }
 
-    fn new_text_layout(&mut self, _text: impl TextStorage) -> TextLayoutBuilder {
-        TextLayoutBuilder
+    fn new_text_layout(&mut self, text: impl TextStorage) -> TextLayoutBuilder {
+        TextLayoutBuilder::new(text)
     }
 }
 
-#[derive(Debug)]
-pub struct TextLayoutBuilder;
+pub struct TextLayoutBuilder {
+    text: Arc<dyn TextStorage>,
+    alignment: TextAlignment,
+    font_family: FontFamily,
+    font_size: f64,
+    font_weight: FontWeight,
+    font_style: FontStyle,
+    text_color: Color,
+    underline: bool,
+    strikethrough: bool,
+    max_width: f64,
+}
+
+impl TextLayoutBuilder {
+    fn new(text: impl TextStorage) -> Self {
+        Self {
+            text: Arc::new(text),
+            alignment: TextAlignment::default(),
+            font_family: FontFamily::default(),
+            font_size: 12.,
+            font_weight: FontWeight::default(),
+            font_style: FontStyle::default(),
+            text_color: Color::BLACK,
+            underline: false,
+            strikethrough: false,
+            max_width: f64::INFINITY,
+        }
+    }
+}
 
 impl piet::TextLayoutBuilder for TextLayoutBuilder {
     type Out = TextLayout;
 
-    fn max_width(self, _width: f64) -> Self {
+    fn max_width(mut self, width: f64) -> Self {
+        // This is totally ignored for now when measuring.
+        self.max_width = width;
         self
     }
 
-    fn alignment(self, _alignment: piet::TextAlignment) -> Self {
+    fn alignment(mut self, alignment: piet::TextAlignment) -> Self {
+        self.alignment = alignment;
         self
     }
 
-    fn default_attribute(self, _attribute: impl Into<TextAttribute>) -> Self {
+    fn default_attribute(mut self, attribute: impl Into<TextAttribute>) -> Self {
+        match attribute.into() {
+            TextAttribute::FontFamily(font) => self.font_family = font,
+            TextAttribute::FontSize(size) => self.font_size = size,
+            TextAttribute::Weight(weight) => self.font_weight = weight,
+            TextAttribute::TextColor(color) => self.text_color = color,
+            TextAttribute::Style(style) => self.font_style = style,
+            TextAttribute::Underline(underline) => self.underline = underline,
+            TextAttribute::Strikethrough(strikethrough) => self.strikethrough = strikethrough,
+        }
+
         self
     }
 
     fn range_attribute(
-        self,
-        _range: impl RangeBounds<usize>,
-        _attribute: impl Into<TextAttribute>,
+        mut self,
+        range: impl RangeBounds<usize>,
+        attribute: impl Into<TextAttribute>,
     ) -> Self {
+        if range.contains(&0) && range.contains(&(self.text.len() - 1)) {
+            self = self.default_attribute(attribute)
+        } else {
+            // TODO non-full ranges are unsupported
+        }
         self
     }
 
     fn build(self) -> Result<TextLayout> {
-        Err(Error::NotSupported)
+        TextLayout::from_builder(self)
     }
 }
 
-/// SVG text layout (unimplemented)
-#[derive(Debug, Clone)]
-pub struct TextLayout;
+/// SVG text layout
+#[derive(Clone)]
+pub struct TextLayout {
+    text: Arc<dyn TextStorage>,
+    pub(crate) max_width: f64,
+    pub(crate) alignment: TextAlignment,
+    pub(crate) font_size: f64,
+    pub(crate) font_family: FontFamily,
+    pub(crate) font_weight: FontWeight,
+    pub(crate) font_style: FontStyle,
+    pub(crate) text_color: Color,
+    pub(crate) underline: bool,
+    pub(crate) strikethrough: bool,
+    size: Size,
+    face: (Arc<Vec<u8>>, u32),
+}
+
+impl TextLayout {
+    /// Because we can't know what the rasterized output will look like (because the SVG could be
+    /// displayed on another computer), we use the host computer to give 'best-guess' results for
+    /// measurements. These are not guaranteed to be the same for when the SVG is rendered (e.g.
+    /// will depend on available fonts, conformance of renderer, DPI, etc), but it is the best we
+    /// can do.
+    fn from_builder(builder: TextLayoutBuilder) -> Result<Self> {
+        let (face_bytes, idx) = load_fontface(
+            &builder.font_family,
+            builder.font_weight,
+            builder.font_style,
+        )?;
+        let mut face = Face::from_slice(&face_bytes, idx).ok_or(Error::FontLoadingFailed)?;
+        let px_per_em = 96. / 72. * builder.font_size;
+        let px_per_unit = px_per_em / face.units_per_em() as f64;
+        face.set_pixels_per_em(Some((px_per_em as u16, px_per_em as u16)));
+        // number of pixels in a point
+        // 96 = dpi, 72 = points per inch
+
+        let mut uni = UnicodeBuffer::new();
+
+        // full text
+        uni.push_str(builder.text.as_str());
+        let layout = rustybuzz::shape(&face, &[], uni);
+        let width = layout
+            .glyph_positions()
+            .iter()
+            .map(|pos| pos.x_advance as f64)
+            .sum::<f64>()
+            * px_per_unit;
+        let height = face.height() as f64 * px_per_unit;
+        let size = Size { width, height };
+
+        Ok(TextLayout {
+            text: builder.text,
+            max_width: builder.max_width,
+            alignment: builder.alignment,
+            font_family: builder.font_family,
+            font_size: builder.font_size,
+            font_weight: builder.font_weight,
+            font_style: builder.font_style,
+            text_color: builder.text_color,
+            underline: builder.underline,
+            strikethrough: builder.strikethrough,
+            face: (face_bytes, idx),
+            size,
+        })
+    }
+}
 
 impl piet::TextLayout for TextLayout {
     fn size(&self) -> Size {
-        unimplemented!()
+        // TODO shape multiple rows
+        self.size
     }
 
     fn trailing_whitespace_width(&self) -> f64 {
-        unimplemented!()
+        // unimplemented
+        0.
     }
 
     fn image_bounds(&self) -> Rect {
-        unimplemented!()
+        Rect::from((Point::from((0., 0.)), self.size()))
     }
 
-    #[allow(clippy::unimplemented)]
-    fn line_text(&self, _line_number: usize) -> Option<&str> {
-        unimplemented!();
+    fn line_text(&self, line_number: usize) -> Option<&str> {
+        if line_number == 0 {
+            Some(&self.text)
+        } else {
+            None
+        }
     }
 
-    #[allow(clippy::unimplemented)]
-    fn line_metric(&self, _line_number: usize) -> Option<LineMetric> {
-        unimplemented!();
+    fn line_metric(&self, line_number: usize) -> Option<LineMetric> {
+        if line_number == 0 {
+            Some(LineMetric {
+                start_offset: 0,
+                end_offset: self.text.len(),
+                trailing_whitespace: self.text.len() - self.text.trim_end().len(),
+                baseline: 0.,
+                height: 0.,
+                y_offset: 0.,
+            })
+        } else {
+            None
+        }
     }
 
-    #[allow(clippy::unimplemented)]
     fn line_count(&self) -> usize {
-        unimplemented!();
+        1
     }
 
     fn hit_test_point(&self, _point: Point) -> HitTestPoint {
-        unimplemented!()
+        HitTestPoint::default()
     }
 
     fn hit_test_text_position(&self, _text_position: usize) -> HitTestPosition {
-        unimplemented!()
+        HitTestPosition::default()
     }
 
     fn text(&self) -> &str {
-        unimplemented!()
+        self.text.as_str()
     }
+}
+
+/// Returns (face data, idx).
+fn load_fontface(
+    family: &FontFamily,
+    weight: FontWeight,
+    style: FontStyle,
+) -> Result<(Arc<Vec<u8>>, u32)> {
+    use font_kit::{
+        family_name::FamilyName,
+        handle::Handle,
+        properties::{Properties, Style},
+    };
+
+    let mut props = Properties::new();
+    props.weight.0 = weight.to_raw() as f32;
+    props.style = match style {
+        FontStyle::Regular => Style::Normal,
+        FontStyle::Italic => Style::Italic,
+    };
+
+    let source = font_kit::source::SystemSource::new();
+    let font_handle = source
+        .select_best_match(
+            &[
+                FamilyName::Title(family.name().to_string()),
+                FamilyName::SansSerif,
+            ],
+            &props,
+        )
+        .map_err(|_| Error::FontLoadingFailed)?;
+    Ok(match font_handle {
+        Handle::Path { path, font_index } => {
+            let bytes = fs::read(path).map_err(|_| Error::FontLoadingFailed)?;
+            (Arc::new(bytes), font_index)
+        }
+        Handle::Memory { bytes, font_index } => (bytes, font_index),
+    })
 }

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -62,11 +62,12 @@ impl piet::Text for Text {
     fn font_family(&mut self, family_name: &str) -> Option<FontFamily> {
         use font_kit::{family_name::FamilyName, properties::Properties};
 
-        if let Ok(_) = self
+        if self
             .source
             .lock()
             .unwrap()
             .select_best_match(&[FamilyName::Title(family_name.into())], &Properties::new())
+            .is_ok()
         {
             Some(FontFamily::new_unchecked(family_name))
         } else {
@@ -190,7 +191,7 @@ impl TextLayout {
     fn from_builder(builder: TextLayoutBuilder) -> Result<Self> {
         let face_bytes = builder
             .font_face
-            .load(&mut *builder.ctx.source.lock().unwrap())?;
+            .load(&*builder.ctx.source.lock().unwrap())?;
         let mut face = Face::from_slice(&face_bytes, 0).ok_or(Error::FontLoadingFailed)?;
         // number of pixels in a point
         // I think we're OK to assume 96 DPI, because the actual SVG renderer will scale for HIDPI

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -22,7 +22,7 @@
 //! [`piet-direct2d`]: https://crates.io/crates/piet-direct2d
 
 #![warn(missing_docs)]
-#![deny(clippy::trivially_copy_pass_by_ref, broken_intra_doc_links)]
+#![deny(clippy::trivially_copy_pass_by_ref, rustdoc::broken_intra_doc_links)]
 
 pub use kurbo;
 

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -390,17 +390,6 @@ enum FailureReason {
     },
 }
 
-#[derive(Debug, Clone)]
-struct ComparisonError {
-    number: usize,
-    reason: FailureReason,
-}
-
-#[derive(Debug, Clone)]
-struct SnapshotError {
-    failures: Vec<ComparisonError>,
-}
-
 impl std::fmt::Display for FailureReason {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
The tricky bit is text layout sizing, which I need for my use-case (drawing graphs in svg using piet).  I've taken the approach of loading the font on the host machine, then doing a shaping run with `rustybuzz` and then calculating the dimensions of the run. It doesn't work perfectly but it's OK on my machine. I thought there would be an issue with DPI, but it seems that the SVG renderer (I'm using Firefox) operates at the standard DPI and then scales everything up, so there's no issue. Named font sizing works better than using `sans-serif` or `system-ui`, presumably because font-kit and Firefox differ in their opinion of what the default sans-serif font is.

Anyway I'm PRing this because although it is not perfect, it is a significant improvement on what is currently there (nothing). I'm happy to put some effort into getting this through, so please do suggest changes etc. as necessary.

**Update** The text rendering is more robust now, and I added image rendering as well since it was fairly straightforward (in comparison). Hit tests etc are still not implemented, but I don't think you'll need these often (if ever) on an SVG backend.