### PR TITLE
feat(piet): add Clone impl to TextAttribute

### DIFF
--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -141,6 +141,7 @@ impl std::ops::Deref for dyn TextStorage {
     }
 }
 
+#[derive(Clone)]
 /// Attributes that can be applied to text.
 pub enum TextAttribute {
     /// The font family.


### PR DESCRIPTION
Issue #483 (conflict with PR #485)

The PR adds `Clone` derive to `TextAttribute`.