### PR TITLE
re-export cairo from piet-cairo

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -14,6 +14,7 @@ use piet::{
     LineJoin, RenderContext, StrokeStyle,
 };
 
+pub use cairo;
 pub use crate::text::{CairoText, CairoTextLayout, CairoTextLayoutBuilder};
 
 pub struct CairoRenderContext<'a> {


### PR DESCRIPTION
This helps the user avoid errors from using
incompatible cairo versions.