### PR TITLE
Satisfy clippy 1.62

### DIFF
--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -1,5 +1,6 @@
 //! Basic example of rendering on Cairo.
 
+use std::fmt::Write as _;
 use std::path::Path;
 use std::process::Command;
 
@@ -43,7 +44,7 @@ fn additional_system_info() -> String {
 
 fn append_lib_version(package_name: &str, buf: &mut String) {
     let version = get_version_from_apt(package_name);
-    buf.push_str(&format!("{:16}", package_name));
+    write!(buf, "{:16}", package_name).expect("Failed to write package name to string");
     buf.push_str(version.as_deref().unwrap_or("not found"));
     buf.push('\n')
 }

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -210,7 +210,7 @@ impl<'a> GradientStops for &'a [Color] {
     }
 }
 
-impl<'a> GradientStops for (Color, Color) {
+impl GradientStops for (Color, Color) {
     #[allow(clippy::wrong_self_convention)]
     fn to_vec(self) -> Vec<GradientStop> {
         let stops: &[Color] = &[self.0, self.1];
@@ -218,7 +218,7 @@ impl<'a> GradientStops for (Color, Color) {
     }
 }
 
-impl<'a> GradientStops for (Color, Color, Color) {
+impl GradientStops for (Color, Color, Color) {
     #[allow(clippy::wrong_self_convention)]
     fn to_vec(self) -> Vec<GradientStop> {
         let stops: &[Color] = &[self.0, self.1, self.2];
@@ -226,7 +226,7 @@ impl<'a> GradientStops for (Color, Color, Color) {
     }
 }
 
-impl<'a> GradientStops for (Color, Color, Color, Color) {
+impl GradientStops for (Color, Color, Color, Color) {
     #[allow(clippy::wrong_self_convention)]
     fn to_vec(self) -> Vec<GradientStop> {
         let stops: &[Color] = &[self.0, self.1, self.2, self.3];
@@ -234,7 +234,7 @@ impl<'a> GradientStops for (Color, Color, Color, Color) {
     }
 }
 
-impl<'a> GradientStops for (Color, Color, Color, Color, Color) {
+impl GradientStops for (Color, Color, Color, Color, Color) {
     #[allow(clippy::wrong_self_convention)]
     fn to_vec(self) -> Vec<GradientStop> {
         let stops: &[Color] = &[self.0, self.1, self.2, self.3, self.4];
@@ -242,7 +242,7 @@ impl<'a> GradientStops for (Color, Color, Color, Color, Color) {
     }
 }
 
-impl<'a> GradientStops for (Color, Color, Color, Color, Color, Color) {
+impl GradientStops for (Color, Color, Color, Color, Color, Color) {
     #[allow(clippy::wrong_self_convention)]
     fn to_vec(self) -> Vec<GradientStop> {
         let stops: &[Color] = &[self.0, self.1, self.2, self.3, self.4, self.5];

--- a/piet/src/image.rs
+++ b/piet/src/image.rs
@@ -198,13 +198,13 @@ impl ImageBuf {
     ///
     /// If the image crate can't decode an image from the data an error will be returned.
     pub fn from_data(raw_image: &[u8]) -> Result<ImageBuf, Box<dyn Error + Send + Sync>> {
-        let image_data = image::load_from_memory(raw_image).map_err(|e| e)?;
+        let image_data = image::load_from_memory(raw_image)?;
         Ok(ImageBuf::from_dynamic_image(image_data))
     }
 
     /// Attempt to load an image from the file at the provided path.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<ImageBuf, Box<dyn Error + Send + Sync>> {
-        let image_data = image::open(path).map_err(|e| e)?;
+        let image_data = image::open(path)?;
         Ok(ImageBuf::from_dynamic_image(image_data))
     }
 }


### PR DESCRIPTION
This PR addresses the following clippy lints:
* [`extra_unused_lifetimes`](https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes)
* [`map_identity`](https://rust-lang.github.io/rust-clippy/master/index.html#map_identity)
* [`format_push_string`](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string)