### PR TITLE
adding const fn with_a8() to Color

### DIFF
--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -187,30 +187,30 @@ impl Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a)
     }
 
-    /// Change just the red value of a color
+    /// Change just the red value of a color.
     ///
-    /// The `r` value represents red as a u8 from 0 to 255.
+    /// The `r` value represents red as a `u8` from 0 to 255.
     pub const fn with_r8(self, r: u8) -> Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff000000) | (r as u32) << 24)
     }
 
-    /// Change just the green value of a color
+    /// Change just the green value of a color.
     ///
-    /// The `g` value represents green as a u8 from 0 to 255.
+    /// The `g` value represents green as a `u8` from 0 to 255.
     pub const fn with_g8(self, g: u8) -> Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff0000) | (g as u32) << 16)
     }
 
-    /// Change just the blue value of a color
+    /// Change just the blue value of a color.
     ///
-    /// The `b` value represents blue as a u8 from 0 to 255.
+    /// The `b` value represents blue as a `u8` from 0 to 255.
     pub const fn with_b8(self, b: u8) -> Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff00) | (b as u32) << 8)
     }
 
-    /// Change just the alpha value of a color
+    /// Change just the alpha value of a color.
     ///
-    /// The `a` value represents alpha as a u8 from 0 to 255.
+    /// The `a` value represents alpha as a `u8` from 0 to 255.
     pub const fn with_a8(self, a: u8) -> Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a as u32)
     }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -187,9 +187,29 @@ impl Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a)
     }
 
+    /// Change just the red value of a color
+    ///
+    /// The `r` value represents red as a u8 from 0 to 255.
+    pub const fn with_r8(self, r: u8) -> Color {
+        Color::from_rgba32_u32((self.as_rgba_u32() & !0xff000000) | (r as u32) << 24)
+    }
+
+    /// Change just the green value of a color
+    ///
+    /// The `g` value represents green as a u8 from 0 to 255.
+    pub const fn with_g8(self, g: u8) -> Color {
+        Color::from_rgba32_u32((self.as_rgba_u32() & !0xff0000) | (g as u32) << 16)
+    }
+
+    /// Change just the blue value of a color
+    ///
+    /// The `b` value represents blue as a u8 from 0 to 255.
+    pub const fn with_b8(self, b: u8) -> Color {
+        Color::from_rgba32_u32((self.as_rgba_u32() & !0xff00) | (b as u32) << 8)
+    }
 
     /// Change just the alpha value of a color
-    /// 
+    ///
     /// The `a` value represents alpha as a u8 from 0 to 255.
     pub const fn with_a8(self, a: u8) -> Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a as u32)
@@ -362,5 +382,27 @@ mod tests {
         assert!(Color::from_hex_str("#0f").is_err());
         assert!(Color::from_hex_str("x0f").is_err());
         assert!(Color::from_hex_str("#0afa1").is_err());
+    }
+
+    #[test]
+    fn change_subcolor_values() {
+        let color = Color::from_rgba32_u32(0x11aa22bb);
+
+        assert_eq!(
+            color.clone().with_r8(0xff),
+            Color::from_rgba32_u32(0xffaa22bb)
+        );
+        assert_eq!(
+            color.clone().with_g8(0xff),
+            Color::from_rgba32_u32(0x11ff22bb)
+        );
+        assert_eq!(
+            color.clone().with_b8(0xff),
+            Color::from_rgba32_u32(0x11aaffbb)
+        );
+        assert_eq!(
+            color.clone().with_a8(0xff),
+            Color::from_rgba32_u32(0x11aa22ff)
+        );
     }
 }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -388,21 +388,9 @@ mod tests {
     fn change_subcolor_values() {
         let color = Color::from_rgba32_u32(0x11aa22bb);
 
-        assert_eq!(
-            color.clone().with_r8(0xff),
-            Color::from_rgba32_u32(0xffaa22bb)
-        );
-        assert_eq!(
-            color.clone().with_g8(0xff),
-            Color::from_rgba32_u32(0x11ff22bb)
-        );
-        assert_eq!(
-            color.clone().with_b8(0xff),
-            Color::from_rgba32_u32(0x11aaffbb)
-        );
-        assert_eq!(
-            color.clone().with_a8(0xff),
-            Color::from_rgba32_u32(0x11aa22ff)
-        );
+        assert_eq!(color.with_r8(0xff), Color::from_rgba32_u32(0xffaa22bb));
+        assert_eq!(color.with_g8(0xff), Color::from_rgba32_u32(0x11ff22bb));
+        assert_eq!(color.with_b8(0xff), Color::from_rgba32_u32(0x11aaffbb));
+        assert_eq!(color.with_a8(0xff), Color::from_rgba32_u32(0x11aa22ff));
     }
 }

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -187,8 +187,16 @@ impl Color {
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a)
     }
 
+
+    /// Change just the alpha value of a color
+    /// 
+    /// The `a` value represents alpha as a u8 from 0 to 255.
+    pub const fn with_a8(self, a: u8) -> Color {
+        Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a as u32)
+    }
+
     /// Convert a color value to a 32-bit rgba value.
-    pub fn as_rgba_u32(self) -> u32 {
+    pub const fn as_rgba_u32(self) -> u32 {
         match self {
             Color::Rgba32(rgba) => rgba,
         }


### PR DESCRIPTION
similar to `with_alpha()`, which unfortunately can't currently be `const fn` due to floating point arithmetic's, I am suggesting to add `const fn with_a8()`.

My personal use case for it: I have a palette of predefined colors (think Gnome Colors), which I use as the basis for other default colors definitions (which is why I need 'const' ).

Related: [the discussion](https://github.com/linebender/piet/pull/524) that Color probably won't be anything else than u32 so the `const` is unlikely to become a problem in the future.

With the same thought, `as_rgba_u32()` can then also converted to be const.

I could also add analogous methods `with_r8()`, `with_g8()` and `with_b8()` to the PR for completeness sake, if the idea is approved.