### PR TITLE
Refactor the test picture generator

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -21,7 +21,7 @@ xi-unicode = "0.3.0"
 
 [dev-dependencies]
 piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
-cairo-rs = { version = "0.15.1", default-features = false, features = ["png"] }
+piet-common = { version = "=0.5.0", path = "../piet-common", features = ["png"] }
 criterion = "0.3"
 
 [[bench]]

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -186,8 +186,8 @@ impl<'a> BitmapTarget<'a> {
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
     pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
-        let width = self.surface.width();
-        let height = self.surface.height();
+        let width = self.surface.width() as usize;
+        let height = self.surface.height() as usize;
         let mut data = vec![0; width * height * 4];
         self.copy_raw_pixels(ImageFormat::RgbaPremul, &mut data)?;
         util::unpremultiply_rgba(&mut data);

--- a/piet-common/src/cairo_back.rs
+++ b/piet-common/src/cairo_back.rs
@@ -13,6 +13,8 @@ use std::io::BufWriter;
 use std::marker::PhantomData;
 use std::path::Path;
 
+#[cfg(feature = "png")]
+use piet::util;
 use piet::{ImageBuf, ImageFormat};
 #[doc(hidden)]
 pub use piet_cairo::*;
@@ -184,16 +186,19 @@ impl<'a> BitmapTarget<'a> {
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
     pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
-        let height = self.surface.height();
         let width = self.surface.width();
-        let image = self.to_image_buf(ImageFormat::RgbaPremul)?;
+        let height = self.surface.height();
+        let mut data = vec![0; width * height * 4];
+        self.copy_raw_pixels(ImageFormat::RgbaPremul, &mut data)?;
+        util::unpremultiply_rgba(&mut data);
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
         encoder
             .write_header()
             .map_err(Into::<Box<_>>::into)?
-            .write_image_data(image.raw_pixels())
+            .write_image_data(&data)
             .map_err(Into::<Box<_>>::into)?;
         Ok(())
     }

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -12,6 +12,8 @@ use core_graphics::{color_space::CGColorSpace, context::CGContext};
 #[cfg(feature = "png")]
 use png::{ColorType, Encoder};
 
+#[cfg(feature = "png")]
+use piet::util;
 use piet::{Error, ImageBuf, ImageFormat};
 #[doc(hidden)]
 pub use piet_coregraphics::*;
@@ -164,7 +166,7 @@ impl<'a> BitmapTarget<'a> {
         let height = self.ctx.height() as usize;
         let mut data = vec![0; width * height * 4];
         self.copy_raw_pixels(ImageFormat::RgbaPremul, &mut data)?;
-        piet_coregraphics::unpremultiply_rgba(&mut data);
+        util::unpremultiply_rgba(&mut data);
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
         let mut encoder = Encoder::new(file, width as u32, height as u32);
         encoder.set_color(ColorType::Rgba);

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -22,4 +22,4 @@ associative-cache = "1.0"
 
 [dev-dependencies]
 piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
-png = "0.17"
+piet-common = { version = "=0.5.0", path = "../piet-common", features = ["png"] }

--- a/piet-coregraphics/examples/test-picture.rs
+++ b/piet-coregraphics/examples/test-picture.rs
@@ -1,15 +1,9 @@
 //! Run the piet-test examples with the coregraphics backend.
 
-use std::fs::File;
-use std::io::BufWriter;
 use std::path::Path;
 
-use core_graphics::color_space::CGColorSpace;
-use core_graphics::context::CGContext;
-
-use piet::kurbo::Size;
 use piet::{samples, RenderContext};
-use piet_coregraphics::CoreGraphicsContext;
+use piet_common::Device;
 
 // TODO: Improve support for fractional scaling where sample size ends up fractional.
 const SCALE: f64 = 2.0;
@@ -26,36 +20,14 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
     let file_name = format!("{}{}.png", FILE_PREFIX, idx);
     let path = base_dir.join(file_name);
 
-    let mut cg_ctx = make_cg_ctx(size);
-    let mut piet_context = CoreGraphicsContext::new_y_up(&mut cg_ctx, sample.size().height, None);
+    let mut device = Device::new()?;
+    let mut target = device.bitmap_target(size.width as usize, size.height as usize, SCALE)?;
+    let mut piet_context = target.render_context();
 
     sample.draw(&mut piet_context)?;
 
     piet_context.finish()?;
     std::mem::drop(piet_context);
-    let mut data = cg_ctx.data().to_vec();
-    let file = File::create(path)?;
-    let w = BufWriter::new(file);
 
-    let mut encoder = png::Encoder::new(w, size.width as u32, size.height as u32);
-    encoder.set_color(png::ColorType::Rgba);
-    encoder.set_depth(png::BitDepth::Eight);
-    let mut writer = encoder.write_header()?;
-
-    piet_coregraphics::unpremultiply_rgba(&mut data);
-    writer.write_image_data(&data).map_err(Into::into)
-}
-
-fn make_cg_ctx(size: Size) -> CGContext {
-    let cg_ctx = CGContext::create_bitmap_context(
-        None,
-        size.width as usize,
-        size.height as usize,
-        8,
-        0,
-        &CGColorSpace::create_device_rgb(),
-        core_graphics::base::kCGImageAlphaPremultipliedLast,
-    );
-    cg_ctx.scale(SCALE, SCALE);
-    cg_ctx
+    target.save_to_file(path).map_err(Into::into)
 }

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -22,7 +22,6 @@ use foreign_types::ForeignTypeRef;
 
 use piet::kurbo::{Affine, PathEl, Point, QuadBez, Rect, Shape, Size};
 
-use piet::util::unpremul;
 use piet::{
     Color, Error, FixedGradient, Image, ImageFormat, InterpolationMode, IntoBrush, LineCap,
     LineJoin, RenderContext, RoundInto, StrokeStyle,
@@ -575,18 +574,6 @@ fn to_cgrect(rect: impl Into<Rect>) -> CGRect {
 fn to_cgaffine(affine: Affine) -> CGAffineTransform {
     let [a, b, c, d, tx, ty] = affine.as_coeffs();
     CGAffineTransform::new(a, b, c, d, tx, ty)
-}
-
-#[allow(dead_code)]
-pub fn unpremultiply_rgba(data: &mut [u8]) {
-    for i in (0..data.len()).step_by(4) {
-        let a = data[i + 3];
-        if a != 0 {
-            for x in &mut data[i..(i + 3)] {
-                *x = unpremul(*x, a);
-            }
-        }
-    }
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -21,4 +21,4 @@ dwrote = { version = "0.11.0", default_features = false }
 
 [dev-dependencies]
 piet = { version = "=0.5.0", path = "../piet", features = ["samples"] }
-image = "0.24.0"
+piet-common = { version = "=0.5.0", path = "../piet-common", features = ["png"] }

--- a/piet-direct2d/examples/test-picture.rs
+++ b/piet-direct2d/examples/test-picture.rs
@@ -2,105 +2,37 @@
 
 use std::path::Path;
 
-use winapi::shared::dxgi::DXGI_MAP_READ;
-
 use piet::{samples, RenderContext};
-use piet_direct2d::{D2DRenderContext, D2DText};
+use piet_common::Device;
 
 // TODO: Improve support for fractional scaling where sample size ends up fractional.
-const SCALE: f32 = 2.0;
+const SCALE: f64 = 2.0;
 const FILE_PREFIX: &str = "d2d-test-";
 
 fn main() {
     samples::samples_main(run_sample, FILE_PREFIX, None);
 }
 
-fn run_sample(number: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let sample = samples::get(number)?;
-    let size = sample.size() * SCALE as f64;
+fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let sample = samples::get(idx)?;
+    let size = sample.size() * SCALE;
 
-    let file_name = format!("{}{}.png", FILE_PREFIX, number);
+    let file_name = format!("{}{}.png", FILE_PREFIX, idx);
     let path = base_dir.join(file_name);
 
-    // Create the D2D factory
-    let d2d = piet_direct2d::D2DFactory::new()?;
-    let dwrite = piet_direct2d::DwriteFactory::new()?;
-    let text = D2DText::new_with_shared_fonts(dwrite, None);
+    let mut device = Device::new()?;
+    let mut target = device.bitmap_target(size.width as usize, size.height as usize, SCALE)?;
+    let mut piet_context = target.render_context();
 
-    // Initialize a D3D Device
-    let (d3d, d3d_ctx) = piet_direct2d::d3d::D3D11Device::create()?;
+    // We need to postpone returning a potential error to ensure cleanup
+    let draw_error = sample.draw(&mut piet_context).err();
 
-    // Create the D2D Device and Context
-    let mut device = unsafe { d2d.create_device(d3d.as_dxgi().unwrap().as_raw())? };
-    let mut context = device.create_device_context()?;
-
-    // Create a texture to render to
-    let tex = d3d
-        .create_texture(
-            size.width as u32,
-            size.height as u32,
-            piet_direct2d::d3d::TextureMode::Target,
-        )
-        .unwrap();
-
-    // Bind the backing texture to a D2D Bitmap
-    let target = unsafe { context.create_bitmap_from_dxgi(&tex.as_dxgi(), SCALE)? };
-
-    context.set_target(&target);
-    context.set_dpi_scale(SCALE);
-    context.begin_draw();
-    let mut piet_context = D2DRenderContext::new(&d2d, text, &mut context);
-    // TODO: report errors more nicely than these unwraps.
-    match sample.draw(&mut piet_context) {
-        Ok(()) => (),
-        Err(e) => {
-            // cleanup
-            piet_context.finish().unwrap();
-            std::mem::drop(piet_context);
-            context.end_draw().unwrap();
-            return Err(e.into());
-        }
-    };
     piet_context.finish()?;
     std::mem::drop(piet_context);
-    context.end_draw()?;
 
-    let temp_texture = d3d.create_texture(
-        size.width as u32,
-        size.height as u32,
-        piet_direct2d::d3d::TextureMode::Read,
-    )?;
-
-    // Get the data so we can write it to a file
-    // TODO: Have a safe way to accomplish this :D
-    let pixel_count = (size.width * size.height) as usize * 4;
-    let mut raw_pixels = vec![0_u8; pixel_count];
-    unsafe {
-        d3d_ctx
-            .inner()
-            .CopyResource(temp_texture.as_raw() as *mut _, tex.as_raw() as *mut _);
-        d3d_ctx.inner().Flush();
-
-        let surface = temp_texture.as_dxgi();
-        let mut mapped_rect = std::mem::zeroed();
-        let _hr = surface.Map(&mut mapped_rect, DXGI_MAP_READ);
-        for y in 0..size.height as usize {
-            let src = mapped_rect
-                .pBits
-                .offset(mapped_rect.Pitch as isize * y as isize);
-            let dst = raw_pixels
-                .as_mut_ptr()
-                .offset(size.width as isize * 4 * y as isize);
-            std::ptr::copy_nonoverlapping(src, dst, size.width as usize * 4);
-        }
-    }
-
-    image::save_buffer(
-        &path,
-        &raw_pixels,
-        size.width as u32,
-        size.height as u32,
-        image::ColorType::Rgba8,
-    )?;
-    Ok(())
+    // Return either the draw error, or the result of the attempt to save the file
+    draw_error.map_or_else(
+        || target.save_to_file(path).map_err(Into::into),
+        |e| Err(e.into()),
+    )
 }

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -204,6 +204,18 @@ pub fn unpremul(x: u8, a: u8) -> u8 {
     }
 }
 
+/// Takes a buffer of premultiplied RGBA pixels and unpremultiplies them in place.
+pub fn unpremultiply_rgba(data: &mut [u8]) {
+    for i in (0..data.len()).step_by(4) {
+        let a = data[i + 3];
+        if a != 0 {
+            for x in &mut data[i..(i + 3)] {
+                *x = unpremul(*x, a);
+            }
+        }
+    }
+}
+
 /// A heurstic for text direction; returns `true` if, while enumerating characters
 /// in this string, a character in the 'R' (strong right-to-left) category is
 /// encountered before any character in the 'L' (strong left-to-right) category is.


### PR DESCRIPTION
# The problem

Currently the `test-picuture` example projects for Direct2D/CoreGraphics/Cairo are very bespoke.

The code is brittle and not as widely tested. My motivation for doing this refactoring comes from finding out that the CoreGraphics test picture code has no understanding of stride. Yet it gives `0` (which means automatic) as the stride to `CGBitmapContextCreate`, so macOS decides.

Running tests on my macOS 10.15.4 with sample picture `0` (which has a width of `200dp`) gave me the following results:

| Scale | Expected | Actual |
|-------|----------|--------|
| 1.0   | 800      | 832    |
| 1.5   | 1200     | 1216   |
| 2.0   | 1600     | 1600   |
| 2.5   | 2000     | 2048   |

As you can see, the faulty logic is invisible at a scale ratio of `2.0` but causes an assert failure with other scales, as macOS seems to automatically choose a stride that is divisible by 64.

# The solution

Nowadays we have the functionality in `piet-common` to provide us with a bitmap render target and the ability to save the results as a PNG. Indeed the `piet-common` code path even already has stride support thanks to #196.

This PR thus removes most of the platform specific code from `test-picture` and replaces it with simpler code that uses `piet-common` to achieve a more robust result.