### PR TITLE
Re-export the `image` crate and prepare v0.6.2.

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-cairo"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Cairo backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.6.1", path = "../piet" }
+piet = { version = "=0.6.2", path = "../piet" }
 
 cairo-rs = { version = "0.16.7", default-features = false } # We don't need glib
 pango = { version = "0.16.5", features = ["v1_44"] }
@@ -20,8 +20,8 @@ unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
 
 [dev-dependencies]
-piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
-piet-common = { version = "=0.6.1", path = "../piet-common", features = ["png"] }
+piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }
+piet-common = { version = "=0.6.2", path = "../piet-common", features = ["png"] }
 criterion = "0.3.6"
 
 [[bench]]

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-common"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Selection of a single preferred back-end for piet"
 license = "MIT/Apache-2.0"
@@ -33,25 +33,25 @@ hdr = ["piet/hdr"]
 serde = ["piet/serde"]
 
 [dependencies]
-piet = { version = "=0.6.1", path = "../piet" }
-piet-web = { version = "=0.6.1", path = "../piet-web", optional = true }
+piet = { version = "=0.6.2", path = "../piet" }
+piet-web = { version = "=0.6.2", path = "../piet-web", optional = true }
 cfg-if = "1.0.0"
 png = { version = "0.17.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
-piet-cairo = { version = "=0.6.1", path = "../piet-cairo" }
+piet-cairo = { version = "=0.6.2", path = "../piet-cairo" }
 cairo-rs = { version = "0.16.3", default_features = false }
 cairo-sys-rs = { version = "0.16.3" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
-piet-coregraphics = { version = "=0.6.1", path = "../piet-coregraphics" }
+piet-coregraphics = { version = "=0.6.2", path = "../piet-coregraphics" }
 core-graphics = { version = "0.22.3" }
 
 [target.'cfg(target_os="windows")'.dependencies]
-piet-direct2d = { version = "=0.6.1", path = "../piet-direct2d" }
+piet-direct2d = { version = "=0.6.2", path = "../piet-direct2d" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-piet-web = { version = "=0.6.1", path = "../piet-web" }
+piet-web = { version = "=0.6.2", path = "../piet-web" }
 wasm-bindgen = "0.2.83"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate reexports the [piet crate][piet], alongside an appropriate backend
 //! for the given platform. It also exposes [kurbo], which defines shape and
-//! curve types useful in drawing.
+//! curve types useful in drawing, and [image] for image manipulation.
 //!
 //! The intention of this crate is to provide a single dependency that handles
 //! the common piet use-case. If you have more complicated needs (such as
@@ -22,6 +22,7 @@
 //!
 //! [piet]: https://crates.io/crates/piet
 //! [kurbo]: https://crates.io/crates/kurbo
+//! [image]: https://crates.io/crates/image
 //! [piet-cairo]: https://crates.io/crates/piet-cairo
 
 #![deny(clippy::trivially_copy_pass_by_ref)]
@@ -30,6 +31,10 @@ pub use piet::*;
 
 #[doc(hidden)]
 pub use piet::kurbo;
+
+#[doc(hidden)]
+#[cfg(feature = "image")]
+pub use piet::image_crate;
 
 cfg_if::cfg_if! {
      if #[cfg(any(feature = "web", target_arch = "wasm32"))] {

--- a/piet-common/src/lib.rs
+++ b/piet-common/src/lib.rs
@@ -29,13 +29,6 @@
 
 pub use piet::*;
 
-#[doc(hidden)]
-pub use piet::kurbo;
-
-#[doc(hidden)]
-#[cfg(feature = "image")]
-pub use piet::image_crate;
-
 cfg_if::cfg_if! {
      if #[cfg(any(feature = "web", target_arch = "wasm32"))] {
         #[path = "web_back.rs"]

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-coregraphics"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Jeff Muizelaar <jrmuizel@gmail.com>, Raph Levien <raph.levien@gmail.com>, Colin Rofls <colin.rofls@gmail.com>"]
 description = "CoreGraphics backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.6.1", path = "../piet" }
+piet = { version = "=0.6.2", path = "../piet" }
 
 foreign-types = "0.3.2"
 core-graphics = "0.22.3"
@@ -21,8 +21,8 @@ core-foundation-sys = "0.8.3"
 associative-cache = "1.0.1"
 
 [dev-dependencies]
-piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
-piet-common = { version = "=0.6.1", path = "../piet-common", features = ["png"] }
+piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }
+piet-common = { version = "=0.6.2", path = "../piet-common", features = ["png"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-apple-darwin"

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-direct2d"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Direct2D backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["graphics", "2d"]
 categories = ["rendering::graphics-api"]
 
 [dependencies]
-piet = { version = "=0.6.1", path = "../piet" }
+piet = { version = "=0.6.2", path = "../piet" }
 utf16_lit = "2.0.2"
 associative-cache = "1.0.1"
 
@@ -20,8 +20,8 @@ winapi = { version = "0.3.9", features = ["d2d1", "d2d1_1", "d2d1effects", "d2db
 dwrote = { version = "0.11.0", default_features = false }
 
 [dev-dependencies]
-piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
-piet-common = { version = "=0.6.1", path = "../piet-common", features = ["png"] }
+piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }
+piet-common = { version = "=0.6.2", path = "../piet-common", features = ["png"] }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-svg"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Benjamin Saunders <ben.e.saunders@gmail.com>"]
 description = "SVG backend for piet 2D graphics abstraction."
 edition = "2018"
@@ -18,9 +18,9 @@ base64 = "0.13.1"
 evcxr_runtime = { version = "1.1.0", optional = true }
 font-kit = "0.10.1"
 image = { version = "0.24.5", default-features = false, features = ["png"] }
-piet = { version = "=0.6.1", path = "../piet" }
+piet = { version = "=0.6.2", path = "../piet" }
 rustybuzz = "0.4.0"
 svg = "0.10.0"
 
 [dev-dependencies]
-piet = { version = "=0.6.1", path = "../piet", features = ["samples"] }
+piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet-web"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "Web canvas backend for piet 2D graphics abstraction."
 license = "MIT/Apache-2.0"
@@ -14,7 +14,7 @@ categories = ["rendering::graphics-api", "wasm"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-piet = { version = "=0.6.1", path = "../piet" }
+piet = { version = "=0.6.2", path = "../piet" }
 
 unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piet"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 description = "An abstraction for 2D graphics."
 license = "MIT/Apache-2.0"

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -16,7 +16,7 @@ image = { version = "0.24.5", optional = true, default-features = false }
 kurbo = "0.9"
 pico-args = { version = "0.4.2", optional = true }
 png = { version = "0.17.7", optional = true }
-os_info = { version = "3.5.1", optional = true, default-features = false }
+os_info = { version = "3.6.0", optional = true, default-features = false }
 unic-bidi = "0.9.0"
 
 [features]

--- a/piet/src/lib.rs
+++ b/piet/src/lib.rs
@@ -26,6 +26,9 @@
 
 pub use kurbo;
 
+#[cfg(feature = "image")]
+pub use ::image as image_crate;
+
 /// utilities shared by various backends
 pub mod util;
 


### PR DESCRIPTION
Druid v0.8 ended up shipping with a different major version of `image` than Piet, which causes severe issues due to their incompatibility. The ultimate solution to this is to just have Piet re-export the `image` crate and `druid-shell` depend on that. Synchronization bliss!

This PR re-exports the `image` crate and bumps the version to v0.6.2.