### PR TITLE
Improve piet-coregraphics

### DIFF
--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -382,8 +382,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
     ) {
         if let CoreGraphicsImage::NonEmpty(image) = image {
             if let Some(cropped) = image.cropped(to_cgrect(src_rect)) {
-                // TODO: apply interpolation mode
-                self.ctx.draw_image(to_cgrect(dst_rect), &cropped);
+               self.draw_image(&CoreGraphicsImage::NonEmpty(cropped), dst_rect, _interp);
             }
         }
     }

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -731,8 +731,12 @@ mod tests {
         let copy = piet
             .capture_image_area(Rect::new(100.0, 100.0, 200.0, 200.0))
             .unwrap();
+
+        let unwrapped_copy = copy.as_ref().unwrap();
+        let rewrapped_copy = CoreGraphicsImage::from_cgimage_and_ydir(unwrapped_copy.clone(), true);
+
         piet.draw_image(
-            &copy,
+            &rewrapped_copy,
             Rect::new(0.0, 0.0, 400.0, 400.0),
             InterpolationMode::Bilinear,
         );

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -134,7 +134,7 @@ impl CoreGraphicsImage {
             false => CoreGraphicsImage::YUp(image),
         }
     }
-    pub fn as_ref(&self) -> Option<&CGImage> {
+    pub fn as_cgimage(&self) -> Option<&CGImage> {
         match self {
             CoreGraphicsImage::Empty => None,
             CoreGraphicsImage::YUp(image) | CoreGraphicsImage::YDown(image) => Some(image),
@@ -758,7 +758,7 @@ mod tests {
             .capture_image_area(Rect::new(100.0, 100.0, 200.0, 200.0))
             .unwrap();
 
-        let unwrapped_copy = copy.as_ref().unwrap();
+        let unwrapped_copy = copy.as_cgimage().unwrap();
         let rewrapped_copy = CoreGraphicsImage::from_cgimage_and_ydir(unwrapped_copy.clone(), true);
 
         piet.draw_image(

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -382,7 +382,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
     ) {
         if let CoreGraphicsImage::NonEmpty(image) = image {
             if let Some(cropped) = image.cropped(to_cgrect(src_rect)) {
-               self.draw_image(&CoreGraphicsImage::NonEmpty(cropped), dst_rect, _interp);
+                self.draw_image(&CoreGraphicsImage::NonEmpty(cropped), dst_rect, _interp);
             }
         }
     }

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -134,17 +134,10 @@ impl CoreGraphicsImage {
             false => CoreGraphicsImage::YUp(image),
         }
     }
-    fn as_ref(&self) -> Option<&CGImage> {
+    pub fn as_ref(&self) -> Option<&CGImage> {
         match self {
             CoreGraphicsImage::Empty => None,
             CoreGraphicsImage::YUp(image) | CoreGraphicsImage::YDown(image) => Some(image),
-        }
-    }
-    pub fn copy_image(&self) -> Option<CGImage> {
-        if let CoreGraphicsImage::YUp(image) | CoreGraphicsImage::YDown(image) = self {
-            Some(image.clone())
-        } else {
-            None
         }
     }
 }

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -378,11 +378,11 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         image: &Self::Image,
         src_rect: impl Into<Rect>,
         dst_rect: impl Into<Rect>,
-        _interp: InterpolationMode,
+        interp: InterpolationMode,
     ) {
         if let CoreGraphicsImage::NonEmpty(image) = image {
             if let Some(cropped) = image.cropped(to_cgrect(src_rect)) {
-                self.draw_image(&CoreGraphicsImage::NonEmpty(cropped), dst_rect, _interp);
+                self.draw_image(&CoreGraphicsImage::NonEmpty(cropped), dst_rect, interp);
             }
         }
     }


### PR DESCRIPTION
CoreGraphicsContext::draw_image_area() doesn't account for coregraphics' reversed y-axis, 086e8e613dfc951f869b6f6ebb9ebcba012ab25a fixes that by passing the cropped image to CoreGraphicsContext::draw_image() which does draw correctly.