### PR TITLE
Prepeare for releasing v0.6.0

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -13,16 +13,16 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "=0.6.0", path = "../piet" }
 
-cairo-rs = { version = "0.15.1", default-features = false } # We don't need glib
-pango = { version = "0.15.2", features = ["v1_44"] }
+cairo-rs = { version = "0.15.11", default-features = false } # We don't need glib
+pango = { version = "0.15.10", features = ["v1_44"] }
 pangocairo = "0.15.1"
-unicode-segmentation = "1.3.0"
+unicode-segmentation = "1.9.0"
 xi-unicode = "0.3.0"
 
 [dev-dependencies]
 piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
-cairo-rs = { version = "0.15.1", default-features = false, features = ["png"] }
-criterion = "0.3"
+cairo-rs = { version = "0.15.11", default-features = false, features = ["png"] }
+criterion = "0.3.5"
 
 [[bench]]
 name = "make_image"

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-cairo"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Cairo backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "=0.6.0", path = "../piet" }
 
 cairo-rs = { version = "0.15.1", default-features = false } # We don't need glib
 pango = { version = "0.15.2", features = ["v1_44"] }
@@ -20,7 +20,7 @@ unicode-segmentation = "1.3.0"
 xi-unicode = "0.3.0"
 
 [dev-dependencies]
-piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
+piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 cairo-rs = { version = "0.15.1", default-features = false, features = ["png"] }
 criterion = "0.3"
 

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-common"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Selection of a single preferred back-end for piet"
 license = "MIT/Apache-2.0"
