### PR TITLE
Mention submodules in readme & at likely error site

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ the basis of [Druid], a cross-platform GUI toolkit.
 
 A companion for Bézier path representation and geometry is [kurbo].
 
+## Getting started
+
+Running the examples requires that submodules be checked out. From the root
+directory, run
+
+```sh
+git submodule update --init
+```
+
 ## Backends
 
 *For cross-platform use, the [`piet-common`][] crate reexports the most

--- a/piet/src/samples/picture_13.rs
+++ b/piet/src/samples/picture_13.rs
@@ -15,7 +15,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let text = rc.text();
     let _ = text.load_font(include_bytes!(
         "../../snapshots/resources/Anaheim-Regular.ttf"
-    ));
+    )); // SEEING AN ERROR? run `git submodule update --init`
     let font = text
         .load_font(include_bytes!("../../snapshots/resources/Anaheim-Bold.ttf"))
         .unwrap_or(FontFamily::SYSTEM_UI);


### PR DESCRIPTION
The problem here is that `include_bytes` runs at compile time, and it doesn't seem to matter what features are enabled? So I suspect this problem will pop up fairly often.

I don't want to spend the time to try and figure out a real solution right now (although someone else is welcome to!) but this at least mentions the problem in the README, and adds a comment inline that will be printed whenever this problem is encountered. Maybe someone will even see it?

```
error: couldn't read piet/src/samples/../../snapshots/resources/Anaheim-Regular.ttf: No such file or directory (os error 2)
  --> piet/src/samples/picture_13.rs:16:28
   |
16 |       let _ = text.load_font(include_bytes!(
   |  ____________________________^
17 | |         "../../snapshots/resources/Anaheim-Regular.ttf"
18 | |     )); // SEEING AN ERROR? run `git submodule update --init`
   | |_____^
   |
   = note: this error originates in the macro `include_bytes` (in Nightly builds, run with -Z macro-backtrace for more info)
```

closes #491 