### PR TITLE
Release 0.5.1

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-cairo"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Cairo backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "0.5.1", path = "../piet" }
 
 cairo-rs = { version = "0.14.0", default-features = false } # We don't need glib
 pango = { version = "0.14.0", features = ["v1_44"] }

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-common"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Selection of a single preferred back-end for piet"
 license = "MIT/Apache-2.0"
@@ -33,8 +33,8 @@ hdr = ["piet/hdr"]
 serde = ["piet/serde"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
-piet-web = { version = "=0.5.0", path = "../piet-web", optional = true }
+piet = { version = "0.5.1", path = "../piet" }
+piet-web = { version = "0.5.1", path = "../piet-web", optional = true }
 cfg-if = "1.0"
 png = { version = "0.17", optional = true }
 

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-coregraphics"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Jeff Muizelaar <jrmuizel@gmail.com>, Raph Levien <raph.levien@gmail.com>, Colin Rofls <colin.rofls@gmail.com>"]
 description = "CoreGraphics backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "0.5.1", path = "../piet" }
 
 foreign-types = "0.3.2"
 core-graphics = "0.22.2"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-direct2d"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Direct2D backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "0.5.1", path = "../piet" }
 utf16_lit = "2.0"
 associative-cache = "1.0"
 

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-svg"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 description = "SVG backend for piet 2D graphics abstraction."
 edition = "2018"
@@ -18,7 +18,7 @@ base64 = "0.13.0"
 evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
 image = { version = "0.23.10", default-features = false, features = ["png"] }
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "0.5.1", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"
 

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-web"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Web canvas backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "0.5.1", path = "../piet" }
 
 unicode-segmentation = "1.6.0"
 xi-unicode = "0.3.0"

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "An abstraction for 2D graphics."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
I wonder if you'd consider releasing a new version of piet. It contains support for outputting bitmaps on cairo. There are very few changes other than that - this would be a patch release even if piet were stable.

If you prefer you could close this PR and use cargo-workspaces to do the releases.

piet@0.5.1
piet-cairo@0.5.1
piet-common@0.5.1
piet-coregraphics@0.5.1
piet-direct2d@0.5.1
piet-svg@0.5.1
piet-web@0.5.1

Generated by cargo-workspaces