@@ -33,25 +33,25 @@ hdr = ["piet/hdr"]
 serde = ["piet/serde"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
-piet-web = { version = "=0.5.0", path = "../piet-web", optional = true }
+piet = { version = "=0.6.0", path = "../piet" }
+piet-web = { version = "=0.6.0", path = "../piet-web", optional = true }
 cfg-if = "1.0"
 png = { version = "0.17", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd"))'.dependencies]
-piet-cairo = { version = "=0.5.0", path = "../piet-cairo" }
+piet-cairo = { version = "=0.6.0", path = "../piet-cairo" }
 cairo-rs = { version = "0.15.1", default_features = false }
 cairo-sys-rs = { version = "0.15.1" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
-piet-coregraphics = { version = "=0.5.0", path = "../piet-coregraphics" }
+piet-coregraphics = { version = "=0.6.0", path = "../piet-coregraphics" }
 core-graphics = { version = "0.22.2" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-piet-direct2d = { version = "=0.5.0", path = "../piet-direct2d" }
+piet-direct2d = { version = "=0.6.0", path = "../piet-direct2d" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-piet-web = { version = "=0.5.0", path = "../piet-web" }
+piet-web = { version = "=0.6.0", path = "../piet-web" }
 wasm-bindgen = "0.2.59"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -35,31 +35,31 @@ serde = ["piet/serde"]
 [dependencies]
 piet = { version = "=0.6.0", path = "../piet" }
 piet-web = { version = "=0.6.0", path = "../piet-web", optional = true }
-cfg-if = "1.0"
-png = { version = "0.17", optional = true }
+cfg-if = "1.0.0"
+png = { version = "0.17.5", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd"))'.dependencies]
 piet-cairo = { version = "=0.6.0", path = "../piet-cairo" }
-cairo-rs = { version = "0.15.1", default_features = false }
+cairo-rs = { version = "0.15.11", default_features = false }
 cairo-sys-rs = { version = "0.15.1" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 piet-coregraphics = { version = "=0.6.0", path = "../piet-coregraphics" }
-core-graphics = { version = "0.22.2" }
+core-graphics = { version = "0.22.3" }
 
 [target.'cfg(target_os="windows")'.dependencies]
 piet-direct2d = { version = "=0.6.0", path = "../piet-direct2d" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 piet-web = { version = "=0.6.0", path = "../piet-web" }
-wasm-bindgen = "0.2.59"
+wasm-bindgen = "0.2.80"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]
-getrandom = { version = "0.2.3", features = ["js"] }
-wasm-bindgen-test = "0.3.13"
+getrandom = { version = "0.2.6", features = ["js"] }
+wasm-bindgen-test = "0.3.30"
 
 [target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
-version = "0.3.36"
+version = "0.3.57"
 features = [
     "console",
     "Window",
@@ -76,5 +76,5 @@ features = [
 
 [dev-dependencies]
 static_assertions = "1.1.0"
-rand = "0.8.4"
-rand_distr = "0.4.1"
+rand = "0.8.5"
+rand_distr = "0.4.3"

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-coregraphics"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jeff Muizelaar <jrmuizel@gmail.com>, Raph Levien <raph.levien@gmail.com>, Colin Rofls <colin.rofls@gmail.com>"]
 description = "CoreGraphics backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "=0.6.0", path = "../piet" }
 
 foreign-types = "0.3.2"
 core-graphics = "0.22.2"
@@ -21,5 +21,5 @@ core-foundation-sys = "0.8"
 associative-cache = "1.0"
 
 [dev-dependencies]
-piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
+piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 png = "0.17"

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -14,12 +14,12 @@ categories = ["rendering::graphics-api"]
 piet = { version = "=0.6.0", path = "../piet" }
 
 foreign-types = "0.3.2"
-core-graphics = "0.22.2"
-core-text = "19.0.0"
-core-foundation = "0.9"
-core-foundation-sys = "0.8"
-associative-cache = "1.0"
+core-graphics = "0.22.3"
+core-text = "19.2.0"
+core-foundation = "0.9.3"
+core-foundation-sys = "0.8.3"
+associative-cache = "1.0.1"
 
 [dev-dependencies]
 piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
-png = "0.17"
+png = "0.17.5"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-direct2d"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Direct2D backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "=0.6.0", path = "../piet" }
 utf16_lit = "2.0"
 associative-cache = "1.0"
 
@@ -20,5 +20,5 @@ winapi = { version = "0.3.8", features = ["d2d1", "d2d1_1", "d2d1effects", "d2db
 dwrote = { version = "0.11.0", default_features = false }
 
 [dev-dependencies]
-piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
+piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 image = "0.24.0"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -12,13 +12,13 @@ categories = ["rendering::graphics-api"]
 
 [dependencies]
 piet = { version = "=0.6.0", path = "../piet" }
-utf16_lit = "2.0"
-associative-cache = "1.0"
+utf16_lit = "2.0.2"
+associative-cache = "1.0.1"
 
 wio = "0.2.2"
-winapi = { version = "0.3.8", features = ["d2d1", "d2d1_1", "d2d1effects", "d2dbasetypes", "dcommon", "d3d11", "dxgi", "winnls"] }
+winapi = { version = "0.3.9", features = ["d2d1", "d2d1_1", "d2d1effects", "d2dbasetypes", "dcommon", "d3d11", "dxgi", "winnls"] }
 dwrote = { version = "0.11.0", default_features = false }
 
 [dev-dependencies]
 piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
-image = "0.24.0"
+image = "0.24.2"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -17,7 +17,7 @@ evcxr = ["evcxr_runtime"]
 base64 = "0.13.0"
 evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
-image = { version = "0.24.0", default-features = false, features = ["png"] }
+image = { version = "0.24.2", default-features = false, features = ["png"] }
 piet = { version = "=0.6.0", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-svg"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 description = "SVG backend for piet 2D graphics abstraction."
 edition = "2018"
@@ -18,9 +18,9 @@ base64 = "0.13.0"
 evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
 image = { version = "0.24.0", default-features = false, features = ["png"] }
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "=0.6.0", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"
 
 [dev-dependencies]
-piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
+piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -16,22 +16,22 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 piet = { version = "=0.6.0", path = "../piet" }
 
-unicode-segmentation = "1.6.0"
+unicode-segmentation = "1.9.0"
 xi-unicode = "0.3.0"
-wasm-bindgen = "0.2.70"
-js-sys = "0.3.47"
+wasm-bindgen = "0.2.80"
+js-sys = "0.3.57"
 
 [dependencies.web-sys]
-version = "0.3.47"
+version = "0.3.57"
 features = ["Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap",
             "ImageData", "TextMetrics"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = "0.3.30"
 
 [dev-dependencies.web-sys]
-version = "0.3.47"
+version = "0.3.57"
 features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData",
             "TextMetrics"]

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-web"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Web canvas backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-piet = { version = "=0.5.0", path = "../piet" }
+piet = { version = "=0.6.0", path = "../piet" }
 
 unicode-segmentation = "1.6.0"
 xi-unicode = "0.3.0"

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -14,9 +14,9 @@ default = ["console_error_panic_hook"]
 piet = { path = "../../../piet", features = ["samples"] }
 piet-web = { path = "../.." }
 
-wasm-bindgen = "0.2.30"
-console_error_panic_hook = { version = "0.1.6", optional = true }
+wasm-bindgen = "0.2.80"
+console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dependencies.web-sys]
-version = "0.3.10"
+version = "0.3.57"
 features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement"]

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["rendering::graphics-api"]
 include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
-image = { version = "0.24.0", optional = true, default-features = false }
-kurbo = "0.8.2"
-pico-args = { version = "0.4.0", optional = true }
-png = { version = "0.17", optional = true }
-os_info = { version = "3.0.0", optional = true, default-features = false }
-unic-bidi = "0.9"
+image = { version = "0.24.2", optional = true, default-features = false }
+kurbo = "0.8.3"
+pico-args = { version = "0.4.2", optional = true }
+png = { version = "0.17.5", optional = true }
+os_info = { version = "3.4.0", optional = true, default-features = false }
+unic-bidi = "0.9.0"
 
 [features]
 samples = ["pico-args", "png", "os_info"]

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "An abstraction for 2D graphics."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This PR does two things:

#### Update dependencies explicitly to the latest compatible versions

These are all semver compatible changes. These are versions that Cargo resolves to anyway, which also means they're the versions we actually test with. For the curious I've written more about the rationale for doing this in the Druid [CONTRIBUTING.md](https://github.com/linebender/druid/blob/master/CONTRIBUTING.md#dependencies).

#### Increase Piet version to v0.6.0

Straightforward, with the only question being if it should be v0.5.1 or v0.6.0. When I went over all the changes it seemed like the choice of v0.6.0 was clear. One example is #494 which updated `image` from `0.23` to `0.24`. Some of the Piet API exposes this crate and so by extension the Piet API changed.