### PR TITLE
Remove unspecific comment

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -504,12 +504,11 @@ impl CairoTextLayout {
         loop {
             let line = iterator.line_readonly().unwrap();
 
-            //FIXME: replace this when pango 0.10.0 lands
             let start_offset: usize = line.start_index().try_into().unwrap();
             let length: usize = line.length().try_into().unwrap();
             let end_offset = start_offset + length;
 
-            //Pango likes to give us the line range *without* the newline char(s)
+            // Pango likes to give us the line range *without* the newline char(s).
             let end_offset = match self.text.as_bytes()[end_offset..] {
                 [b'\r', b'\n', ..] => end_offset + 2,
                 [b'\r', ..] | [b'\n', ..] => end_offset + 1,


### PR DESCRIPTION
This comment used to point out unneeded `unsafe` which has been removed.

On a side note, I had a look at the hacks for RTL and it doesn't look like the original problem has been fixed yet (tested with pango `1.50.3`). I did start going down the path of fixing pango, but I need to find some more time for that task as it is a bit more convoluted than I thought it would be. I'll make a PR if I do get around to fixing it.