### PR TITLE
Satisfy clippy 1.63

### DIFF
--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -211,7 +211,7 @@ impl RenderContext for WebRenderContext<'_> {
         let brush = brush.make_brush(self, || shape.bounding_box());
         self.set_path(shape);
         self.set_stroke(width, None);
-        self.set_brush(&*brush.deref(), false);
+        self.set_brush(brush.deref(), false);
         self.ctx.stroke();
     }
 
@@ -225,7 +225,7 @@ impl RenderContext for WebRenderContext<'_> {
         let brush = brush.make_brush(self, || shape.bounding_box());
         self.set_path(shape);
         self.set_stroke(width, Some(style));
-        self.set_brush(&*brush.deref(), false);
+        self.set_brush(brush.deref(), false);
         self.ctx.stroke();
     }
 

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -15,7 +15,7 @@ pub enum Color {
 }
 
 /// Errors that can occur when parsing a hex color.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ColorParseError {
     /// The input string has an incorrect length
     WrongSize(usize),

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// A requested interpolation mode for drawing images.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum InterpolationMode {
     /// Don't interpolate, use nearest neighbor.
     NearestNeighbor,
@@ -19,7 +19,7 @@ pub enum InterpolationMode {
 }
 
 /// The pixel format for bitmap images.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ImageFormat {
     /// 1 byte per pixel.

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -108,7 +108,7 @@ impl LineJoin {
 }
 
 /// Options for the cap of stroked lines.
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LineCap {
     /// The stroke is squared off at the endpoint of the path.
     Butt,

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -543,7 +543,7 @@ impl LineMetric {
 ///
 /// [`TextLayout`]: ../piet/trait.TextLayout.html
 /// [`TextLayout::hit_test_point`]: ../piet/trait.TextLayout.html#tymethod.hit_test_point
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct HitTestPoint {
     /// The index representing the grapheme boundary closest to the `Point`.


### PR DESCRIPTION
This PR addresses the following clippy lints:
* [`borrow_deref_ref`](https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref)
* [`derive_partial_eq_without_eq`](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq)

The `PartialEq` without `Eq` lint seems somewhat slippery in general, because we might want to expand a type with floats or such in the future. However in the specific cases here I think it's fine.