### PR TITLE
Fixup new clippy lints

### DIFF
--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -681,8 +681,7 @@ impl TextLayout for CoreGraphicsTextLayout {
                 let utf16_range = line.get_string_range();
                 let rel_offset = (n - utf16_range.location) as usize;
                 metric.start_offset
-                    + util::count_until_utf16(line_text, rel_offset)
-                        .unwrap_or_else(|| line_text.len())
+                    + util::count_until_utf16(line_text, rel_offset).unwrap_or(line_text.len())
             }
             // some other value; should never happen
             _ => panic!("gross violation of api contract"),

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -385,8 +385,8 @@ impl TextLayout for D2DTextLayout {
         } as usize;
 
         // Convert text position from utf-16 code units to utf-8 code units.
-        let text_position = util::count_until_utf16(&self.text, text_position_16)
-            .unwrap_or_else(|| self.text.len());
+        let text_position =
+            util::count_until_utf16(&self.text, text_position_16).unwrap_or(self.text.len());
 
         HitTestPoint::new(text_position, htp.is_inside)
     }

--- a/piet-direct2d/src/text/lines.rs
+++ b/piet-direct2d/src/text/lines.rs
@@ -40,9 +40,9 @@ pub(crate) fn fetch_line_metrics(text: &str, layout: &dwrite::TextLayout) -> Vec
 // with offsets
 fn len_and_ws_len_utf8(s: &str, total_len_16: u32, ws_len_16: u32) -> (usize, usize) {
     let non_ws_len_16 = (total_len_16 - ws_len_16) as usize;
-    let non_ws_len_8 = util::count_until_utf16(s, non_ws_len_16).unwrap_or_else(|| s.len());
+    let non_ws_len_8 = util::count_until_utf16(s, non_ws_len_16).unwrap_or(s.len());
     let s = &s[non_ws_len_8..];
-    let ws_len_8 = util::count_until_utf16(s, ws_len_16 as usize).unwrap_or_else(|| s.len());
+    let ws_len_8 = util::count_until_utf16(s, ws_len_16 as usize).unwrap_or(s.len());
     (non_ws_len_8, ws_len_8)
 }
 

--- a/piet-web/src/text/grapheme.rs
+++ b/piet-web/src/text/grapheme.rs
@@ -18,7 +18,7 @@ pub(crate) fn get_grapheme_boundaries(
 ) -> Option<GraphemeBoundaries> {
     let mut graphemes = UnicodeSegmentation::grapheme_indices(text, true);
     let (text_position, _) = graphemes.nth(grapheme_position)?;
-    let (next_text_position, _) = graphemes.next().unwrap_or_else(|| (text.len(), ""));
+    let (next_text_position, _) = graphemes.next().unwrap_or((text.len(), ""));
 
     let curr_edge = hit_test_line_position(ctx, text, text_position);
     let next_edge = hit_test_line_position(ctx, text, next_text_position);


### PR DESCRIPTION
These are slightly weird, but basically clippy now uses a heuristic to
identify certain method calls that it expects to be resolve to a field
access, and flags that these do not need to be wrapped in closures:

https://github.com/rust-lang/rust-clippy/issues/8109#issuecomment-991964291