### PR TITLE
Satisfy clippy 1.66

### DIFF
--- a/piet-cairo/src/text.rs
+++ b/piet-cairo/src/text.rs
@@ -411,7 +411,7 @@ impl TextLayout for CairoTextLayout {
         let line_text = self.line_text(line_number).unwrap();
         let line_start_idx = self.line_metric(line_number).unwrap().start_offset;
 
-        let hitpos = line.x_to_index(x as i32);
+        let hitpos = line.x_to_index(x);
         let rel_idx = if hitpos.is_inside() {
             let idx = hitpos.index() as usize - line_start_idx;
             let trailing_len: usize = line_text[idx..]

--- a/piet-common/src/cg_back.rs
+++ b/piet-common/src/cg_back.rs
@@ -112,8 +112,8 @@ impl<'a> BitmapTarget<'a> {
     // really a mutation, so we'll keep the name. Consider using interior mutability in the future.
     #[allow(clippy::wrong_self_convention)]
     pub fn to_image_buf(&mut self, fmt: ImageFormat) -> Result<ImageBuf, piet::Error> {
-        let width = self.ctx.width() as usize;
-        let height = self.ctx.height() as usize;
+        let width = self.ctx.width();
+        let height = self.ctx.height();
         let mut buf = vec![0; width * height * 4];
         self.copy_raw_pixels(fmt, &mut buf)?;
         Ok(ImageBuf::from_raw(buf, fmt, width, height))
@@ -134,8 +134,8 @@ impl<'a> BitmapTarget<'a> {
             return Err(Error::NotSupported);
         }
 
-        let width = self.ctx.width() as usize;
-        let height = self.ctx.height() as usize;
+        let width = self.ctx.width();
+        let height = self.ctx.height();
         let stride = self.ctx.bytes_per_row();
         let data = self.ctx.data();
         let size = width * height * 4;
@@ -160,8 +160,8 @@ impl<'a> BitmapTarget<'a> {
     /// Save bitmap to RGBA PNG file
     #[cfg(feature = "png")]
     pub fn save_to_file<P: AsRef<Path>>(mut self, path: P) -> Result<(), piet::Error> {
-        let width = self.ctx.width() as usize;
-        let height = self.ctx.height() as usize;
+        let width = self.ctx.width();
+        let height = self.ctx.height();
         let mut data = vec![0; width * height * 4];
         self.copy_raw_pixels(ImageFormat::RgbaPremul, &mut data)?;
         util::unpremultiply_rgba(&mut data);

--- a/piet-common/src/web_back.rs
+++ b/piet-common/src/web_back.rs
@@ -161,7 +161,7 @@ impl<'a> BitmapTarget<'a> {
         let width = self.canvas.width();
         let image = self.raw_pixels(ImageFormat::RgbaPremul)?;
         let file = BufWriter::new(File::create(path).map_err(Into::<Box<_>>::into)?);
-        let mut encoder = Encoder::new(file, width as u32, height as u32);
+        let mut encoder = Encoder::new(file, width, height);
         encoder.set_color(ColorType::Rgba);
         encoder
             .write_header()

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -317,7 +317,7 @@ impl TextLayout {
             let mut ptr = null_mut();
             let hr = dwrite.0.CreateTextLayout(
                 text.as_ptr(),
-                len as u32,
+                len,
                 format.0.as_raw(),
                 width,
                 MAX_LAYOUT_CONSTRAINT,
@@ -465,7 +465,7 @@ impl TextLayout {
         };
 
         unsafe {
-            let hr = self.0.SetMaxWidth(max_width as f32);
+            let hr = self.0.SetMaxWidth(max_width);
 
             if SUCCEEDED(hr) {
                 Ok(())

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -443,7 +443,7 @@ fn hit_test_line_position(ctx: &CanvasRenderingContext2d, text: &str, idx: usize
         return 0.0;
     }
 
-    if idx as usize >= text_len {
+    if idx >= text_len {
         return text_width(text, ctx);
     }
 

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -89,10 +89,10 @@ impl Color {
     /// The interpretation is the same as rgba32, and no greater precision is
     /// (currently) assumed.
     pub fn rgba(r: f64, g: f64, b: f64, a: f64) -> Color {
-        let r = (r.max(0.0).min(1.0) * 255.0).round() as u32;
-        let g = (g.max(0.0).min(1.0) * 255.0).round() as u32;
-        let b = (b.max(0.0).min(1.0) * 255.0).round() as u32;
-        let a = (a.max(0.0).min(1.0) * 255.0).round() as u32;
+        let r = (r.clamp(0.0, 1.0) * 255.0).round() as u32;
+        let g = (g.clamp(0.0, 1.0) * 255.0).round() as u32;
+        let b = (b.clamp(0.0, 1.0) * 255.0).round() as u32;
+        let a = (a.clamp(0.0, 1.0) * 255.0).round() as u32;
         Color::from_rgba32_u32((r << 24) | (g << 16) | (b << 8) | a)
     }
 
@@ -101,9 +101,9 @@ impl Color {
     /// The interpretation is the same as rgb8, and no greater precision is
     /// (currently) assumed.
     pub fn rgb(r: f64, g: f64, b: f64) -> Color {
-        let r = (r.max(0.0).min(1.0) * 255.0).round() as u32;
-        let g = (g.max(0.0).min(1.0) * 255.0).round() as u32;
-        let b = (b.max(0.0).min(1.0) * 255.0).round() as u32;
+        let r = (r.clamp(0.0, 1.0) * 255.0).round() as u32;
+        let g = (g.clamp(0.0, 1.0) * 255.0).round() as u32;
+        let b = (b.clamp(0.0, 1.0) * 255.0).round() as u32;
         Color::from_rgba32_u32((r << 24) | (g << 16) | (b << 8) | 0xff)
     }
 
@@ -183,7 +183,7 @@ impl Color {
     ///
     /// The `a` value represents alpha in the range 0.0 to 1.0.
     pub fn with_alpha(self, a: f64) -> Color {
-        let a = (a.max(0.0).min(1.0) * 255.0).round() as u32;
+        let a = (a.clamp(0.0, 1.0) * 255.0).round() as u32;
         Color::from_rgba32_u32((self.as_rgba_u32() & !0xff) | a)
     }
 

--- a/piet/src/font.rs
+++ b/piet/src/font.rs
@@ -141,7 +141,7 @@ impl FontWeight {
     ///
     /// Values will be clamped to the range 1..=1000.
     pub fn new(raw: u16) -> FontWeight {
-        let raw = raw.min(1000).max(1);
+        let raw = raw.clamp(1, 1000);
         FontWeight(raw)
     }
 

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -287,7 +287,7 @@ fn compare_files(
         one_info.color_type, two_info.color_type,
         "color types should always match"
     );
-    let err_write_path = p2.with_file_name(&get_filename(prefix, scale, number, true));
+    let err_write_path = p2.with_file_name(get_filename(prefix, scale, number, true));
     compare_pngs(one_info, &one, &two, err_write_path)
 }
 
@@ -394,12 +394,12 @@ fn write_os_info(base_dir: &Path, env_info: Option<&str>) -> std::io::Result<()>
             buf.push('\n');
         }
     }
-    std::fs::write(&path, buf.as_bytes())
+    std::fs::write(path, buf.as_bytes())
 }
 
 fn read_os_info(base_dir: &Path) -> std::io::Result<String> {
     let path = base_dir.join(GENERATED_BY);
-    std::fs::read_to_string(&path)
+    std::fs::read_to_string(path)
 }
 
 /// Get info about the system used to create these samples.


### PR DESCRIPTION
This PR addresses the following clippy lints:
* [`manual_clamp`](https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp)
* [`needless_borrow`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
* [`unnecessary_cast`](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast)