### PR TITLE
Add runtime scale configuration to the test picture generator.

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -27,11 +27,18 @@ jobs:
           profile: minimal
           override: true
 
-      - name: generate and compare (ubuntu+cairo)
+      - name: generate and compare (1.00) (ubuntu+cairo)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path=piet-cairo/Cargo.toml --example=test-picture -- --all --out=cairo_samples --compare=./piet/snapshots/cairo
+          args: --manifest-path=piet-cairo/Cargo.toml --example=test-picture -- --all --scale=1 --out=cairo_samples --compare=./piet/snapshots/cairo
+        if: contains(matrix.os, 'ubuntu')
+
+      - name: generate and compare (2.00) (ubuntu+cairo)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --manifest-path=piet-cairo/Cargo.toml --example=test-picture -- --all --scale=2 --out=cairo_samples --compare=./piet/snapshots/cairo
         if: contains(matrix.os, 'ubuntu')
 
       - name: upload failures (ubuntu+cairo)
@@ -41,11 +48,18 @@ jobs:
           path: cairo_samples
         if: contains(matrix.os, 'ubuntu') && failure()
 
-      - name: generate and compare (macOS)
+      - name: generate and compare (1.00) (macOS)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path=piet-coregraphics/Cargo.toml --example=test-picture -- --all --out=coregraphics_samples --compare=./piet/snapshots/coregraphics
+          args: --manifest-path=piet-coregraphics/Cargo.toml --example=test-picture -- --all --scale=1 --out=coregraphics_samples --compare=./piet/snapshots/coregraphics
+        if: contains(matrix.os, 'macOS')
+
+      - name: generate and compare (2.00) (macOS)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --manifest-path=piet-coregraphics/Cargo.toml --example=test-picture -- --all --scale=2 --out=coregraphics_samples --compare=./piet/snapshots/coregraphics
         if: contains(matrix.os, 'macOS')
 
       - name: upload failures (macOS)
@@ -55,11 +69,18 @@ jobs:
           path: coregraphics_samples
         if: contains(matrix.os, 'macOS') && failure()
 
-      - name: generate and compare (d2d)
+      - name: generate and compare (1.00) (d2d)
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --manifest-path=piet-direct2d/Cargo.toml --example=test-picture -- --all --out=d2d_samples --compare=./piet/snapshots/d2d
+          args: --manifest-path=piet-direct2d/Cargo.toml --example=test-picture -- --all --scale=1 --out=d2d_samples --compare=./piet/snapshots/d2d
+        if: contains(matrix.os, 'windows')
+
+      - name: generate and compare (2.00) (d2d)
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --manifest-path=piet-direct2d/Cargo.toml --example=test-picture -- --all --scale=2 --out=d2d_samples --compare=./piet/snapshots/d2d
         if: contains(matrix.os, 'windows')
 
       - name: upload failures (d2d)

--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -6,24 +6,23 @@ use std::process::Command;
 use piet::{samples, RenderContext};
 use piet_common::Device;
 
-// TODO: Improve support for fractional scaling where sample size ends up fractional.
-const SCALE: f64 = 2.0;
-const FILE_PREFIX: &str = "cairo-test-";
+const FILE_PREFIX: &str = "cairo-test";
 
 fn main() {
     let sys_info = additional_system_info();
     samples::samples_main(run_sample, FILE_PREFIX, Some(&sys_info));
 }
 
-fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let sample = samples::get(idx)?;
-    let size = sample.size() * SCALE;
-
-    let file_name = format!("{}{}.png", FILE_PREFIX, idx);
-    let path = base_dir.join(file_name);
+fn run_sample(
+    number: usize,
+    scale: f64,
+    save_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sample = samples::get(number)?;
+    let size = sample.size() * scale;
 
     let mut device = Device::new()?;
-    let mut target = device.bitmap_target(size.width as usize, size.height as usize, SCALE)?;
+    let mut target = device.bitmap_target(size.width as usize, size.height as usize, scale)?;
     let mut piet_context = target.render_context();
 
     sample.draw(&mut piet_context)?;
@@ -31,7 +30,7 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
     piet_context.finish()?;
     std::mem::drop(piet_context);
 
-    target.save_to_file(path).map_err(Into::into)
+    target.save_to_file(save_path).map_err(Into::into)
 }
 
 fn additional_system_info() -> String {

--- a/piet-coregraphics/examples/test-picture.rs
+++ b/piet-coregraphics/examples/test-picture.rs
@@ -5,23 +5,22 @@ use std::path::Path;
 use piet::{samples, RenderContext};
 use piet_common::Device;
 
-// TODO: Improve support for fractional scaling where sample size ends up fractional.
-const SCALE: f64 = 2.0;
-const FILE_PREFIX: &str = "coregraphics-test-";
+const FILE_PREFIX: &str = "coregraphics-test";
 
 fn main() {
     samples::samples_main(run_sample, FILE_PREFIX, None);
 }
 
-fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let sample = samples::get(idx)?;
-    let size = sample.size() * SCALE;
-
-    let file_name = format!("{}{}.png", FILE_PREFIX, idx);
-    let path = base_dir.join(file_name);
+fn run_sample(
+    number: usize,
+    scale: f64,
+    save_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sample = samples::get(number)?;
+    let size = sample.size() * scale;
 
     let mut device = Device::new()?;
-    let mut target = device.bitmap_target(size.width as usize, size.height as usize, SCALE)?;
+    let mut target = device.bitmap_target(size.width as usize, size.height as usize, scale)?;
     let mut piet_context = target.render_context();
 
     sample.draw(&mut piet_context)?;
@@ -29,5 +28,5 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
     piet_context.finish()?;
     std::mem::drop(piet_context);
 
-    target.save_to_file(path).map_err(Into::into)
+    target.save_to_file(save_path).map_err(Into::into)
 }

--- a/piet-direct2d/examples/test-picture.rs
+++ b/piet-direct2d/examples/test-picture.rs
@@ -5,23 +5,22 @@ use std::path::Path;
 use piet::{samples, RenderContext};
 use piet_common::Device;
 
-// TODO: Improve support for fractional scaling where sample size ends up fractional.
-const SCALE: f64 = 2.0;
-const FILE_PREFIX: &str = "d2d-test-";
+const FILE_PREFIX: &str = "d2d-test";
 
 fn main() {
     samples::samples_main(run_sample, FILE_PREFIX, None);
 }
 
-fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
-    let sample = samples::get(idx)?;
-    let size = sample.size() * SCALE;
-
-    let file_name = format!("{}{}.png", FILE_PREFIX, idx);
-    let path = base_dir.join(file_name);
+fn run_sample(
+    number: usize,
+    scale: f64,
+    save_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sample = samples::get(number)?;
+    let size = sample.size() * scale;
 
     let mut device = Device::new()?;
-    let mut target = device.bitmap_target(size.width as usize, size.height as usize, SCALE)?;
+    let mut target = device.bitmap_target(size.width as usize, size.height as usize, scale)?;
     let mut piet_context = target.render_context();
 
     // We need to postpone returning a potential error to ensure cleanup
@@ -32,7 +31,7 @@ fn run_sample(idx: usize, base_dir: &Path) -> Result<(), Box<dyn std::error::Err
 
     // Return either the draw error, or the result of the attempt to save the file
     draw_error.map_or_else(
-        || target.save_to_file(path).map_err(Into::into),
+        || target.save_to_file(save_path).map_err(Into::into),
         |e| Err(e.into()),
     )
 }


### PR DESCRIPTION
This PR further generalizes the test picture code by making it much more scale-aware. It is now possible to specify a `--scale 5` option at runtime to get the test pictures at 500% scale. The generated filenames now contain the scale information and the comparison functions are aware of this.

Additionally I also updated the snapshots testing configuration to do the tests at both 1x and 2x scale. While reviewing #513 I've found that this points out weird behavior that would go unnoticed with just the old 2x scale testing.