### PR TITLE
Fix `capture_image_area` not respecting CG transformation matrix

### DIFF
--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -391,7 +391,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
     fn capture_image_area(&mut self, src_rect: impl Into<Rect>) -> Result<Self::Image, Error> {
         let src_rect = src_rect.into();
 
-        // When creating a CoreGraphicsContext, we a transformation matrix is applied to map
+        // When creating a CoreGraphicsContext, a transformation matrix is applied to map
         // between piet's coordinate system and CoreGraphic's coordinate system
         // (see [`CoreGraphicsContext::new_impl`] for details). Since the `src_rect` we receive
         // as parameter is in piet's coordinate system, we need to first convert it to the CG one,

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -96,6 +96,18 @@ pub(crate) fn affine_to_matrix3x2f(affine: Affine) -> D2D1_MATRIX_3X2_F {
     }
 }
 
+// TODO: Needs tests
+pub(crate) fn matrix3x2f_to_affine(matrix: D2D1_MATRIX_3X2_F) -> Affine {
+    Affine::new([
+        matrix.matrix[0][0] as f64,
+        matrix.matrix[0][1] as f64,
+        matrix.matrix[1][0] as f64,
+        matrix.matrix[1][1] as f64,
+        matrix.matrix[2][0] as f64,
+        matrix.matrix[2][1] as f64,
+    ])
+}
+
 // TODO: consider adding to kurbo.
 pub(crate) fn rect_to_rectf(rect: Rect) -> D2D1_RECT_F {
     D2D1_RECT_F {

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -785,7 +785,6 @@ impl DeviceContext {
         width: usize,
         height: usize,
         alpha_mode: D2D1_ALPHA_MODE,
-        dpi_scale: f32,
     ) -> Result<Bitmap, Error> {
         // Maybe using TryInto would be more Rust-like.
         // Note: value is set so that multiplying by 4 (for pitch) is valid.
@@ -801,8 +800,8 @@ impl DeviceContext {
         };
         let props = D2D1_BITMAP_PROPERTIES1 {
             pixelFormat: format,
-            dpiX: 96.0 * dpi_scale,
-            dpiY: 96.0 * dpi_scale,
+            dpiX: 96.0,
+            dpiY: 96.0,
             bitmapOptions: D2D1_BITMAP_OPTIONS_NONE,
             colorContext: null_mut(),
         };

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -428,6 +428,16 @@ impl DeviceContext {
         }
     }
 
+    pub fn get_dpi_scale(&self) -> (f32, f32) {
+        let mut dpi_x = 0.0f32;
+        let mut dpi_y = 0.0f32;
+        unsafe {
+            self.0.GetDpi(&mut dpi_x, &mut dpi_y);
+        }
+        // https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-and-high-dpi
+        (dpi_x / 96., dpi_y / 96.)
+    }
+
     /// Begin drawing.
     ///
     /// This must be done before any piet drawing operations.
@@ -775,6 +785,7 @@ impl DeviceContext {
         width: usize,
         height: usize,
         alpha_mode: D2D1_ALPHA_MODE,
+        dpi_scale: f32,
     ) -> Result<Bitmap, Error> {
         // Maybe using TryInto would be more Rust-like.
         // Note: value is set so that multiplying by 4 (for pitch) is valid.
@@ -790,8 +801,8 @@ impl DeviceContext {
         };
         let props = D2D1_BITMAP_PROPERTIES1 {
             pixelFormat: format,
-            dpiX: 96.0,
-            dpiY: 96.0,
+            dpiX: 96.0 * dpi_scale,
+            dpiY: 96.0 * dpi_scale,
             bitmapOptions: D2D1_BITMAP_OPTIONS_NONE,
             colorContext: null_mut(),
         };

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -469,6 +469,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         };
         // TODO: This transformation is untested with the current test pictures
         let device_size = affine_transform * device_size;
+        let device_size = device_size.to_vec2().to_size();
 
         let device_origin = Point {
             x: r.x0 * dpi_scale,
@@ -478,17 +479,12 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         let device_origin = affine_transform * device_origin;
 
         let mut target_bitmap = self.rt.create_blank_bitmap(
-            device_size.x as usize,
-            device_size.y as usize,
+            device_size.width as usize,
+            device_size.height as usize,
             D2D1_ALPHA_MODE_PREMULTIPLIED,
         )?;
 
-        let src_rect = Rect {
-            x0: device_origin.x,
-            y0: device_origin.y,
-            x1: device_size.x * dpi_scale,
-            y1: device_size.y * dpi_scale,
-        };
+        let src_rect = Rect::from_origin_size(device_origin, device_size);
 
         let d2d_dest_point = to_point2u((0.0f32, 0.0f32));
         let d2d_src_rect = rect_to_rectu(src_rect);

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -481,10 +481,6 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             device_size.x as usize,
             device_size.y as usize,
             D2D1_ALPHA_MODE_PREMULTIPLIED,
-            // Here we force a 1.0 dpi scale, because we're already doing all of
-            // the dpi calculations manually. For some reason I can't get this part
-            // to work if I pass the dpi scale of render context bitmap.
-            1.0,
         )?;
 
         let src_rect = Rect {

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -37,7 +37,7 @@ type BoxErr = Box<dyn std::error::Error>;
 pub const DEFAULT_SCALE: f64 = 2.0;
 
 /// The total number of samples in this module.
-pub const SAMPLE_COUNT: usize = 16;
+pub const SAMPLE_COUNT: usize = 17;
 
 /// file we save an os fingerprint to
 pub const GENERATED_BY: &str = "GENERATED_BY";

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -28,6 +28,7 @@ mod picture_12;
 mod picture_13;
 mod picture_14;
 mod picture_15;
+mod picture_16;
 
 type BoxErr = Box<dyn std::error::Error>;
 
@@ -60,6 +61,7 @@ pub fn get<R: RenderContext>(number: usize) -> Result<SamplePicture<R>, BoxErr> 
         13 => SamplePicture::new(picture_13::SIZE, picture_13::draw),
         14 => SamplePicture::new(picture_14::SIZE, picture_14::draw),
         15 => SamplePicture::new(picture_15::SIZE, picture_15::draw),
+        16 => SamplePicture::new(picture_16::SIZE, picture_16::draw),
         _ => return Err(format!("No sample #{} exists", number).into()),
     })
 }

