### PR TITLE
Add support for NetBSD

### DIFF
--- a/piet-cairo/README.md
+++ b/piet-cairo/README.md
@@ -36,6 +36,11 @@ On FreeBSD, the library can be installed with `pkg`:
 pkg install cairo
 ```
 
+On NetBSD, the library can be installed with:
+```shell
+pkgin install cairo
+```
+
 A pkg-config file is provided as usual and cairo-rs will build as expected.
 
 TODO: nicer installation instructions (contributions welcome)

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -38,7 +38,7 @@ piet-web = { version = "=0.5.0", path = "../piet-web", optional = true }
 cfg-if = "1.0"
 png = { version = "0.17", optional = true }
 
-[target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd"))'.dependencies]
+[target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.5.0", path = "../piet-cairo" }
 cairo-rs = { version = "0.15.1", default_features = false }
 cairo-sys-rs = { version = "0.15.1" }

--- a/piet-common/README.md
+++ b/piet-common/README.md
@@ -4,7 +4,7 @@
 [Piet][] 2D graphics API, for the current platform.
 
 On Windows, the backend will be [piet-direct2d][], on macOS
-[piet-coregraphics][], and on Linux, OpenBSD and FreeBSD [piet-cairo][].
+[piet-coregraphics][], and on Linux, OpenBSD, FreeBSD and NetBSD [piet-cairo][].
 The [piet-web][] backend can be selected with the `web` feature.
 
 [Piet]: https://crates.io/crates/piet

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -35,7 +35,7 @@ cfg_if::cfg_if! {
      if #[cfg(any(feature = "web", target_arch = "wasm32"))] {
         #[path = "web_back.rs"]
         mod backend;
-    } else if #[cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd"))] {
+    } else if #[cfg(any(target_os = "linux", target_os = "openbsd", target_os = "freebsd", target_os = "netbsd"))] {
         #[path = "cairo_back.rs"]
         mod backend;
     } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {


### PR DESCRIPTION
The following changes allow `piet` to build on NetBSD.

```
> uname -a
NetBSD mybox 9.99.101 NetBSD 9.99.101 (GENERIC) #0: Tue Oct 11 15:59:38 UTC 2022  mkrepro@mkrepro.NetBSD.org:/usr/src/sys/arch/amd64/compile/GENERIC amd64
> cargo build --release
   Compiling proc-macro2 v1.0.47
   Compiling quote v1.0.21
   Compiling unicode-ident v1.0.5
   Compiling pkg-config v0.3.25
   Compiling syn v1.0.102
   Compiling serde v1.0.145
   Compiling heck v0.4.0
   Compiling smallvec v1.10.0
   Compiling thiserror v1.0.37
   Compiling autocfg v1.1.0
   Compiling version-compare v0.1.0
   Compiling libc v0.2.135
   Compiling log v0.4.17
   Compiling cfg-if v1.0.0
   Compiling once_cell v1.15.0
   Compiling bitflags v1.3.2
   Compiling version_check v0.9.4
   Compiling cc v1.0.73
   Compiling wasm-bindgen-shared v0.2.83
   Compiling crc32fast v1.3.2
   Compiling futures-core v0.3.24
   Compiling adler v1.0.2
   Compiling futures-task v0.3.24
   Compiling ucd-trie v0.1.5
   Compiling anyhow v1.0.65
   Compiling futures-util v0.3.24
   Compiling unic-char-range v0.9.0
   Compiling unic-common v0.9.0
   Compiling bumpalo v3.11.0
   Compiling futures-channel v0.3.24
   Compiling pin-utils v0.1.0
   Compiling pin-project-lite v0.2.9
   Compiling wasm-bindgen v0.2.83
   Compiling arrayvec v0.7.2
   Compiling matches v0.1.9
   Compiling libm v0.2.5
   Compiling pico-args v0.4.2
   Compiling unicode-segmentation v1.10.0
   Compiling unicode-general-category v0.4.0
   Compiling xi-unicode v0.3.0
   Compiling byteorder v1.4.3
   Compiling bytemuck v1.12.1
   Compiling same-file v1.0.6
   Compiling color_quant v1.1.0
   Compiling lazy_static v1.4.0
   Compiling unicode-ccc v0.1.2
   Compiling float-ord v0.2.0
   Compiling unicode-script v0.5.5
   Compiling unicode-bidi-mirroring v0.1.0
   Compiling ttf-parser v0.12.3
   Compiling base64 v0.13.0
   Compiling svg v0.10.0
   Compiling cfg-expr v0.10.3
   Compiling servo-fontconfig-sys v5.1.0
   Compiling slab v0.4.7
   Compiling num-traits v0.2.15
   Compiling num-integer v0.1.45
   Compiling num-rational v0.4.1
   Compiling proc-macro-error-attr v1.0.4
   Compiling proc-macro-error v1.0.4
   Compiling miniz_oxide v0.5.4
   Compiling cmake v0.1.48
   Compiling unic-char-property v0.9.0
   Compiling unic-ucd-version v0.9.0
   Compiling kurbo v0.8.3
   Compiling walkdir v2.3.2
   Compiling freetype-sys v0.13.1
   Compiling expat-sys v2.1.6
   Compiling unic-ucd-bidi v0.9.0
   Compiling dirs-sys-next v0.1.2
   Compiling os_info v3.5.1
   Compiling flate2 v1.0.24
   Compiling unic-bidi v0.9.0
   Compiling dirs-next v2.0.0
   Compiling rustybuzz v0.4.0
   Compiling toml v0.5.9
   Compiling png v0.17.6
   Compiling system-deps v6.0.2
   Compiling wasm-bindgen-backend v0.2.83
   Compiling futures-executor v0.3.24
   Compiling freetype v0.7.0
   Compiling piet v0.5.0 (/home/pin/Git/piet/piet)
   Compiling glib-sys v0.15.10
   Compiling gobject-sys v0.15.10
   Compiling cairo-sys-rs v0.15.1
   Compiling pango-sys v0.15.10
   Compiling pangocairo-sys v0.15.1
   Compiling thiserror-impl v1.0.37
   Compiling wasm-bindgen-macro-support v0.2.83
   Compiling servo-fontconfig v0.5.1
   Compiling image v0.24.4
   Compiling wasm-bindgen-macro v0.2.83
   Compiling pest v2.4.0
   Compiling proc-macro-crate v1.2.1
   Compiling js-sys v0.3.60
   Compiling console_error_panic_hook v0.1.7
   Compiling semver-parser v0.10.2
   Compiling glib-macros v0.15.11
   Compiling semver v0.11.0
   Compiling web-sys v0.3.60
   Compiling rustc_version v0.3.3
   Compiling pathfinder_simd v0.5.1
   Compiling pathfinder_geometry v0.5.1
   Compiling font-kit v0.10.1
   Compiling piet-svg v0.5.0 (/home/pin/Git/piet/piet-svg)
   Compiling glib v0.15.12
   Compiling piet-web v0.5.0 (/home/pin/Git/piet/piet-web)
   Compiling piet-web-example v0.0.2 (/home/pin/Git/piet/piet-web/examples/basic)
   Compiling pango v0.15.10
   Compiling cairo-rs v0.15.12
   Compiling pangocairo v0.15.1
   Compiling piet-cairo v0.5.0 (/home/pin/Git/piet/piet-cairo)
   Compiling piet-common v0.5.0 (/home/pin/Git/piet/piet-common)
    Finished release [optimized] target(s) in 2m 58s
```
