### PR TITLE
Fix CoreGraphics copy_raw_pixels swaping red and blue channels.

### DIFF
--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -142,16 +142,14 @@ impl<'a> BitmapTarget<'a> {
         if buf.len() < size {
             return Err(piet::Error::InvalidInput);
         }
-        if stride != width * 4 {
+        let used_stride = width * 4;
+        if stride != used_stride {
             for y in 0..height {
-                let src_off = y * stride;
-                let dst_off = y * width * 4;
-                for x in 0..width {
-                    buf[dst_off + x * 4 + 0] = data[src_off + x * 4 + 2];
-                    buf[dst_off + x * 4 + 1] = data[src_off + x * 4 + 1];
-                    buf[dst_off + x * 4 + 2] = data[src_off + x * 4 + 0];
-                    buf[dst_off + x * 4 + 3] = data[src_off + x * 4 + 3];
-                }
+                let src_start = y * stride;
+                let src_end = src_start + used_stride;
+                let dst_start = y * used_stride;
+                let dst_end = dst_start + used_stride;
+                buf[dst_start..dst_end].copy_from_slice(&data[src_start..src_end])
             }
         } else {
             buf.copy_from_slice(data);


### PR DESCRIPTION
#196 added stride support which is great, but the pixel byte order swapping introduced there seems wrong.

1) In the fast path, when the whole stride is used, the code just copies bytes. However when the stride is longer, blue and red are swapped. This seems highly suspicious by itself already. Why would the pixel format depend on the stride length? In my testing, it doesn't.
2) As I discovered during my work in [#520](https://github.com/linebender/piet/pull/520), macOS gives us a fully utilized stride with our current test code. So the pixel swaping code never runs with our test images. The bug is hidden.
3) Changing `SCALE` in `test-picture.rs` to something else like `1.0` causes the output test image to have blue and red swapped. Confirming the bug.

Thus I have modified the code to keep the pixel component order as is, even when the stride is partially used.

I have manually tested this change to work correctly by temporarily removing the fast path and always using the new code.