--- a/piet/src/samples/picture_16.rs
+++ b/piet/src/samples/picture_16.rs
@@ -4,18 +4,16 @@
 //!
 //! 1. clear ignores clipping and transforms
 
-use crate::kurbo::{Affine, Circle, Rect, Size};
+use crate::kurbo::{Rect, Size};
 use crate::{Color, Error, InterpolationMode, RenderContext};
 
 pub const SIZE: Size = Size::new(400., 400.);
 
 const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);
-const SEMI_TRANSPARENT_GREEN: Color = Color::rgba8(0, 255, 0, 125);
-const SEMI_TRANSPARENT_WHITE: Color = Color::rgba8(255, 255, 255, 125);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
-    rc.clear(None, Color::BLACK);
+    rc.clear(None, Color::FUCHSIA);
 
     let outer_rect = Rect::new(20., 20., 180., 180.);
     let inner_rect = Rect::new(21., 21., 179., 179.);
@@ -25,14 +23,13 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     let bottom_left_corner = Rect::new(5., 150., 50., 195.);
     let bottom_right_corner = Rect::new(150., 150., 195., 195.);
 
-
     // Draw a box with a red border
     rc.fill(outer_rect, &RED);
     rc.fill(inner_rect, &BLUE);
 
     // Cache the box, clear the image and re-draw the box from the cache
     let cache = rc.capture_image_area(outer_rect).unwrap();
-    rc.clear(None, Color::WHITE);
+    rc.clear(None, Color::BLACK);
     rc.draw_image(&cache, outer_rect, InterpolationMode::NearestNeighbor);
 
     // Draw the cached image, scaled, in all four corners of the image

--- a/piet/src/samples/picture_16.rs
+++ b/piet/src/samples/picture_16.rs
@@ -10,18 +10,13 @@ pub const SIZE: Size = Size::new(200., 200.);
 const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);
 const INTERPOLATION_MODE: InterpolationMode = InterpolationMode::NearestNeighbor;
-const BORDER_WIDTH: f64 = 2.0;
+const BORDER_WIDTH: f64 = 4.0;
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(None, Color::FUCHSIA);
 
     let outer_rect_red = Rect::new(20., 20., 180., 180.);
-    let inner_rect_blue = Rect::new(
-        20. + BORDER_WIDTH,
-        20. + BORDER_WIDTH,
-        180. - BORDER_WIDTH,
-        180. - BORDER_WIDTH
-    );
+    let inner_rect_blue = outer_rect_red.inset(-BORDER_WIDTH);
 
     // Draw a box with a red border
     rc.fill(outer_rect_red, &RED);
@@ -33,10 +28,10 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.draw_image(&cache, outer_rect_red, INTERPOLATION_MODE);
 
     // Draw the cached image, scaled, in all four corners of the image
-    let top_left_corner = Rect::new(5., 5., 50., 50.);
-    let top_right_corner = Rect::new(150., 5., 195., 50.);
-    let bottom_left_corner = Rect::new(5., 150., 50., 195.);
-    let bottom_right_corner = Rect::new(150., 150., 195., 195.);
+    let top_left_corner = Rect::from_origin_size((5., 5.), (40., 40.));
+    let top_right_corner = Rect::from_origin_size((155., 5.), (40., 40.));
+    let bottom_left_corner = Rect::from_origin_size((5., 155.), (40., 40.));
+    let bottom_right_corner = Rect::from_origin_size((155., 155.), (40., 40.));
 
     rc.draw_image(&cache, top_left_corner, INTERPOLATION_MODE);
     rc.draw_image(&cache, top_right_corner, INTERPOLATION_MODE);

--- a/piet/src/samples/picture_16.rs
+++ b/piet/src/samples/picture_16.rs
@@ -7,7 +7,7 @@
 use crate::kurbo::{Rect, Size};
 use crate::{Color, Error, InterpolationMode, RenderContext};
 
-pub const SIZE: Size = Size::new(400., 400.);
+pub const SIZE: Size = Size::new(200., 200.);
 
 const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);

--- a/piet/src/samples/picture_16.rs
+++ b/piet/src/samples/picture_16.rs
@@ -1,8 +1,6 @@
-//! Clipping and clearing.
+//! capture_image_rect
 //!
-//! This tests interactions between clipping, transforms, and the clear method.
-//!
-//! 1. clear ignores clipping and transforms
+//! This tests makes sure that copying part of an image works
 
 use crate::kurbo::{Rect, Size};
 use crate::{Color, Error, InterpolationMode, RenderContext};
@@ -11,32 +9,39 @@ pub const SIZE: Size = Size::new(200., 200.);
 
 const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);
+const INTERPOLATION_MODE: InterpolationMode = InterpolationMode::NearestNeighbor;
+const BORDER_WIDTH: f64 = 2.0;
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(None, Color::FUCHSIA);
 
-    let outer_rect = Rect::new(20., 20., 180., 180.);
-    let inner_rect = Rect::new(21., 21., 179., 179.);
+    let outer_rect_red = Rect::new(20., 20., 180., 180.);
+    let inner_rect_blue = Rect::new(
+        20. + BORDER_WIDTH,
+        20. + BORDER_WIDTH,
+        180. - BORDER_WIDTH,
+        180. - BORDER_WIDTH
+    );
 
+    // Draw a box with a red border
+    rc.fill(outer_rect_red, &RED);
+    rc.fill(inner_rect_blue, &BLUE);
+
+    // Cache the box, clear the image and re-draw the box from the cache
+    let cache = rc.capture_image_area(outer_rect_red).unwrap();
+    rc.clear(None, Color::BLACK);
+    rc.draw_image(&cache, outer_rect_red, INTERPOLATION_MODE);
+
+    // Draw the cached image, scaled, in all four corners of the image
     let top_left_corner = Rect::new(5., 5., 50., 50.);
     let top_right_corner = Rect::new(150., 5., 195., 50.);
     let bottom_left_corner = Rect::new(5., 150., 50., 195.);
     let bottom_right_corner = Rect::new(150., 150., 195., 195.);
 
