### PR TITLE
Derive `Copy` for `Color`

### DIFF
--- a/piet-common/examples/mondrian.rs
+++ b/piet-common/examples/mondrian.rs
@@ -80,7 +80,7 @@ impl Mondrian {
     fn generate(&self, size: Size, ctx: &mut impl RenderContext) {
         // Start with single rect over whole picture
         let mut rects = vec![ColorRect {
-            color: self.white.clone(),
+            color: self.white,
             rect: Rect::new(0., 0., size.width, size.height).inset(-self.border * DPI),
         }];
         let mut rng = thread_rng();
@@ -116,7 +116,7 @@ impl Mondrian {
         .unwrap();
         'a: for color in &self.colors {
             for _ in 0..(n.sample(&mut rng).exp().round() as usize) {
-                rects[i].color = color.clone();
+                rects[i].color = *color;
                 i += 1;
                 // bail rather than panic if we run out of rectangles
                 if i >= rects.len() {
@@ -157,7 +157,7 @@ impl ColorRect {
         {
             Either::Left(IntoIterator::into_iter([
                 ColorRect {
-                    color: self.color.clone(),
+                    color: self.color,
                     rect: Rect {
                         x0: self.rect.x0,
                         y0: self.rect.y0,
@@ -188,7 +188,7 @@ impl ColorRect {
         {
             Either::Left(IntoIterator::into_iter([
                 ColorRect {
-                    color: self.color.clone(),
+                    color: self.color,
                     rect: Rect {
                         x0: self.rect.x0,
                         y0: self.rect.y0,

--- a/piet-coregraphics/src/ct_helpers.rs
+++ b/piet-coregraphics/src/ct_helpers.rs
@@ -174,7 +174,7 @@ impl AttributedString {
         }
     }
 
-    pub(crate) fn set_fg_color(&mut self, range: CFRange, color: &Color) {
+    pub(crate) fn set_fg_color(&mut self, range: CFRange, color: Color) {
         let (r, g, b, a) = color.as_rgba();
         let color = CGColor::rgb(r, g, b, a);
         unsafe {

--- a/piet-coregraphics/src/gradient.rs
+++ b/piet-coregraphics/src/gradient.rs
@@ -66,7 +66,7 @@ fn new_cg_gradient(stops: &[GradientStop]) -> CGGradient {
     let mut components = Vec::<CGFloat>::new();
     let mut locations = Vec::<CGFloat>::new();
     for GradientStop { pos, color } in stops {
-        let (r, g, b, a) = Color::as_rgba(color);
+        let (r, g, b, a) = Color::as_rgba(*color);
         components.extend_from_slice(&[r, g, b, a]);
         locations.push(*pos as CGFloat);
     }

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -176,7 +176,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.set_path(shape);
         match brush.as_ref() {
             Brush::Solid(color) => {
-                self.set_fill_color(color);
+                self.set_fill_color(*color);
                 self.ctx.fill_path();
             }
             Brush::Gradient(grad) => {
@@ -193,7 +193,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.set_path(shape);
         match brush.as_ref() {
             Brush::Solid(color) => {
-                self.set_fill_color(color);
+                self.set_fill_color(*color);
                 self.ctx.fill_path();
             }
             Brush::Gradient(grad) => {
@@ -216,7 +216,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.set_stroke(width.round_into(), None);
         match brush.as_ref() {
             Brush::Solid(color) => {
-                self.set_stroke_color(color);
+                self.set_stroke_color(*color);
                 self.ctx.stroke_path();
             }
             Brush::Gradient(grad) => {
@@ -241,7 +241,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.set_stroke(width.round_into(), Some(style));
         match brush.as_ref() {
             Brush::Solid(color) => {
-                self.set_stroke_color(color);
+                self.set_stroke_color(*color);
                 self.ctx.stroke_path();
             }
             Brush::Gradient(grad) => {
@@ -473,12 +473,12 @@ fn convert_line_cap(line_cap: LineCap) -> CGLineCap {
 }
 
 impl<'a> CoreGraphicsContext<'a> {
-    fn set_fill_color(&mut self, color: &Color) {
+    fn set_fill_color(&mut self, color: Color) {
         let (r, g, b, a) = Color::as_rgba(color);
         self.ctx.set_rgb_fill_color(r, g, b, a);
     }
 
-    fn set_stroke_color(&mut self, color: &Color) {
+    fn set_stroke_color(&mut self, color: Color) {
         let (r, g, b, a) = Color::as_rgba(color);
         self.ctx.set_rgb_stroke_color(r, g, b, a);
     }

--- a/piet-coregraphics/src/text.rs
+++ b/piet-coregraphics/src/text.rs
@@ -283,7 +283,7 @@ impl CoreGraphicsTextLayoutBuilder {
         self.default_baseline = (font.ascent() + 0.5).floor();
         self.attr_string.set_font(whole_range, &font);
         self.attr_string
-            .set_fg_color(whole_range, &self.attrs.defaults.fg_color);
+            .set_fg_color(whole_range, self.attrs.defaults.fg_color);
         self.attr_string
             .set_underline(whole_range, self.attrs.defaults.underline);
     }
@@ -294,7 +294,7 @@ impl CoreGraphicsTextLayoutBuilder {
         let range = CFRange::init(utf16_start as isize, utf16_len as isize);
         match attr {
             TextAttribute::TextColor(color) => {
-                self.attr_string.set_fg_color(range, &color);
+                self.attr_string.set_fg_color(range, color);
             }
             TextAttribute::Underline(flag) => self.attr_string.set_underline(range, flag),
             _ => unreachable!(),

--- a/piet-direct2d/src/conv.rs
+++ b/piet-direct2d/src/conv.rs
@@ -144,7 +144,7 @@ pub(crate) fn color_to_colorf(color: Color) -> D2D1_COLOR_F {
 pub(crate) fn gradient_stop_to_d2d(stop: &GradientStop) -> D2D1_GRADIENT_STOP {
     D2D1_GRADIENT_STOP {
         position: stop.pos,
-        color: color_to_colorf(stop.color.clone()),
+        color: color_to_colorf(stop.color),
     }
 }
 

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -466,7 +466,7 @@ impl D2DTextLayout {
     fn resolve_colors_if_needed(&self, ctx: &mut D2DRenderContext) {
         if self.needs_to_set_colors.replace(false) {
             for (range, color) in self.colors.as_ref() {
-                let brush = ctx.solid_brush(color.clone());
+                let brush = ctx.solid_brush(*color);
                 self.layout.borrow_mut().set_foregound_brush(*range, brush)
             }
         }

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -98,8 +98,8 @@ impl piet::RenderContext for RenderContext {
                 .set("width", "100%")
                 .set("height", "100%"),
         }
-        .set("fill", fmt_color(&color))
-        .set("fill-opacity", fmt_opacity(&color));
+        .set("fill", fmt_color(color))
+        .set("fill-opacity", fmt_opacity(color));
         //FIXME: I don't think we should be clipping, here?
         if let Some(id) = self.state.clip {
             rect.assign("clip-path", format!("url(#{})", id.to_string()));
@@ -128,8 +128,8 @@ impl piet::RenderContext for RenderContext {
                     gradient.append(
                         svg::node::element::Stop::new()
                             .set("offset", stop.pos)
-                            .set("stop-color", fmt_color(&stop.color))
-                            .set("stop-opacity", fmt_opacity(&stop.color)),
+                            .set("stop-color", fmt_color(stop.color))
+                            .set("stop-opacity", fmt_opacity(stop.color)),
                     );
                 }
                 self.doc.append(gradient);
@@ -147,8 +147,8 @@ impl piet::RenderContext for RenderContext {
                     gradient.append(
                         svg::node::element::Stop::new()
                             .set("offset", stop.pos)
-                            .set("stop-color", fmt_color(&stop.color))
-                            .set("stop-opacity", fmt_opacity(&stop.color)),
+                            .set("stop-color", fmt_color(stop.color))
+                            .set("stop-opacity", fmt_opacity(stop.color)),
                     );
                 }
                 self.doc.append(gradient);
@@ -629,14 +629,14 @@ enum BrushKind {
 impl Brush {
     fn color(&self) -> svg::node::Value {
         match self.kind {
-            BrushKind::Solid(ref color) => fmt_color(color).into(),
+            BrushKind::Solid(color) => fmt_color(color).into(),
             BrushKind::Ref(id) => format!("url(#{})", id.to_string()).into(),
         }
     }
 
     fn opacity(&self) -> Option<svg::node::Value> {
         match self.kind {
-            BrushKind::Solid(ref color) => Some(fmt_opacity(color).into()),
+            BrushKind::Solid(color) => Some(fmt_opacity(color).into()),
             BrushKind::Ref(_) => None,
         }
     }
@@ -653,12 +653,12 @@ impl IntoBrush<RenderContext> for Brush {
 }
 
 // RGB in hex representation
-fn fmt_color(color: &Color) -> String {
+fn fmt_color(color: Color) -> String {
     format!("#{:06x}", color.as_rgba_u32() >> 8)
 }
 
 // Opacity as value from [0, 1]
-fn fmt_opacity(color: &Color) -> String {
+fn fmt_opacity(color: Color) -> String {
     format!("{}", color.as_rgba().3)
 }
 

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -237,7 +237,8 @@ impl RenderContext for WebRenderContext<'_> {
         // TODO: bounding box for text
         self.ctx.save();
         self.ctx.set_font(&layout.font.get_font_string());
-        let brush = layout.color().make_brush(self, || layout.size().to_rect());
+        let color = layout.color();
+        let brush = color.make_brush(self, || layout.size().to_rect());
         self.set_brush(&brush, true);
         let pos = pos.into();
         for lm in &layout.line_metrics {

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -305,8 +305,8 @@ impl WebTextLayout {
         self.size
     }
 
-    pub(crate) fn color(&self) -> &Color {
-        &self.color
+    pub(crate) fn color(&self) -> Color {
+        self.color
     }
 
     fn update_width(&mut self, new_width: impl Into<Option<f64>>) {

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Formatter};
 /// Currently this is only a 32 bit RGBA value, but it will likely
 /// extend to some form of wide-gamut colorspace, and in the meantime
 /// is useful for giving programs proper type.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Color {
     #[doc(hidden)]

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -188,14 +188,14 @@ impl Color {
     }
 
     /// Convert a color value to a 32-bit rgba value.
-    pub fn as_rgba_u32(&self) -> u32 {
-        match *self {
+    pub fn as_rgba_u32(self) -> u32 {
+        match self {
             Color::Rgba32(rgba) => rgba,
         }
     }
 
     /// Convert a color value to four 8-bit rgba values.
-    pub fn as_rgba8(&self) -> (u8, u8, u8, u8) {
+    pub fn as_rgba8(self) -> (u8, u8, u8, u8) {
         let rgba = self.as_rgba_u32();
         (
             (rgba >> 24 & 255) as u8,
@@ -206,7 +206,7 @@ impl Color {
     }
 
     /// Convert a color value to four f64 values, each in the range 0.0 to 1.0.
-    pub fn as_rgba(&self) -> (f64, f64, f64, f64) {
+    pub fn as_rgba(self) -> (f64, f64, f64, f64) {
         let rgba = self.as_rgba_u32();
         (
             (rgba >> 24) as f64 / 255.0,


### PR DESCRIPTION
A small patch that derives the `Copy` trait for `Color` making it more convenient to use as a value and also permits embedding it in other `Copy` structures.