### PR TITLE
Convert doc links to symbols.

### DIFF
--- a/piet/src/font.rs
+++ b/piet/src/font.rs
@@ -13,9 +13,9 @@ use std::sync::Arc;
 ///
 /// To use a specific font family you should not construct this type directly;
 /// instead you should verify that the desired family exists, via the
-/// [`Text::font`] API.
+/// [`Text::font_family`] API.
 ///
-/// [`Text::font`]: trait.Text.html#tymethod.font
+/// [`Text::font_family`]: crate::Text::font_family
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FontFamily(FontFamilyInner);
 
@@ -72,7 +72,7 @@ impl FontFamily {
     /// by calling the [`Text::font_family`] method, which verifies that the
     /// family name exists.
     ///
-    /// [`Text::font_family`]: trait.Text.html#tymethod.font_family
+    /// [`Text::font_family`]: crate::Text::font_family
     pub fn new_unchecked(s: impl Into<Arc<str>>) -> Self {
         FontFamily(FontFamilyInner::Named(s.into()))
     }

--- a/piet/src/gradient.rs
+++ b/piet/src/gradient.rs
@@ -18,10 +18,6 @@
 //! anywhere you can use the fixed ones, and they will be automatically
 //! resolved appropriately.
 //!
-//! [`LinearGradient`]: struct.LinearGradient.html
-//! [`RadialGradient`]: struct.RadialGradient.html
-//! [`FixedLinearGradient`]: struct.FixedLinearGradient.html
-//! [`FixedRadialGradient`]: struct.FixedRadialGradient.html
 //! [unit square]: https://en.wikipedia.org/wiki/Unit_square
 
 use std::borrow::Cow;
@@ -38,8 +34,6 @@ use crate::Color;
 /// This specification is in terms of image-space coordinates. In many
 /// cases, it is better to specify coordinates relative to the `Rect`
 /// of the item being drawn; for these, use [`LinearGradient`] instead.
-///
-/// [`LinearGradient`]: struct.LinearGradient.html
 #[derive(Debug, Clone)]
 pub struct FixedLinearGradient {
     /// The start point (corresponding to pos 0.0).
@@ -57,8 +51,6 @@ pub struct FixedLinearGradient {
 /// This specification is in terms of image-space coordinates. In many
 /// cases, it is better to specify coordinates relative to the `Rect`
 /// of the item being drawn; for these, use [`RadialGradient`] instead.
-///
-/// [`RadialGradient`]: struct.RadialGradient.html
 #[derive(Debug, Clone)]
 pub struct FixedRadialGradient {
     /// The center.
@@ -69,7 +61,7 @@ pub struct FixedRadialGradient {
     ///
     /// The circle with this radius from the center corresponds to pos 1.0.
     pub radius: f64,
-    /// The stops (see similar field in [`LinearGradient`](struct.LinearGradient.html)).
+    /// The stops (see similar field in [`LinearGradient`]).
     pub stops: Vec<GradientStop>,
 }
 
@@ -79,9 +71,6 @@ pub struct FixedRadialGradient {
 /// accept both [`FixedLinearGradient`] and [`FixedRadialGradient`].
 /// You should not construct this type dirctly; rather construct one of those
 /// types, both of which impl `Into<FixedGradient>`.
-///
-/// [`FixedLinearGradient`]: struct.FixedLinearGradient.html
-/// [`FixedRadialGradient`]: struct.FixedRadialGradient.html
 #[derive(Debug, Clone)]
 pub enum FixedGradient {
     /// A linear gradient.
@@ -116,9 +105,6 @@ pub trait GradientStops {
 /// which are then resolved to image-space coordinates for any given concrete `Rect`.
 ///
 /// When the fixed coordinates are known, use [`FixedLinearGradient`] instead.
-///
-/// [`UnitPoint`]: struct.UnitPoint.html
-/// [`FixedLinearGradient`]: struct.FixedLinearGradient.html
 #[derive(Debug, Clone)]
 pub struct LinearGradient {
     start: UnitPoint,
@@ -148,11 +134,9 @@ pub struct LinearGradient {
 /// be changed with the [`with_scale_mode`] builder method.
 ///
 /// [config]: https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-brushes-overview#configuring-a-radial-gradient
-/// [`UnitPoint`]: struct.UnitPoint.html
-/// [`ScaleMode`]: enum.ScaleMode.html
-/// [`with_center`]: struct.RadialGradient.html#method.with_center
-/// [`with_origin`]: struct.RadialGradient.html#method.with_origin
-/// [`with_scale_mode`]: struct.RadialGradient.html#method.with_scale_mode
+/// [`with_center`]: RadialGradient::with_center
+/// [`with_origin`]: RadialGradient::with_origin
+/// [`with_scale_mode`]: RadialGradient::with_scale_mode
 #[derive(Debug, Clone)]
 pub struct RadialGradient {
     center: UnitPoint,
@@ -308,8 +292,6 @@ impl LinearGradient {
     /// );
     /// render_ctx.fill(circle, &gradient);
     /// ```
-    ///
-    /// [`UnitPoint`]: struct.UnitPoint.html
     pub fn new(start: UnitPoint, end: UnitPoint, stops: impl GradientStops) -> LinearGradient {
         LinearGradient {
             start,
@@ -322,8 +304,6 @@ impl LinearGradient {
     // sure there's a clear use, so keeping them private for now.
     /// Generate a [`FixedLinearGradient`] by mapping points in the unit square
     /// onto points in `rect`.
-    ///
-    /// [`FixedLinearGradient`]: struct.FixedLinearGradient.html
     fn resolve(&self, rect: Rect) -> FixedLinearGradient {
         FixedLinearGradient {
             start: self.start.resolve(rect),
@@ -339,10 +319,9 @@ impl RadialGradient {
     /// modified with the [`with_center`], [`with_origin`],
     /// and [`with_scale_mode`] builder methods.
     ///
-    /// [`ScaleMode`]: enum.ScaleMode.html
-    /// [`with_center`]: struct.RadialGradient.html#method.with_center
-    /// [`with_origin`]: struct.RadialGradient.html#method.with_origin
-    /// [`with_scale_mode`]: struct.RadialGradient.html#method.with_scale_mode
+    /// [`with_center`]: RadialGradient::with_center
+    /// [`with_origin`]: RadialGradient::with_origin
+    /// [`with_scale_mode`]: RadialGradient::with_scale_mode
     pub fn new(radius: f64, stops: impl GradientStops) -> Self {
         RadialGradient {
             center: UnitPoint::CENTER,
@@ -358,8 +337,6 @@ impl RadialGradient {
     /// both values.
     ///
     /// See the main [`RadialGradient`] docs for an explanation of center vs. origin.
-    ///
-    /// [`RadialGradient`]: struct.RadialGradient.html
     pub fn with_center(mut self, center: UnitPoint) -> Self {
         self.center = center;
         self
@@ -368,16 +345,12 @@ impl RadialGradient {
     /// A builder-style method for changing the origin of the gradient.
     ///
     /// See the main [`RadialGradient`] docs for an explanation of center vs. origin.
-    ///
-    /// [`RadialGradient`]: struct.RadialGradient.html
     pub fn with_origin(mut self, origin: UnitPoint) -> Self {
         self.origin = origin;
         self
     }
 
     /// A builder-style method for changing the [`ScaleMode`] of the gradient.
-    ///
-    /// [`ScaleMode`]: enum.ScaleMode.html
     pub fn with_scale_mode(mut self, scale_mode: ScaleMode) -> Self {
         self.scale_mode = scale_mode;
         self
@@ -385,8 +358,6 @@ impl RadialGradient {
 
     /// Generate a [`FixedRadialGradient`] by mapping points in the unit square
     /// onto points in `rect`.
-    ///
-    /// [`FixedRadialGradient`]: struct.FixedRadialGradient.html
     fn resolve(&self, rect: Rect) -> FixedRadialGradient {
         let scale_len = match self.scale_mode {
             ScaleMode::Fill => rect.width().max(rect.height()),

--- a/piet/src/image.rs
+++ b/piet/src/image.rs
@@ -34,9 +34,7 @@ pub trait Image: Clone {
 
 /// An in-memory pixel buffer.
 ///
-/// Contains raw bytes, dimensions, and image format ([`piet::ImageFormat`]).
-///
-/// [`piet::ImageFormat`]: ../piet/enum.ImageFormat.html
+/// Contains raw bytes, dimensions, and image format ([`ImageFormat`]).
 #[derive(Clone)]
 pub struct ImageBuf {
     pixels: Arc<[u8]>,
@@ -134,8 +132,6 @@ impl ImageBuf {
     }
 
     /// Converts this buffer an image that is optimized for drawing into a [`RenderContext`].
-    ///
-    /// [`RenderContext`]: ../piet/trait.RenderContext.html
     pub fn to_image<Ctx: RenderContext>(&self, ctx: &mut Ctx) -> Ctx::Image {
         ctx.make_image(self.width(), self.height(), &self.pixels, self.format)
             .unwrap()

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -118,7 +118,7 @@ where
     /// modes, at which point it will be easier to just use [`fill`] for
     /// everything.
     ///
-    /// [`fill`]: #method.fill
+    /// [`fill`]: RenderContext::fill
     fn clear(&mut self, region: impl Into<Option<Rect>>, color: Color);
 
     /// Stroke a [`Shape`], using the default [`StrokeStyle`].
@@ -145,8 +145,10 @@ where
 
     /// Clip to a [`Shape`].
     ///
-    /// All subsequent drawing operations up to the next [`restore`](#method.restore)
+    /// All subsequent drawing operations up to the next [`restore`]
     /// are clipped by the shape.
+    ///
+    /// [`restore`]: RenderContext::restore
     fn clip(&mut self, shape: impl Shape);
 
     /// Returns a reference to a shared [`Text`] object.
@@ -158,31 +160,39 @@ where
     ///
     /// The `pos` parameter specifies the upper-left corner of the layout object
     /// (even for right-to-left text). To draw on a baseline, you can use
-    /// [TextLayout::line_metric] to get the baseline position of a specific line.
+    /// [`TextLayout::line_metric`] to get the baseline position of a specific line.
     fn draw_text(&mut self, layout: &Self::TextLayout, pos: impl Into<Point>);
 
     /// Save the context state.
     ///
     /// Pushes the current context state onto a stack, to be popped by
-    /// [`restore`](#method.restore).
+    /// [`restore`].
     ///
-    /// Prefer [`with_save`](#method.with_save) if possible, as that statically
+    /// Prefer [`with_save`] if possible, as that statically
     /// enforces balance of save/restore pairs.
     ///
     /// The context state currently consists of a clip region and an affine
     /// transform, but is expected to grow in the near future.
+    ///
+    /// [`restore`]: RenderContext::restore
+    /// [`with_save`]: RenderContext::with_save
     fn save(&mut self) -> Result<(), Error>;
 
     /// Restore the context state.
     ///
-    /// Pop a context state that was pushed by [`save`](#method.save). See
+    /// Pop a context state that was pushed by [`save`]. See
     /// that method for details.
+    ///
+    /// [`save`]: RenderContext::save
     fn restore(&mut self) -> Result<(), Error>;
 
     /// Do graphics operations with the context state saved and then restored.
     ///
-    /// Equivalent to [`save`](#method.save), calling `f`, then
-    /// [`restore`](#method.restore). See those methods for more details.
+    /// Equivalent to [`save`], calling `f`, then
+    /// [`restore`]. See those methods for more details.
+    ///
+    /// [`restore`]: RenderContext::restore
+    /// [`save`]: RenderContext::save
     fn with_save(&mut self, f: impl FnOnce(&mut Self) -> Result<(), Error>) -> Result<(), Error> {
         self.save()?;
         // Always try to restore the stack, even if `f` errored.
@@ -199,7 +209,9 @@ where
     /// Apply a transform.
     ///
     /// Apply an affine transformation. The transformation remains in effect
-    /// until a [`restore`](#method.restore) operation.
+    /// until a [`restore`] operation.
+    ///
+    /// [`restore`]: RenderContext::restore
     fn transform(&mut self, transform: Affine);
 
     /// Create a new [`Image`] from a pixel buffer.
@@ -217,9 +229,9 @@ where
     /// If you are trying to create an image from the contents of this
     /// [`RenderContext`], see [`capture_image_area`].
     ///
-    /// [`draw_image`]: #method.draw_image
-    /// [`draw_image_area`]: #method.draw_image_area
-    /// [`capture_image_area`]: #method.capture_image_area
+    /// [`draw_image`]: RenderContext::draw_image
+    /// [`draw_image_area`]: RenderContext::draw_image_area
+    /// [`capture_image_area`]: RenderContext::capture_image_area
     fn make_image(
         &mut self,
         width: usize,
@@ -271,7 +283,7 @@ where
 
 /// A trait for various types that can be used as brushes.
 ///
-/// These include backend-independent types such `Color` and `LinearGradient`,
+/// These include backend-independent types such [`Color`] and [`LinearGradient`],
 /// as well as the types used to represent these on a specific backend.
 ///
 /// This is an internal trait that you should not have to implement or think about.

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -154,16 +154,12 @@ impl StrokeStyle {
     }
 
     /// Builder-style method to set the [`LineJoin`].
-    ///
-    /// [`LineJoin`]: enum.LineJoin.html
     pub const fn line_join(mut self, line_join: LineJoin) -> Self {
         self.line_join = line_join;
         self
     }
 
     /// Builder-style method to set the [`LineCap`].
-    ///
-    /// [`LineCap`]: enum.LineCap.html
     pub const fn line_cap(mut self, line_cap: LineCap) -> Self {
         self.line_cap = line_cap;
         self
@@ -183,8 +179,8 @@ impl StrokeStyle {
     /// do not have a static slice, you may use [`set_dash_pattern`] instead,
     /// which does allocate.
     ///
-    /// [`dash_pattern`]: #structfield.dash_pattern
-    /// [`set_dash_pattern`]: #method.set_dash_pattern
+    /// [`dash_pattern`]: StrokeStyle#structfield.dash_pattern
+    /// [`set_dash_pattern`]: StrokeStyle::set_dash_pattern
     pub const fn dash_pattern(mut self, lengths: &'static [f64]) -> Self {
         self.dash_pattern.slice = lengths;
         self
@@ -210,7 +206,7 @@ impl StrokeStyle {
     /// This method always allocates. To construct without allocating, use the
     /// [`dash_pattern`] builder method.
     ///
-    /// [`dash_pattern`]: #method.dash_pattern
+    /// [`dash_pattern`]: StrokeStyle::dash_pattern()
     pub fn set_dash_pattern(&mut self, lengths: impl Into<Rc<[f64]>>) {
         self.dash_pattern.alloc = Some(lengths.into());
     }

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -11,13 +11,9 @@ use crate::{Color, Error, FontFamily, FontStyle, FontWeight};
 /// management and text layout.
 pub trait Text: Clone {
     /// A concrete type that implements the [`TextLayoutBuilder`] trait.
-    ///
-    /// [`TextLayoutBuilder`]: trait.TextLayoutBuilder.html
     type TextLayoutBuilder: TextLayoutBuilder<Out = Self::TextLayout>;
 
     /// A concrete type that implements the [`TextLayout`] trait.
-    ///
-    /// [`TextLayout`]: trait.TextLayout.html
     type TextLayout: TextLayout;
 
     /// Query the platform for a font with a given name, and return a [`FontFamily`]
@@ -35,8 +31,6 @@ pub trait Text: Clone {
     ///     .or_else(|| text.font_family("Garamond"))
     ///     .unwrap_or(FontFamily::SERIF);
     /// ```
-    ///
-    /// [`FontFamily`]: struct.FontFamily.html
     fn font_family(&mut self, family_name: &str) -> Option<FontFamily>;
 
     /// Load the provided font data and make it available for use.
@@ -87,9 +81,6 @@ pub trait Text: Clone {
     ///     .range_attribute(6.., FontWeight::BOLD);
     ///
     /// ```
-    ///
-    /// [`TextLayout`]: trait.TextLayout.html
-    /// [`FontFamily`]: struct.FontFamily.html
     fn load_font(&mut self, data: &[u8]) -> Result<FontFamily, Error>;
 
     /// Create a new layout object to display the provided `text`.
@@ -102,8 +93,6 @@ pub trait Text: Clone {
     /// (which is likely also owned elsewhere in your application) you can pass
     /// a type such as `Rc<str>` or `Rc<String>`; alternatively you can just use
     /// `String` or `&static str`.
-    ///
-    /// [`TextLayoutBuilder`]: trait.TextLayoutBuilder.html
     fn new_text_layout(&mut self, text: impl TextStorage) -> Self::TextLayoutBuilder;
 }
 
@@ -130,8 +119,6 @@ pub trait TextStorage: 'static {
     ///
     /// In practice, these types should be using a [`TextLayout`] object
     /// per paragraph, and in general a separate buffer will be unnecessary.
-    ///
-    /// [`TextLayout`]: trait.TextLayout.html
     fn as_str(&self) -> &str;
 }
 
@@ -149,13 +136,11 @@ pub enum TextAttribute {
     FontFamily(FontFamily),
     /// The font size, in points.
     FontSize(f64),
-    /// The [`FontWeight`](struct.FontWeight.html).
+    /// The [`FontWeight`].
     Weight(FontWeight),
     /// The foreground color of the text.
     TextColor(crate::Color),
     /// The [`FontStyle`]; either regular or italic.
-    ///
-    /// [`FontStyle`]: enum.FontStyle.html
     Style(FontStyle),
     /// Underline.
     Underline(bool),
@@ -178,8 +163,6 @@ pub trait TextLayoutBuilder: Sized {
     fn max_width(self, width: f64) -> Self;
 
     /// Set the [`TextAlignment`] to be used for this layout.
-    ///
-    /// [`TextAlignment`]: enum.TextAlignment.html
     fn alignment(self, alignment: TextAlignment) -> Self;
 
     /// A convenience method for setting the default font family and size.
@@ -224,8 +207,7 @@ pub trait TextLayoutBuilder: Sized {
     /// You must set default attributes before setting range attributes,
     /// or the implementation is free to ignore them.
     ///
-    /// [`TextAttribute`]: enum.TextAttribute.html
-    /// [`range_attribute`]: #tymethod.range_attribute
+    /// [`range_attribute`]: TextLayoutBuilder::range_attribute
     fn default_attribute(self, attribute: impl Into<TextAttribute>) -> Self;
 
     /// Add a [`TextAttribute`] to a range of this layout.
@@ -268,9 +250,6 @@ pub trait TextLayoutBuilder: Sized {
     ///     .range_attribute(20.., TextAttribute::TextColor(Color::rgb(1.0, 0., 0.,)))
     ///     .build();
     /// ```
-    ///
-    /// [`TextAttribute`]: enum.TextAttribute.html
-    /// [`FontWeight`]: struct.FontWeight.html
     fn range_attribute(
         self,
         range: impl RangeBounds<usize>,
@@ -284,8 +263,6 @@ pub trait TextLayoutBuilder: Sized {
 }
 
 /// The alignment of text in a [`TextLayout`].
-///
-/// [`TextLayout`]: trait.TextLayout.html
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextAlignment {
     /// Text is aligned to the left edge in left-to-right scripts, and the
@@ -322,8 +299,6 @@ pub enum TextAlignment {
 /// - The end of a line is a valid text position. e.g. `text.len()` is a valid text position.
 /// - If the text position is not at a code point or grapheme boundary, undesirable behavior may
 /// occur.
-///
-/// [`LineMetric`]: struct.LineMetric.html
 pub trait TextLayout: Clone {
     /// The total size of this `TextLayout`.
     ///
@@ -376,8 +351,6 @@ pub trait TextLayout: Clone {
     /// returns some [`LineMetric`]; this will use the layout's default font to
     /// determine what the expected height of the first line would be, which is
     /// necessary for things like cursor drawing.
-    ///
-    /// [`LineMetric`]: struct.LineMetric.html
     fn line_metric(&self, line_number: usize) -> Option<LineMetric>;
 
     /// Returns total number of lines in the text layout.
@@ -399,9 +372,6 @@ pub trait TextLayout: Clone {
     /// the bounds of the layout, it will return the nearest text position.
     ///
     /// For more on text positions, see docs for the [`TextLayout`] trait.
-    ///
-    /// [`HitTestPoint`]: struct.HitTestPoint.html
-    /// [`TextLayout`]: ../piet/trait.TextLayout.html
     fn hit_test_point(&self, point: Point) -> HitTestPoint;
 
     /// Given a grapheme boundary in the string used to create this [`TextLayout`],
@@ -419,9 +389,6 @@ pub trait TextLayout: Clone {
     /// ## Panics:
     ///
     /// This method will panic if the text position is not a character boundary,
-    ///
-    /// [`HitTestPosition`]: struct.HitTestPosition.html
-    /// [`TextLayout`]: ../piet/trait.TextLayout.html
     fn hit_test_text_position(&self, idx: usize) -> HitTestPosition;
 
     /// Returns a vector of `Rect`s that cover the region of the text indicated
@@ -485,8 +452,6 @@ pub trait TextLayout: Clone {
 pub struct LineMetric {
     /// The start index of this line in the underlying `String` used to create the
     /// [`TextLayout`] to which this line belongs.
-    ///
-    /// [`TextLayout`]: trait.TextLayout.html
     pub start_offset: usize,
 
     /// The end index of this line in the underlying `String` used to create the
@@ -495,8 +460,6 @@ pub struct LineMetric {
     /// This is the end of an exclusive range; this index is not part of the line.
     ///
     /// Includes trailing whitespace.
-    ///
-    /// [`TextLayout`]: trait.TextLayout.html
     pub end_offset: usize,
 
     /// The length of the trailing whitespace at the end of this line, in utf-8
@@ -529,8 +492,6 @@ pub struct LineMetric {
 impl LineMetric {
     /// The utf-8 range in the underlying `String` used to create the
     /// [`TextLayout`] to which this line belongs.
-    ///
-    /// [`TextLayout`]: trait.TextLayout.html
     #[inline]
     pub fn range(&self) -> Range<usize> {
         self.start_offset..self.end_offset
@@ -540,9 +501,6 @@ impl LineMetric {
 /// Result of hit testing a point in a [`TextLayout`].
 ///
 /// This type is returned by [`TextLayout::hit_test_point`].
-///
-/// [`TextLayout`]: ../piet/trait.TextLayout.html
-/// [`TextLayout::hit_test_point`]: ../piet/trait.TextLayout.html#tymethod.hit_test_point
 #[derive(Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct HitTestPoint {
@@ -560,9 +518,6 @@ pub struct HitTestPoint {
 /// Result of hit testing a text position in a [`TextLayout`].
 ///
 /// This type is returned by [`TextLayout::hit_test_text_position`].
-///
-/// [`TextLayout`]: ../piet/trait.TextLayout.html
-/// [`TextLayout::hit_test_text_position`]: ../piet/trait.TextLayout.html#tymethod.hit_test_text_position
 #[derive(Debug, Default)]
 #[non_exhaustive]
 pub struct HitTestPosition {
@@ -577,9 +532,6 @@ pub struct HitTestPosition {
     ///
     /// This value can be used to retrieve the [`LineMetric`] for this line,
     /// via the [`TextLayout::line_metric`] method.
-    ///
-    /// [`LineMetric`]: struct.LineMetric.html
-    /// [`TextLayout::line_metric`]: trait.TextLayout.html#tymethod.line_metric
     pub line: usize,
 }
 


### PR DESCRIPTION
Some links were broken while others were not. I converted all of them to symbol based links to fix the broken ones and hopefully keep all of them functioning for longer.

The only exceptions were `StrokeStyle#structfield.dash_offset` and `StrokeStyle#structfield.dash_pattern` which keep the URL fragment part. Apparently rustdoc has no way to [disambiguate](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html#namespaces-and-disambiguators) struct fields. There are ways to disambiguate other stuff like methods, but not fields. Fields were mentioned as [a potential future extension](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md#linking-to-fields) in the RFC, but that work hasn't happened as far as I can tell.