### PR TITLE
Prepeare for releasing v0.6.1

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -13,16 +13,16 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "=0.6.0", path = "../piet" }
 
-cairo-rs = { version = "0.16.3", default-features = false } # We don't need glib
-pango = { version = "0.16.3", features = ["v1_44"] }
+cairo-rs = { version = "0.16.7", default-features = false } # We don't need glib
+pango = { version = "0.16.5", features = ["v1_44"] }
 pangocairo = "0.16.3"
-unicode-segmentation = "1.9.0"
+unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
 
 [dev-dependencies]
 piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
 piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
-criterion = "0.3.5"
+criterion = "0.3.6"
 
 [[bench]]
 name = "make_image"

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-cairo"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Cairo backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.6.0", path = "../piet" }
+piet = { version = "=0.6.1", path = "../piet" }
 
 cairo-rs = { version = "0.16.7", default-features = false } # We don't need glib
 pango = { version = "0.16.5", features = ["v1_44"] }
@@ -20,8 +20,8 @@ unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
 
 [dev-dependencies]
-piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
-piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
+piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
+piet-common = { version = "=0.6.1", path = "../piet-common", features = ["png"] }
 criterion = "0.3.6"
 
 [[bench]]

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -36,7 +36,7 @@ serde = ["piet/serde"]
 piet = { version = "=0.6.0", path = "../piet" }
 piet-web = { version = "=0.6.0", path = "../piet-web", optional = true }
 cfg-if = "1.0.0"
