### PR TITLE
Modify capture_image_area to work with druid direct2d surfaces

### DIFF
--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -784,7 +784,7 @@ impl DeviceContext {
         &mut self,
         width: usize,
         height: usize,
-        alpha_mode: D2D1_ALPHA_MODE,
+        dpi_scale: f32,
     ) -> Result<Bitmap, Error> {
         // Maybe using TryInto would be more Rust-like.
         // Note: value is set so that multiplying by 4 (for pitch) is valid.
@@ -794,18 +794,17 @@ impl DeviceContext {
             width: width as u32,
             height: height as u32,
         };
-        let format = D2D1_PIXEL_FORMAT {
-            format: DXGI_FORMAT_R8G8B8A8_UNORM,
-            alphaMode: alpha_mode,
-        };
-        let props = D2D1_BITMAP_PROPERTIES1 {
-            pixelFormat: format,
-            dpiX: 96.0,
-            dpiY: 96.0,
-            bitmapOptions: D2D1_BITMAP_OPTIONS_NONE,
-            colorContext: null_mut(),
-        };
+
         unsafe {
+            let pixel_format = self.0.GetPixelFormat();
+            let props = D2D1_BITMAP_PROPERTIES1 {
+                pixelFormat: pixel_format,
+                dpiX: dpi_scale * 96.0,
+                dpiY: dpi_scale * 96.0,
+                bitmapOptions: D2D1_BITMAP_OPTIONS_TARGET,
+                colorContext: null_mut(),
+            };
+
             let mut ptr = null_mut();
             let hr = self
                 .0

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -481,14 +481,25 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         let mut target_bitmap = self.rt.create_blank_bitmap(
             device_size.width as usize,
             device_size.height as usize,
-            D2D1_ALPHA_MODE_PREMULTIPLIED,
+            dpi_scale as f32,
         )?;
 
         let src_rect = Rect::from_origin_size(device_origin, device_size);
 
         let d2d_dest_point = to_point2u((0.0f32, 0.0f32));
         let d2d_src_rect = rect_to_rectu(src_rect);
+
+        // Clear layers from the render target
+        for _ in 0..self.layers.len() {
+            self.rt.pop_layer();
+        }
+
         target_bitmap.copy_from_render_target(d2d_dest_point, self.rt, d2d_src_rect);
+
+        // Restore cleared layers
+        for (mask, layer) in self.layers.iter() {
+            self.rt.push_layer_mask(mask, layer);
+        }
 
         Ok(target_bitmap)
     }


### PR DESCRIPTION
Using capture_image_area on a druid paint context currently fails on windows/direct2d for the following reasons:

1) Druid paint contexts have layer masks applied to the render context, which causes the call to [ID2D1Bitmap::CopyFromRenderTarget](https://docs.microsoft.com/en-us/windows/win32/api/d2d1/nf-d2d1-id2d1bitmap-copyfromrendertarget) to fail.

2) Druid's internal surface format is BGRA and piet_direct2d::D2DRenderContext::create_blank_bitmap hardcoded RGBA, which also causes the call to ID2D1Bitmap::CopyFromRenderTarget to fail.

This PR fixes the above two issues so that capture_image_area works inside druid widget paint loops. The caveat is that as the returned image format now matches the druid surface format, you can receive captured images which are not RGBA. That's not an issue for my uses as I'm drawing the captured image back to the paint context, but it probably could be an issue for some.