### PR TITLE
Fix `docs.rs` generation by building on Windows for D2D and on Mac for Coregraphics

### DIFF
--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -23,3 +23,6 @@ associative-cache = "1.0.1"
 [dev-dependencies]
 piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-apple-darwin"]

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -25,4 +25,4 @@ piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
 
 [package.metadata.docs.rs]
-targets = ["x86_64-apple-darwin"]
+default-target = "x86_64-apple-darwin"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -22,3 +22,6 @@ dwrote = { version = "0.11.0", default_features = false }
 [dev-dependencies]
 piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-pc-windows-msvc"]

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -24,4 +24,4 @@ piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
 
 [package.metadata.docs.rs]
-targets = ["x86_64-pc-windows-msvc"]
+default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Adds [`docs.rs` metadata](https://docs.rs/about/metadata) instructions.

I haven't tested if this is enough to actually build, but considering that [`winapi`](https://docs.rs/crate/winapi/latest/source/Cargo.toml), `win-rs` and [`core-x`](https://docs.rs/crate/core-foundation/0.9.3/source/Cargo.toml) are doing this, it should work.