### PR TITLE
Add iOS as a CoreGraphics operating system to piet-common

### DIFF
--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -43,7 +43,7 @@ piet-cairo = { version = "=0.5.0", path = "../piet-cairo" }
 cairo-rs = { version = "0.14.0", default_features = false }
 cairo-sys-rs = { version = "0.14.0" }
 
-[target.'cfg(target_os="macos")'.dependencies]
+[target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 piet-coregraphics = { version = "=0.5.0", path = "../piet-coregraphics" }
 core-graphics = { version = "0.22.2" }
 

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -38,7 +38,7 @@ cfg_if::cfg_if! {
     } else if #[cfg(any(target_os = "linux", target_os = "openbsd"))] {
         #[path = "cairo_back.rs"]
         mod backend;
-    } else if #[cfg(target_os = "macos")] {
+    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         #[path = "cg_back.rs"]
         mod backend;
     } else if #[cfg(target_os = "windows")] {


### PR DESCRIPTION
Confirmed text drawing and simple shapes work on iOS:

![IMG_94837D379BD8-1](https://user-images.githubusercontent.com/1976330/147862133-c79b4198-d2a9-43f2-a6e7-aa9204b8bd7e.jpeg)