### PR TITLE
Impl Default for piet-svg Text and remove `new` method

### DIFF
--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -44,7 +44,7 @@ impl RenderContext {
             state: State::default(),
             doc: svg::Document::new(),
             next_id: 0,
-            text: Text::default(),
+            text: Text::new(),
         }
     }
 

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -44,7 +44,7 @@ impl RenderContext {
             state: State::default(),
             doc: svg::Document::new(),
             next_id: 0,
-            text: Text::new(),
+            text: Text::default(),
         }
     }
 

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -32,10 +32,9 @@ pub struct Text {
     pub(crate) seen_fonts: Arc<Mutex<HashSet<FontFace>>>,
 }
 
-impl Text {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Text {
+impl Default for Text {
+    fn default() -> Self {
+        Self {
             source: Arc::new(Mutex::new(MultiSource::from_sources(vec![
                 Box::new(SystemSource::new()),
                 Box::new(MemSource::empty()),
@@ -43,7 +42,9 @@ impl Text {
             seen_fonts: Arc::new(Mutex::new(HashSet::new())),
         }
     }
+}
 
+impl Text {
     pub(crate) fn font_data(&self, face: &FontFace) -> Result<Arc<Vec<u8>>> {
         let handle = self
             .source

--- a/piet-svg/src/text.rs
+++ b/piet-svg/src/text.rs
@@ -45,6 +45,10 @@ impl Default for Text {
 }
 
 impl Text {
+    pub fn new() -> Self {
+        Seld::default()
+    }
+
     pub(crate) fn font_data(&self, face: &FontFace) -> Result<Arc<Vec<u8>>> {
         let handle = self
             .source


### PR DESCRIPTION
This removes the need for `#[allow(clippy::new_without_default)]`