-    // Draw a box with a red border
-    rc.fill(outer_rect, &RED);
-    rc.fill(inner_rect, &BLUE);
-
-    // Cache the box, clear the image and re-draw the box from the cache
-    let cache = rc.capture_image_area(outer_rect).unwrap();
-    rc.clear(None, Color::BLACK);
-    rc.draw_image(&cache, outer_rect, InterpolationMode::NearestNeighbor);
-
-    // Draw the cached image, scaled, in all four corners of the image
-    rc.draw_image(&cache, top_left_corner, InterpolationMode::Bilinear);
-    rc.draw_image(&cache, top_right_corner, InterpolationMode::Bilinear);
-    rc.draw_image(&cache, bottom_left_corner, InterpolationMode::Bilinear);
-    rc.draw_image(&cache, bottom_right_corner, InterpolationMode::Bilinear);
+    rc.draw_image(&cache, top_left_corner, INTERPOLATION_MODE);
+    rc.draw_image(&cache, top_right_corner, INTERPOLATION_MODE);
+    rc.draw_image(&cache, bottom_left_corner, INTERPOLATION_MODE);
+    rc.draw_image(&cache, bottom_right_corner, INTERPOLATION_MODE);
 
     Ok(())
 }

--- a/piet/src/samples/picture_16.rs
+++ b/piet/src/samples/picture_16.rs
@@ -1,0 +1,45 @@
+//! Clipping and clearing.
+//!
+//! This tests interactions between clipping, transforms, and the clear method.
+//!
+//! 1. clear ignores clipping and transforms
+
+use crate::kurbo::{Affine, Circle, Rect, Size};
+use crate::{Color, Error, InterpolationMode, RenderContext};
+
+pub const SIZE: Size = Size::new(400., 400.);
+
+const RED: Color = Color::rgb8(255, 0, 0);
+const BLUE: Color = Color::rgb8(0, 0, 255);
+const SEMI_TRANSPARENT_GREEN: Color = Color::rgba8(0, 255, 0, 125);
+const SEMI_TRANSPARENT_WHITE: Color = Color::rgba8(255, 255, 255, 125);
+
+pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
+    rc.clear(None, Color::BLACK);
+
+    let outer_rect = Rect::new(20., 20., 180., 180.);
+    let inner_rect = Rect::new(21., 21., 179., 179.);
+
+    let top_left_corner = Rect::new(5., 5., 50., 50.);
+    let top_right_corner = Rect::new(150., 5., 195., 50.);
+    let bottom_left_corner = Rect::new(5., 150., 50., 195.);
+    let bottom_right_corner = Rect::new(150., 150., 195., 195.);
+
+
+    // Draw a box with a red border
+    rc.fill(outer_rect, &RED);
+    rc.fill(inner_rect, &BLUE);
+
+    // Cache the box, clear the image and re-draw the box from the cache
+    let cache = rc.capture_image_area(outer_rect).unwrap();
+    rc.clear(None, Color::WHITE);
+    rc.draw_image(&cache, outer_rect, InterpolationMode::NearestNeighbor);
+
+    // Draw the cached image, scaled, in all four corners of the image
+    rc.draw_image(&cache, top_left_corner, InterpolationMode::Bilinear);
+    rc.draw_image(&cache, top_right_corner, InterpolationMode::Bilinear);
+    rc.draw_image(&cache, bottom_left_corner, InterpolationMode::Bilinear);
+    rc.draw_image(&cache, bottom_right_corner, InterpolationMode::Bilinear);
+
+    Ok(())
+}


### PR DESCRIPTION
The `capture_image_area` method of the CoreGraphicsContext was not
taking into account that a transformation matrix is applied to the
context. As a result, it only worked correctly if one applied this
scaling manually to the `src_rect` prior to passing it to the method.

With this addition, we now respect the CG transformation matrix and
apply it to the `src_rect` prior to cropping the captured `CGImage`.