### PR TITLE
update cairo and pango to v0.16

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "=0.5.0", path = "../piet" }
 
-cairo-rs = { version = "0.15.1", default-features = false } # We don't need glib
-pango = { version = "0.15.2", features = ["v1_44"] }
-pangocairo = "0.15.1"
+cairo-rs = { version = "0.16.3", default-features = false } # We don't need glib
+pango = { version = "0.16.3", features = ["v1_44"] }
+pangocairo = "0.16.3"
 unicode-segmentation = "1.3.0"
 xi-unicode = "0.3.0"
 

--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -152,9 +152,9 @@ impl CairoText {
     /// Create a new factory that satisfies the piet `Text` trait.
     #[allow(clippy::new_without_default)]
     pub fn new() -> CairoText {
-        let fontmap = FontMap::default().unwrap();
+        let fontmap = FontMap::default();
         CairoText {
-            pango_context: fontmap.create_context().unwrap(),
+            pango_context: fontmap.create_context(),
         }
     }
 }
@@ -412,11 +412,11 @@ impl TextLayout for CairoTextLayout {
         let line_start_idx = self.line_metric(line_number).unwrap().start_offset;
 
         let hitpos = line.x_to_index(x as i32);
-        let rel_idx = if hitpos.is_inside {
-            let idx = hitpos.index as usize - line_start_idx;
+        let rel_idx = if hitpos.is_inside() {
+            let idx = hitpos.index() as usize - line_start_idx;
             let trailing_len: usize = line_text[idx..]
                 .chars()
-                .take(hitpos.trailing as usize)
+                .take(hitpos.trailing() as usize)
                 .map(char::len_utf8)
                 .sum();
             idx + trailing_len
@@ -436,7 +436,7 @@ impl TextLayout for CairoTextLayout {
 
         let is_inside_y = point.y >= 0. && point.y <= self.size.height;
 
-        HitTestPoint::new(line_start_idx + rel_idx, hitpos.is_inside && is_inside_y)
+        HitTestPoint::new(line_start_idx + rel_idx, hitpos.is_inside() && is_inside_y)
     }
 
     fn hit_test_text_position(&self, idx: usize) -> HitTestPosition {
@@ -500,7 +500,7 @@ impl CairoTextLayout {
         let mut y_offset = 0.;
         let mut widest_logical_width = 0;
         let mut widest_whitespaceless_width = 0;
-        let mut iterator = self.pango_layout.iter().unwrap();
+        let mut iterator = self.pango_layout.iter();
         loop {
             let line = iterator.line_readonly().unwrap();
 

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -40,8 +40,8 @@ png = { version = "0.17", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.5.0", path = "../piet-cairo" }
-cairo-rs = { version = "0.15.1", default_features = false }
-cairo-sys-rs = { version = "0.15.1" }
+cairo-rs = { version = "0.16.3", default_features = false }
+cairo-sys-rs = { version = "0.16.3" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 piet-coregraphics = { version = "=0.5.0", path = "../piet-coregraphics" }


### PR DESCRIPTION
this updates the cairo and pango dependencies to the newest versions.
There were not a lot of API changes: some struct fields were changed to private visibility and now have getter methods, and some structs now need to be created through `new()` functions.