-png = { version = "0.17.5", optional = true }
+png = { version = "0.17.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.6.0", path = "../piet-cairo" }
@@ -52,14 +52,14 @@ piet-direct2d = { version = "=0.6.0", path = "../piet-direct2d" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 piet-web = { version = "=0.6.0", path = "../piet-web" }
-wasm-bindgen = "0.2.80"
+wasm-bindgen = "0.2.83"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]
-getrandom = { version = "0.2.6", features = ["js"] }
-wasm-bindgen-test = "0.3.30"
+getrandom = { version = "0.2.8", features = ["js"] }
+wasm-bindgen-test = "0.3.33"
 
 [target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.60"
 features = [
     "console",
     "Window",

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-common"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Selection of a single preferred back-end for piet"
 license = "MIT/Apache-2.0"
@@ -33,25 +33,25 @@ hdr = ["piet/hdr"]
 serde = ["piet/serde"]
 
 [dependencies]
-piet = { version = "=0.6.0", path = "../piet" }
-piet-web = { version = "=0.6.0", path = "../piet-web", optional = true }
+piet = { version = "=0.6.1", path = "../piet" }
+piet-web = { version = "=0.6.1", path = "../piet-web", optional = true }
 cfg-if = "1.0.0"
 png = { version = "0.17.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
-piet-cairo = { version = "=0.6.0", path = "../piet-cairo" }
+piet-cairo = { version = "=0.6.1", path = "../piet-cairo" }
 cairo-rs = { version = "0.16.3", default_features = false }
 cairo-sys-rs = { version = "0.16.3" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
-piet-coregraphics = { version = "=0.6.0", path = "../piet-coregraphics" }
+piet-coregraphics = { version = "=0.6.1", path = "../piet-coregraphics" }
 core-graphics = { version = "0.22.3" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-piet-direct2d = { version = "=0.6.0", path = "../piet-direct2d" }
+piet-direct2d = { version = "=0.6.1", path = "../piet-direct2d" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-piet-web = { version = "=0.6.0", path = "../piet-web" }
+piet-web = { version = "=0.6.1", path = "../piet-web" }
 wasm-bindgen = "0.2.83"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-coregraphics"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jeff Muizelaar <jrmuizel@gmail.com>, Raph Levien <raph.levien@gmail.com>, Colin Rofls <colin.rofls@gmail.com>"]
 description = "CoreGraphics backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.6.0", path = "../piet" }
+piet = { version = "=0.6.1", path = "../piet" }
 
 foreign-types = "0.3.2"
 core-graphics = "0.22.3"
@@ -21,8 +21,8 @@ core-foundation-sys = "0.8.3"
 associative-cache = "1.0.1"
 
 [dev-dependencies]
-piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
-piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
+piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
+piet-common = { version = "=0.6.1", path = "../piet-common", features = ["png"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-direct2d"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Direct2D backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.6.0", path = "../piet" }
+piet = { version = "=0.6.1", path = "../piet" }
 utf16_lit = "2.0.2"
 associative-cache = "1.0.1"
 
@@ -20,8 +20,8 @@ winapi = { version = "0.3.9", features = ["d2d1", "d2d1_1", "d2d1effects", "d2db
 dwrote = { version = "0.11.0", default_features = false }
 
 [dev-dependencies]
-piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
-piet-common = { version = "=0.6.0", path = "../piet-common", features = ["png"] }
+piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
+piet-common = { version = "=0.6.1", path = "../piet-common", features = ["png"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-svg"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 description = "SVG backend for piet 2D graphics abstraction."
 edition = "2018"
@@ -18,9 +18,9 @@ base64 = "0.13.1"
 evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
 image = { version = "0.24.5", default-features = false, features = ["png"] }
-piet = { version = "=0.6.0", path = "../piet" }
+piet = { version = "=0.6.1", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"
 
 [dev-dependencies]
-piet = { version = "=0.6.0", path = "../piet", features = ["samples"] }
+piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -14,10 +14,10 @@ default = []
 evcxr = ["evcxr_runtime"]
 
 [dependencies]
-base64 = "0.13.0"
+base64 = "0.13.1"
 evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
-image = { version = "0.24.2", default-features = false, features = ["png"] }
+image = { version = "0.24.5", default-features = false, features = ["png"] }
 piet = { version = "=0.6.0", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-web"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Web canvas backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-piet = { version = "=0.6.0", path = "../piet" }
+piet = { version = "=0.6.1", path = "../piet" }
 
 unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -16,22 +16,22 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 piet = { version = "=0.6.0", path = "../piet" }
 
-unicode-segmentation = "1.9.0"
+unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
-wasm-bindgen = "0.2.80"
-js-sys = "0.3.57"
+wasm-bindgen = "0.2.83"
+js-sys = "0.3.60"
 
 [dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.60"
 features = ["Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap",
             "ImageData", "TextMetrics"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.30"
+wasm-bindgen-test = "0.3.33"
 
 [dev-dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.60"
 features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData",
             "TextMetrics"]

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -14,9 +14,9 @@ default = ["console_error_panic_hook"]
 piet = { path = "../../../piet", features = ["samples"] }
 piet-web = { path = "../.." }
 
-wasm-bindgen = "0.2.80"
+wasm-bindgen = "0.2.83"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dependencies.web-sys]
-version = "0.3.57"
+version = "0.3.60"
 features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement"]

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["rendering::graphics-api"]
 include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
-image = { version = "0.24.2", optional = true, default-features = false }
+image = { version = "0.24.5", optional = true, default-features = false }
 kurbo = "0.9"
 pico-args = { version = "0.4.2", optional = true }
-png = { version = "0.17.5", optional = true }
-os_info = { version = "3.4.0", optional = true, default-features = false }
+png = { version = "0.17.7", optional = true }
+os_info = { version = "3.5.1", optional = true, default-features = false }
 unic-bidi = "0.9.0"
 
 [features]

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "An abstraction for 2D graphics."
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This PR does two things:

#### Update dependencies explicitly to the latest compatible versions

These are all semver compatible changes. These are versions that Cargo resolves to anyway, which also means they're the versions we actually test with. For the curious I've written more about the rationale for doing this in the Druid [CONTRIBUTING.md](https://github.com/linebender/druid/blob/master/CONTRIBUTING.md#dependencies).

#### Increase Piet version to v0.6.1

The main reason for doing the release is the merger of #546 and #548. Both of them address issues with Piet's documentation. A new release gets us a better docs.rs page and also helps with Druid 0.8 docs as Piet is embedded there.