### PR TITLE
Satisfy clippy 1.67 beta

### DIFF
--- a/piet-cairo/benches/make_image.rs
+++ b/piet-cairo/benches/make_image.rs
@@ -35,7 +35,7 @@ pub fn bench_make_image(c: &mut Criterion) {
         let mut data = vec![0; usize::try_from(bytes).expect("Should fit into usize")];
         fill_random(&mut data[..]);
 
-        c.bench_function(&format!("make_image_{}_{:?}", name, format), |b| {
+        c.bench_function(&format!("make_image_{name}_{format:?}"), |b| {
             let unused_surface =
                 ImageSurface::create(Format::ARgb32, 1, 1).expect("Can't create surface");
             let cr = Context::new(&unused_surface).unwrap();

--- a/piet-cairo/examples/test-picture.rs
+++ b/piet-cairo/examples/test-picture.rs
@@ -43,7 +43,7 @@ fn additional_system_info() -> String {
 
 fn append_lib_version(package_name: &str, buf: &mut String) {
     let version = get_version_from_apt(package_name);
-    write!(buf, "{:16}", package_name).expect("Failed to write package name to string");
+    write!(buf, "{package_name:16}").expect("Failed to write package name to string");
     buf.push_str(version.as_deref().unwrap_or("not found"));
     buf.push('\n')
 }
@@ -57,7 +57,7 @@ fn get_version_from_apt(package: &str) -> Option<String> {
     {
         Ok(output) => output,
         Err(e) => {
-            eprintln!("failed to get package version: '{}'", e);
+            eprintln!("failed to get package version: '{e}'");
             return None;
         }
     };

--- a/piet-common/tests/text.rs
+++ b/piet-common/tests/text.rs
@@ -379,7 +379,7 @@ fn debug_impl_exists() {
     let text = "";
     let layout_builder = factory.new_text_layout(text);
     let layout = factory.new_text_layout(text).build().unwrap();
-    let _args = format_args!("{:?} {:?} {:?}", text, layout_builder, layout);
+    let _args = format_args!("{text:?} {layout_builder:?} {layout:?}");
 }
 
 #[test]

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -140,7 +140,7 @@ impl From<HRESULT> for Error {
 impl Debug for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+            Error::WinapiError(hr) => write!(f, "hresult {hr:x}"),
         }
     }
 }
@@ -148,7 +148,7 @@ impl Debug for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+            Error::WinapiError(hr) => write!(f, "hresult {hr:x}"),
         }
     }
 }

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -88,7 +88,7 @@ impl From<HRESULT> for Error {
 impl Debug for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+            Error::WinapiError(hr) => write!(f, "hresult {hr:x}"),
         }
     }
 }
@@ -96,7 +96,7 @@ impl Debug for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Error::WinapiError(hr) => write!(f, "hresult {:x}", hr),
+            Error::WinapiError(hr) => write!(f, "hresult {hr:x}"),
         }
     }
 }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -507,7 +507,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
     fn blurred_rect(&mut self, rect: Rect, blur_radius: f64, brush: &impl IntoBrush<Self>) {
         let brush = brush.make_brush(self, || rect);
         if let Err(e) = self.blurred_rect_raw(rect, blur_radius, brush) {
-            eprintln!("error in drawing blurred rect: {:?}", e);
+            eprintln!("error in drawing blurred rect: {e:?}");
         }
     }
 }

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -961,13 +961,13 @@ mod test {
         println!("lm: {:#?}", full_layout.line_metrics);
         println!("layout width: {:#?}", full_layout.size().width);
 
-        println!("'pie': {}", pie_width);
-        println!("'piet': {}", piet_width);
-        println!("'piet ': {}", piet_space_width);
-        println!("'text': {}", text_width);
-        println!("'tex': {}", tex_width);
-        println!("'te': {}", te_width);
-        println!("'t': {}", t_width);
+        println!("'pie': {pie_width}");
+        println!("'piet': {piet_width}");
+        println!("'piet ': {piet_space_width}");
+        println!("'text': {text_width}");
+        println!("'tex': {tex_width}");
+        println!("'te': {te_width}");
+        println!("'t': {t_width}");
 
         // NOTE these heights are representative of baseline-to-baseline measures
         let line_zero_metric = full_layout.line_metric(0).unwrap();

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -124,7 +124,7 @@ impl WebFont {
             FontStyle::Normal => Cow::from("normal"),
             FontStyle::Italic => Cow::from("italic"),
             FontStyle::Oblique(None) => Cow::from("italic"),
-            FontStyle::Oblique(Some(angle)) => Cow::from(format!("oblique {}deg", angle)),
+            FontStyle::Oblique(Some(angle)) => Cow::from(format!("oblique {angle}deg")),
         };
         format!(
             "{} {} {}px \"{}\"",
@@ -511,7 +511,7 @@ pub(crate) mod test {
     fn assert_close_to(x: f64, target: f64, tolerance: f64) {
         let min = target - tolerance;
         let max = target + tolerance;
-        println!("x: {}, target: {}", x, target);
+        println!("x: {x}, target: {target}");
         assert!(x <= max && x >= min);
     }
 
@@ -975,13 +975,13 @@ pub(crate) mod test {
         println!("lm: {:#?}", full_layout.line_metrics);
         println!("layout width: {:#?}", full_layout.size().width);
 
-        println!("'pie': {}", pie_width);
-        println!("'piet': {}", piet_width);
-        println!("'piet ': {}", piet_space_width);
-        println!("'text': {}", text_width);
-        println!("'tex': {}", tex_width);
-        println!("'te': {}", te_width);
-        println!("'t': {}", t_width);
+        println!("'pie': {pie_width}");
+        println!("'piet': {piet_width}");
+        println!("'piet ': {piet_space_width}");
+        println!("'text': {text_width}");
+        println!("'tex': {tex_width}");
+        println!("'te': {te_width}");
+        println!("'t': {t_width}");
 
         // NOTE these heights are representative of baseline-to-baseline measures
         let line_zero_baseline = 0.0;

--- a/piet/src/color.rs
+++ b/piet/src/color.rs
@@ -321,9 +321,9 @@ impl Debug for Color {
 impl std::fmt::Display for ColorParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ColorParseError::WrongSize(n) => write!(f, "Input string has invalid length {}", n),
+            ColorParseError::WrongSize(n) => write!(f, "Input string has invalid length {n}"),
             ColorParseError::NotHex { idx, byte } => {
-                write!(f, "byte {:X} at index {} is not valid hex digit", byte, idx)
+                write!(f, "byte {byte:X} at index {idx} is not valid hex digit")
             }
         }
     }

--- a/piet/src/error.rs
+++ b/piet/src/error.rs
@@ -39,7 +39,7 @@ impl fmt::Display for Error {
                 f,
                 "This functionality is not yet implemented for this backend"
             ),
-            Error::MissingFeature(feature) => write!(f, "Missing feature '{}'", feature),
+            Error::MissingFeature(feature) => write!(f, "Missing feature '{feature}'"),
             Error::BackendError(e) => {
                 write!(f, "Backend error: ")?;
                 e.fmt(f)

--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -62,7 +62,7 @@ pub fn get<R: RenderContext>(number: usize) -> Result<SamplePicture<R>, BoxErr> 
         14 => SamplePicture::new(picture_14::SIZE, picture_14::draw),
         15 => SamplePicture::new(picture_15::SIZE, picture_15::draw),
         16 => SamplePicture::new(picture_16::SIZE, picture_16::draw),
-        _ => return Err(format!("No sample #{} exists", number).into()),
+        _ => return Err(format!("No sample #{number} exists").into()),
     })
 }
 
@@ -128,14 +128,14 @@ pub fn samples_main(
                 let info_one = read_os_info(compare_dir)?;
                 let info_two = read_os_info(&args.out_dir)?;
                 println!("Compared {} snapshots", results.len());
-                print!("base:\n{}", info_one);
-                println!("rev:\n{}", info_two);
+                print!("base:\n{info_one}");
+                println!("rev:\n{info_two}");
             }
 
             for (number, result) in results.iter() {
-                print!("Image {:02}: ", number);
+                print!("Image {number:02}: ");
                 match result {
-                    Some(failure) => println!("{}", failure),
+                    Some(failure) => println!("{failure}"),
                     None => println!("Ok"),
                 }
             }
@@ -151,10 +151,10 @@ pub fn samples_main(
     };
 
     if let Err(e) = inner() {
-        eprintln!("error generating sample: {}", e);
+        eprintln!("error generating sample: {e}");
         let mut e = &*e;
         while let Some(err) = e.source() {
-            eprintln!("caused by: {}", err);
+            eprintln!("caused by: {err}");
             e = err;
         }
         print_help_text();
@@ -219,7 +219,7 @@ fn run_all(f: impl Fn(usize) -> Result<(), BoxErr>) -> Result<(), BoxErr> {
         Ok(())
     } else {
         for (sample, err) in &errs {
-            eprintln!("error in sample {}: '{}'", sample, err);
+            eprintln!("error in sample {sample}: '{err}'");
         }
         Err(errs.remove(0).1)
     }
@@ -231,8 +231,8 @@ fn get_filename(prefix: &str, scale: f64, number: usize, diff: bool) -> String {
     // prefix-05-1.00.png
     // prefix-05-2.00.png
     match diff {
-        false => format!("{}-{:0>2}-{:.2}.png", prefix, number, scale),
-        true => format!("{}-{:0>2}-{:.2}-diff.png", prefix, number, scale),
+        false => format!("{prefix}-{number:0>2}-{scale:.2}.png"),
+        true => format!("{prefix}-{number:0>2}-{scale:.2}-diff.png"),
     }
 }
 
@@ -364,7 +364,7 @@ fn compare_pngs(
 
 fn get_sample_files(in_dir: &Path, scale: f64) -> Result<BTreeMap<usize, PathBuf>, BoxErr> {
     let mut out = BTreeMap::new();
-    let stem_suffix = format!("-{:.2}", scale);
+    let stem_suffix = format!("-{scale:.2}");
     for entry in std::fs::read_dir(in_dir)? {
         let path = entry?.path();
         if let Some(number) = extract_number(&path, &stem_suffix) {
@@ -437,7 +437,7 @@ impl std::fmt::Display for FailureReason {
                 diff_path.to_string_lossy(),
             ),
             FailureReason::WrongSize { base, rev } => {
-                write!(f, "Mismatched sizes, base {}, revision {}", base, rev)
+                write!(f, "Mismatched sizes, base {base}, revision {rev}")
             }
         }
     }


### PR DESCRIPTION
Clippy lints addressed:
* [`uninlined_format_args`](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args)