### PR TITLE
Improve test image scale support.

### DIFF
--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -9,7 +9,8 @@ use cairo::{Context, Format, ImageSurface};
 use piet::{samples, RenderContext};
 use piet_cairo::CairoRenderContext;
 
-const HIDPI: f64 = 2.0;
+// TODO: Improve support for fractional scaling where sample size ends up fractional.
+const SCALE: f64 = 2.0;
 const FILE_PREFIX: &str = "cairo-test-";
 
 fn main() {
@@ -19,7 +20,7 @@ fn main() {
 
 fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let sample = samples::get(idx)?;
-    let size = sample.size();
+    let size = sample.size() * SCALE;
 
     let file_name = format!("{}{}.png", FILE_PREFIX, idx);
     let path = base_dir.join(file_name);
@@ -27,7 +28,7 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
     let surface = ImageSurface::create(Format::ARgb32, size.width as i32, size.height as i32)
         .expect("Can't create surface");
     let cr = Context::new(&surface).unwrap();
-    cr.scale(HIDPI, HIDPI);
+    cr.scale(SCALE, SCALE);
     let mut piet_context = CairoRenderContext::new(&cr);
     sample.draw(&mut piet_context)?;
     piet_context.finish()?;

--- a/piet-coregraphics/examples/test-picture.rs
+++ b/piet-coregraphics/examples/test-picture.rs
@@ -11,6 +11,7 @@ use piet::kurbo::Size;
 use piet::{samples, RenderContext};
 use piet_coregraphics::CoreGraphicsContext;
 
+// TODO: Improve support for fractional scaling where sample size ends up fractional.
 const SCALE: f64 = 2.0;
 const FILE_PREFIX: &str = "coregraphics-test-";
 
@@ -20,14 +21,13 @@ fn main() {
 
 fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let sample = samples::get(idx)?;
-    let size = sample.size();
+    let size = sample.size() * SCALE;
 
     let file_name = format!("{}{}.png", FILE_PREFIX, idx);
     let path = base_dir.join(file_name);
 
     let mut cg_ctx = make_cg_ctx(size);
-    let mut piet_context =
-        CoreGraphicsContext::new_y_up(&mut cg_ctx, size.height * SCALE.recip(), None);
+    let mut piet_context = CoreGraphicsContext::new_y_up(&mut cg_ctx, sample.size().height, None);
 
     sample.draw(&mut piet_context)?;
 

--- a/piet-direct2d/examples/test-picture.rs
+++ b/piet-direct2d/examples/test-picture.rs
@@ -7,7 +7,8 @@ use winapi::shared::dxgi::DXGI_MAP_READ;
 use piet::{samples, RenderContext};
 use piet_direct2d::{D2DRenderContext, D2DText};
 
-const HIDPI: f32 = 2.0;
+// TODO: Improve support for fractional scaling where sample size ends up fractional.
+const SCALE: f32 = 2.0;
 const FILE_PREFIX: &str = "d2d-test-";
 
 fn main() {
@@ -16,7 +17,7 @@ fn main() {
 
 fn run_sample(number: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let sample = samples::get(number)?;
-    let size = sample.size();
+    let size = sample.size() * SCALE as f64;
 
     let file_name = format!("{}{}.png", FILE_PREFIX, number);
     let path = base_dir.join(file_name);
@@ -43,10 +44,10 @@ fn run_sample(number: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::
         .unwrap();
 
     // Bind the backing texture to a D2D Bitmap
-    let target = unsafe { context.create_bitmap_from_dxgi(&tex.as_dxgi(), HIDPI)? };
+    let target = unsafe { context.create_bitmap_from_dxgi(&tex.as_dxgi(), SCALE)? };
 
     context.set_target(&target);
-    context.set_dpi_scale(HIDPI);
+    context.set_dpi_scale(SCALE);
     context.begin_draw();
     let mut piet_context = D2DRenderContext::new(&d2d, text, &mut context);
     // TODO: report errors more nicely than these unwraps.

--- a/piet/src/samples/picture_0.rs
+++ b/piet/src/samples/picture_0.rs
@@ -12,7 +12,7 @@ const BLUE_ALPHA: Color = Color::rgba8(0x00, 0x00, 0x80, 0xC0);
 const RED_ALPHA: Color = Color::rgba8(0x80, 0x00, 0x00, 0xC0);
 const YELLOW_ALPHA: Color = Color::rgba8(0xCF, 0xCF, 0x00, 0x60);
 
-pub const SIZE: Size = Size::new(400., 200.);
+pub const SIZE: Size = Size::new(200., 100.);
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(None, Color::WHITE);

--- a/piet/src/samples/picture_1.rs
+++ b/piet/src/samples/picture_1.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::{BezPath, Line, Point, Size};
 use crate::{Color, Error, RenderContext};
 
-pub const SIZE: Size = Size::new(400., 200.);
+pub const SIZE: Size = Size::new(200., 100.);
 
 // TODO: this will eventually become a `kurbo::Shape`.
 fn circle<V: Into<Point>>(center: V, radius: f64, num_segments: usize) -> BezPath {

--- a/piet/src/samples/picture_10.rs
+++ b/piet/src/samples/picture_10.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::{Size, Vec2};
 use crate::{Color, Error, RenderContext, Text, TextAttribute, TextLayout, TextLayoutBuilder};
 
-pub const SIZE: Size = Size::new(400., 400.);
+pub const SIZE: Size = Size::new(200., 200.);
 
 static SAMPLE_EN: &str = r#"ḧ́ͥm̾ͭpͭ̒ͦ̎ḧ̐̈̾̆͊
  ch̯͈̙̯̼̠a͚͉o̺̮̳̮̩s̪͇.̥̩̹"#;

--- a/piet/src/samples/picture_11.rs
+++ b/piet/src/samples/picture_11.rs
@@ -41,7 +41,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .alignment(crate::TextAlignment::Justified)
         .max_width(200.0)
         .build()?;
-    let ar_y = ((SIZE.height - layout_ar_start.size().height * 2.0) / 2.0 - 32.0).max(0.0);
+    let ar_y = ((SIZE.height - layout_ar_start.size().height) - 32.0).max(0.0);
 
     visualize_hit_testing(rc, layout_en_start, Point::new(16.0, 32.0))?;
     visualize_hit_testing(rc, layout_en_center, Point::new(232.0, 32.0))?;

--- a/piet/src/samples/picture_11.rs
+++ b/piet/src/samples/picture_11.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::{Circle, Line, Point, Size};
 use crate::{Color, Error, RenderContext, Text, TextLayout, TextLayoutBuilder};
 
-pub const SIZE: Size = Size::new(880., 800.);
+pub const SIZE: Size = Size::new(440., 400.);
 pub const DOT_RADIUS: f64 = 2.0;
 pub const TEST_ADVANCE: f64 = 23.4;
 

--- a/piet/src/samples/picture_12.rs
+++ b/piet/src/samples/picture_12.rs
@@ -24,7 +24,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(280.., TextAttribute::FontSize(18.0))
         .build()?;
 
-    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+    let y_pos = ((SIZE.height - layout.size().height) / 2.0).max(0.0);
     let text_pos = Vec2::new(16.0, y_pos);
 
     let sel_one = layout.rects_for_range(10..72);

--- a/piet/src/samples/picture_12.rs
+++ b/piet/src/samples/picture_12.rs
@@ -5,7 +5,7 @@ use crate::{
     Color, Error, FontFamily, RenderContext, Text, TextAttribute, TextLayout, TextLayoutBuilder,
 };
 
-pub const SIZE: Size = Size::new(480., 560.);
+pub const SIZE: Size = Size::new(240., 280.);
 
 static TEXT: &str = r#"The idea of "structurelessness," however, has moved from a healthy counter to those tendencies to becoming a goddess in its own right. The idea is as little examined as the term is much used, but it has become an intrinsic and unquestioned part of women's liberation ideology. For the early development of the movement this did not much matter."#;
 

--- a/piet/src/samples/picture_13.rs
+++ b/piet/src/samples/picture_13.rs
@@ -35,7 +35,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(250..320, FontWeight::EXTRA_LIGHT)
         .build()?;
 
-    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+    let y_pos = ((SIZE.height - layout.size().height) / 2.0).max(0.0);
     let text_pos = Vec2::new(16.0, y_pos);
     rc.draw_text(&layout, text_pos.to_point());
 

--- a/piet/src/samples/picture_13.rs
+++ b/piet/src/samples/picture_13.rs
@@ -6,7 +6,7 @@ use crate::{
     TextLayoutBuilder,
 };
 
-pub const SIZE: Size = Size::new(480., 560.);
+pub const SIZE: Size = Size::new(240., 280.);
 
 static TEXT: &str = r#"Philosophers often behave like little children who scribble some marks on a piece of paper at random and then ask the grown-up "What's that?" — It happened like this: the grown-up had drawn pictures for the child several times and said "this is a man," "this is a house," etc. And then the child makes some marks too and asks: what's this then?"#;
 

--- a/piet/src/samples/picture_14.rs
+++ b/piet/src/samples/picture_14.rs
@@ -5,7 +5,7 @@ use crate::{
     Color, Error, FontFamily, FontWeight, RenderContext, Text, TextLayout, TextLayoutBuilder,
 };
 
-pub const SIZE: Size = Size::new(480., 560.);
+pub const SIZE: Size = Size::new(240., 280.);
 
 static TEXT: &str = r#"100200300400500
 600700800900950"#;

--- a/piet/src/samples/picture_14.rs
+++ b/piet/src/samples/picture_14.rs
@@ -35,7 +35,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(28..31, FontWeight::EXTRA_BLACK)
         .build()?;
 
-    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+    let y_pos = ((SIZE.height - layout.size().height) / 2.0).max(0.0);
     let text_pos = Vec2::new(16.0, y_pos);
     rc.draw_text(&layout, text_pos.to_point());
 

--- a/piet/src/samples/picture_15.rs
+++ b/piet/src/samples/picture_15.rs
@@ -7,7 +7,7 @@
 use crate::kurbo::{Affine, Circle, Rect, Size};
 use crate::{Color, Error, RenderContext};
 
-pub const SIZE: Size = Size::new(400., 400.);
+pub const SIZE: Size = Size::new(200., 200.);
 
 const RED: Color = Color::rgb8(255, 0, 0);
 const BLUE: Color = Color::rgb8(0, 0, 255);

--- a/piet/src/samples/picture_2.rs
+++ b/piet/src/samples/picture_2.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::{Rect, Size};
 use crate::{Color, Error, ImageFormat, InterpolationMode, RenderContext};
 
-pub const SIZE: Size = Size::new(400., 200.);
+pub const SIZE: Size = Size::new(200., 100.);
 
 pub fn draw(rc: &mut impl RenderContext) -> Result<(), Error> {
     rc.clear(None, Color::WHITE);

--- a/piet/src/samples/picture_3.rs
+++ b/piet/src/samples/picture_3.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::{Affine, BezPath, Line, Size};
 use crate::{Color, Error, LineCap, LineJoin, RenderContext, StrokeStyle};
 
-pub const SIZE: Size = Size::new(400., 200.);
+pub const SIZE: Size = Size::new(200., 100.);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(None, Color::WHITE);

--- a/piet/src/samples/picture_4.rs
+++ b/piet/src/samples/picture_4.rs
@@ -6,7 +6,7 @@ use crate::{
     RenderContext,
 };
 
-pub const SIZE: Size = Size::new(400., 200.);
+pub const SIZE: Size = Size::new(200., 100.);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(None, Color::WHITE);

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -36,7 +36,7 @@ pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
         .range_attribute(240.., FontFamily::SYSTEM_UI)
         .build()?;
 
-    let y_pos = ((SIZE.height - layout.size().height * 2.0) / 4.0).max(0.0);
+    let y_pos = ((SIZE.height - layout.size().height) / 2.0).max(0.0);
     let text_pos = Vec2::new(16.0, y_pos);
     rc.draw_text(&layout, text_pos.to_point());
 

--- a/piet/src/samples/picture_5.rs
+++ b/piet/src/samples/picture_5.rs
@@ -6,7 +6,7 @@ use crate::{
     TextLayout, TextLayoutBuilder,
 };
 
-pub const SIZE: Size = Size::new(480., 560.);
+pub const SIZE: Size = Size::new(240., 280.);
 
 static TEXT: &str = r#"Philosophers often behave like little children who scribble some marks on a piece of paper at random and then ask the grown-up "What's that?" — It happened like this: the grown-up had drawn pictures for the child several times and said "this is a man," "this is a house," etc. And then the child makes some marks too and asks: what's this then?"#;
 

--- a/piet/src/samples/picture_6.rs
+++ b/piet/src/samples/picture_6.rs
@@ -6,7 +6,7 @@ use crate::{
     LineJoin, RenderContext, StrokeStyle,
 };
 
-pub const SIZE: Size = Size::new(400., 200.);
+pub const SIZE: Size = Size::new(200., 100.);
 
 pub fn draw<R: RenderContext>(rc: &mut R) -> Result<(), Error> {
     rc.clear(None, Color::BLACK);

--- a/piet/src/samples/picture_7.rs
+++ b/piet/src/samples/picture_7.rs
@@ -3,7 +3,7 @@
 use crate::kurbo::{Rect, Size};
 use crate::{Color, Error, RenderContext, Text, TextAlignment, TextAttribute, TextLayoutBuilder};
 
-pub const SIZE: Size = Size::new(800., 800.);
+pub const SIZE: Size = Size::new(400., 400.);
 static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 
 static SAMPLE_AR: &str = r#"لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي."#;

--- a/piet/src/samples/picture_8.rs
+++ b/piet/src/samples/picture_8.rs
@@ -6,7 +6,7 @@ use crate::{
     TextAttribute, TextLayoutBuilder,
 };
 
-pub const SIZE: Size = Size::new(400., 800.);
+pub const SIZE: Size = Size::new(200., 400.);
 
 static SAMPLE_EN: &str = r#"This essay is an effort to build an ironic political myth faithful to feminism, socialism, and materialism. Perhaps more faithful as blasphemy is faithful, than as reverent worship and identification. Blasphemy has always seemed to require taking things very seriously. I know no better stance to adopt from within the secular-religious, evangelical traditions of United States politics, including the politics of socialist-feminism."#;
 

--- a/piet/src/samples/picture_9.rs
+++ b/piet/src/samples/picture_9.rs
@@ -6,7 +6,7 @@ use crate::{
     TextLayoutBuilder,
 };
 
-pub const SIZE: Size = Size::new(464., 800.);
+pub const SIZE: Size = Size::new(232., 400.);
 
 static SAMPLE_EN: &str = r#"1nnyyÊbbbb soft break
 2nnyyÊbbbb


### PR DESCRIPTION
The current test image code has a constant size which is hardcoded to expect a scale factor of `2.0`.

This PR changes the test image code to specify the logical size that the code actually uses, and then the platform code that actually generates the image and chooses the scale factor will also choose the proper image size.

Results remain unchanged for the scale factor of `2.0` but this reduces confusion and helps enable a future potential of doing snapshot testing with multiple different scale factors.