### PR TITLE
Add `make_image_with_stride`

### DIFF
--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -238,7 +238,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         // Confident no borrow errors because we just created it.
         let image_stride = image.stride() as usize;
         {
-            if buff.len() < piet::util::expected_image_buffer_size(image_stride, height, stride) {
+            if buf.len() < piet::util::expected_image_buffer_size(image_stride, height, stride) {
                 return Err(Error::InvalidInput);
             }
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -238,7 +238,7 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         // Confident no borrow errors because we just created it.
         let image_stride = image.stride() as usize;
         {
-            if buf.len() < piet::util::expected_image_buffer_size(image_stride, height, stride) {
+            if buf.len() < piet::util::expected_image_buffer_size(width * format.bytes_per_pixel(), height, stride) {
                 return Err(Error::InvalidInput);
             }
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -238,7 +238,13 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         // Confident no borrow errors because we just created it.
         let image_stride = image.stride() as usize;
         {
-            if buf.len() < piet::util::expected_image_buffer_size(width * format.bytes_per_pixel(), height, stride) {
+            if buf.len()
+                < piet::util::expected_image_buffer_size(
+                    width * format.bytes_per_pixel(),
+                    height,
+                    stride,
+                )
+            {
                 return Err(Error::InvalidInput);
             }
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -212,10 +212,11 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
 
     // allows e.g. raw_data[dst_off + x * 4 + 2] = buf[src_off + x * 4 + 0];
     #[allow(clippy::identity_op)]
-    fn make_image(
+    fn make_image_with_stride(
         &mut self,
         width: usize,
         height: usize,
+        stride: usize,
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
@@ -235,13 +236,11 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         }
 
         // Confident no borrow errors because we just created it.
-        let bytes_per_pixel = format.bytes_per_pixel();
-        let bytes_per_row = width * bytes_per_pixel;
         let stride = image.stride() as usize;
         {
             let mut data = image.data().map_err(|e| Error::BackendError(Box::new(e)))?;
             for y in 0..height {
-                let src_off = y * bytes_per_row;
+                let src_off = y * stride;
                 let data = &mut data[y * stride..];
                 match format {
                     ImageFormat::Rgb => {

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -236,12 +236,12 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         }
 
         // Confident no borrow errors because we just created it.
-        let stride = image.stride() as usize;
+        let image_stride = image.stride() as usize;
         {
             let mut data = image.data().map_err(|e| Error::BackendError(Box::new(e)))?;
             for y in 0..height {
                 let src_off = y * stride;
-                let data = &mut data[y * stride..];
+                let data = &mut data[y * image_stride..];
                 match format {
                     ImageFormat::Rgb => {
                         for x in 0..width {

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -238,6 +238,10 @@ impl<'a> RenderContext for CairoRenderContext<'a> {
         // Confident no borrow errors because we just created it.
         let image_stride = image.stride() as usize;
         {
+            if buff.len() < piet::util::expected_image_buffer_size(image_stride, height, stride) {
+                return Err(Error::InvalidInput);
+            }
+
             let mut data = image.data().map_err(|e| Error::BackendError(Box::new(e)))?;
             for y in 0..height {
                 let src_off = y * stride;

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -324,7 +324,9 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
             return Ok(CoreGraphicsImage::Empty);
         }
         assert!(!buf.is_empty() && buf.len() <= format.bytes_per_pixel() * width * height);
-        let data = Arc::new(piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format));
+        let data = Arc::new(piet::util::image_buffer_to_tightly_packed(
+            buf, width, height, stride, format,
+        ));
         let data_provider = CGDataProvider::from_buffer(data);
         let (colorspace, bitmap_info, bytes) = match format {
             ImageFormat::Rgb => (CGColorSpace::create_device_rgb(), 0, 3),

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -326,7 +326,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         assert!(!buf.is_empty() && buf.len() <= format.bytes_per_pixel() * width * height);
         let data = Arc::new(piet::util::image_buffer_to_tightly_packed(
             buf, width, height, stride, format,
-        ));
+        )?);
         let data_provider = CGDataProvider::from_buffer(data);
         let (colorspace, bitmap_info, bytes) = match format {
             ImageFormat::Rgb => (CGColorSpace::create_device_rgb(), 0, 3),

--- a/piet-coregraphics/src/lib.rs
+++ b/piet-coregraphics/src/lib.rs
@@ -312,10 +312,11 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
         self.ctx.concat_ctm(to_cgaffine(transform));
     }
 
-    fn make_image(
+    fn make_image_with_stride(
         &mut self,
         width: usize,
         height: usize,
+        stride: usize,
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
@@ -323,7 +324,7 @@ impl<'a> RenderContext for CoreGraphicsContext<'a> {
             return Ok(CoreGraphicsImage::Empty);
         }
         assert!(!buf.is_empty() && buf.len() <= format.bytes_per_pixel() * width * height);
-        let data = Arc::new(buf.to_owned());
+        let data = Arc::new(piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format));
         let data_provider = CGDataProvider::from_buffer(data);
         let (colorspace, bitmap_info, bytes) = match format {
             ImageFormat::Rgb => (CGColorSpace::create_device_rgb(), 0, 3),

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -376,6 +376,16 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             return Ok(self.rt.create_empty_bitmap()?);
         }
 
+        if buf.len()
+            < piet::util::expected_image_buffer_size(
+                format.bytes_per_pixel() * width,
+                height,
+                stride,
+            )
+        {
+            return Err(Error::InvalidInput);
+        }
+
         // TODO: this method _really_ needs error checking, so much can go wrong...
         let alpha_mode = match format {
             ImageFormat::Rgb | ImageFormat::Grayscale => D2D1_ALPHA_MODE_IGNORE,

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -419,21 +419,8 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
             ImageFormat::RgbaPremul => {
                 if stride == width * format.bytes_per_pixel() {
                     Cow::from(buf)
-                }
-                else {
-                    let mut new_buf = vec![255; width * height * 4];
-                    // TODO (performance): this could be much faster using std::ptr::copy_nonoverlapping
-                    for y in 0..height {
-                        for x in 0..width {
-                            let src_offset = y * stride + x * 4;
-                            let dst_offset = y * width * 4 + x * 4;
-                            new_buf[dst_offset + 0] = buf[src_offset + 0];
-                            new_buf[dst_offset + 1] = buf[src_offset + 1];
-                            new_buf[dst_offset + 2] = buf[src_offset + 2];
-                            new_buf[dst_offset + 3] = buf[src_offset + 3];
-                        }
-                    }
-                    Cow::from(new_buf)
+                } else {
+                    Cow::from(piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format))
                 }
             },
             ImageFormat::Grayscale => {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -420,9 +420,11 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                 if stride == width * format.bytes_per_pixel() {
                     Cow::from(buf)
                 } else {
-                    Cow::from(piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format))
+                    Cow::from(piet::util::image_buffer_to_tightly_packed(
+                        buf, width, height, stride, format,
+                    ))
                 }
-            },
+            }
             ImageFormat::Grayscale => {
                 // it seems like there's no good way to create a 1-channel bitmap
                 // here? I am not alone:

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -422,7 +422,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                 } else {
                     Cow::from(piet::util::image_buffer_to_tightly_packed(
                         buf, width, height, stride, format,
-                    ))
+                    )?)
                 }
             }
             ImageFormat::Grayscale => {

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -388,7 +388,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                 for y in 0..height {
                     for x in 0..width {
                         let src_offset = y * stride + x * 3;
-                        let dst_offset = y * width * 4 + x * 4;
+                        let dst_offset = (y * width + x) * 4;
                         new_buf[dst_offset + 0] = buf[src_offset + 0];
                         new_buf[dst_offset + 1] = buf[src_offset + 1];
                         new_buf[dst_offset + 2] = buf[src_offset + 2];
@@ -406,7 +406,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                 for y in 0..height {
                     for x in 0..width {
                         let src_offset = y * stride + x * 4;
-                        let dst_offset = y * width * 4 + x * 4;
+                        let dst_offset = (y * width + x) * 4;
                         let a = buf[src_offset + 3];
                         new_buf[dst_offset + 0] = premul(buf[src_offset + 0], a);
                         new_buf[dst_offset + 1] = premul(buf[src_offset + 1], a);
@@ -433,7 +433,7 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                 for y in 0..height {
                     for x in 0..width {
                         let src_offset = y * stride + x;
-                        let dst_offset = y * width * 4 + x * 4;
+                        let dst_offset = (y * width + x) * 4;
                         new_buf[dst_offset + 0] = buf[src_offset];
                         new_buf[dst_offset + 1] = buf[src_offset];
                         new_buf[dst_offset + 2] = buf[src_offset];

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -361,10 +361,11 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         self.ctx_stack.last().unwrap().transform
     }
 
-    fn make_image(
+    fn make_image_with_stride(
         &mut self,
         width: usize,
         height: usize,
+        stride: usize,
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
@@ -384,10 +385,14 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
         let buf = match format {
             ImageFormat::Rgb => {
                 let mut new_buf = vec![255; width * height * 4];
-                for i in 0..width * height {
-                    new_buf[i * 4 + 0] = buf[i * 3 + 0];
-                    new_buf[i * 4 + 1] = buf[i * 3 + 1];
-                    new_buf[i * 4 + 2] = buf[i * 3 + 2];
+                for y in 0..height {
+                    for x in 0..width {
+                        let src_offset = y * stride + x * 3;
+                        let dst_offset = y * width * 4 + x * 4;
+                        new_buf[dst_offset + 0] = buf[src_offset + 0];
+                        new_buf[dst_offset + 1] = buf[src_offset + 1];
+                        new_buf[dst_offset + 2] = buf[src_offset + 2];
+                    }
                 }
                 Cow::from(new_buf)
             }
@@ -398,25 +403,52 @@ impl<'a> RenderContext for D2DRenderContext<'a> {
                     let y = (x as u16) * (a as u16);
                     ((y + (y >> 8) + 0x80) >> 8) as u8
                 }
-                for i in 0..width * height {
-                    let a = buf[i * 4 + 3];
-                    new_buf[i * 4 + 0] = premul(buf[i * 4 + 0], a);
-                    new_buf[i * 4 + 1] = premul(buf[i * 4 + 1], a);
-                    new_buf[i * 4 + 2] = premul(buf[i * 4 + 2], a);
-                    new_buf[i * 4 + 3] = a;
+                for y in 0..height {
+                    for x in 0..width {
+                        let src_offset = y * stride + x * 4;
+                        let dst_offset = y * width * 4 + x * 4;
+                        let a = buf[src_offset + 3];
+                        new_buf[dst_offset + 0] = premul(buf[src_offset + 0], a);
+                        new_buf[dst_offset + 1] = premul(buf[src_offset + 1], a);
+                        new_buf[dst_offset + 2] = premul(buf[src_offset + 2], a);
+                        new_buf[dst_offset + 3] = a;
+                    }
                 }
                 Cow::from(new_buf)
             }
-            ImageFormat::RgbaPremul => Cow::from(buf),
+            ImageFormat::RgbaPremul => {
+                if stride == width * format.bytes_per_pixel() {
+                    Cow::from(buf)
+                }
+                else {
+                    let mut new_buf = vec![255; width * height * 4];
+                    // TODO (performance): this could be much faster using std::ptr::copy_nonoverlapping
+                    for y in 0..height {
+                        for x in 0..width {
+                            let src_offset = y * stride + x * 4;
+                            let dst_offset = y * width * 4 + x * 4;
+                            new_buf[dst_offset + 0] = buf[src_offset + 0];
+                            new_buf[dst_offset + 1] = buf[src_offset + 1];
+                            new_buf[dst_offset + 2] = buf[src_offset + 2];
+                            new_buf[dst_offset + 3] = buf[src_offset + 3];
+                        }
+                    }
+                    Cow::from(new_buf)
+                }
+            },
             ImageFormat::Grayscale => {
                 // it seems like there's no good way to create a 1-channel bitmap
                 // here? I am not alone:
                 // https://stackoverflow.com/questions/44270215/direct2d-fails-when-drawing-a-single-channel-bitmap
                 let mut new_buf = vec![255; width * height * 4];
-                for i in 0..width * height {
-                    new_buf[i * 4 + 0] = buf[i];
-                    new_buf[i * 4 + 1] = buf[i];
-                    new_buf[i * 4 + 2] = buf[i];
+                for y in 0..height {
+                    for x in 0..width {
+                        let src_offset = y * stride + x;
+                        let dst_offset = y * width * 4 + x * 4;
+                        new_buf[dst_offset + 0] = buf[src_offset];
+                        new_buf[dst_offset + 1] = buf[src_offset];
+                        new_buf[dst_offset + 2] = buf[src_offset];
+                    }
                 }
                 Cow::from(new_buf)
             }

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -416,9 +416,8 @@ impl piet::RenderContext for RenderContext {
                 use image::Rgba;
                 use piet::util::unpremul;
 
-                let mut image =
-                    ImageBuffer::<Rgba<u8>, _>::from_raw(width as _, height as _, buf)
-                        .ok_or(Error::InvalidInput)?;
+                let mut image = ImageBuffer::<Rgba<u8>, _>::from_raw(width as _, height as _, buf)
+                    .ok_or(Error::InvalidInput)?;
                 for px in image.pixels_mut() {
                     px[0] = unpremul(px[0], px[3]);
                     px[1] = unpremul(px[1], px[3]);

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -395,7 +395,7 @@ impl piet::RenderContext for RenderContext {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image> {
-        let buf = convert_image_buffer(buf, width, height, stride, format);
+        let buf = piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format);
         Ok(SvgImage(match format {
             ImageFormat::Grayscale => {
                 let image = ImageBuffer::from_raw(width as _, height as _, buf)
@@ -711,26 +711,4 @@ impl From<Id> for svg::node::Value {
     fn from(x: Id) -> Self {
         x.to_string().into()
     }
-}
-
-
-fn convert_image_buffer(buff: &[u8], width: usize, height: usize, stride: usize, format: ImageFormat) -> Vec<u8> {
-    let mut new_buff = vec![255u8; width * height * 4];
-
-    let bytes_per_pixel = format.bytes_per_pixel();
-
-    // TODO (performance): this could be much faster using std::ptr::copy_nonoverlapping
-    for y in 0..height {
-        for x in 0..width {
-            let src_offset = y * stride + x * bytes_per_pixel;
-            let dst_offset = (y * width + x) * bytes_per_pixel;
-
-            let src_slice = &buff[src_offset..(src_offset + bytes_per_pixel)];
-            let dst_slice = &mut new_buff[dst_offset..(dst_offset + bytes_per_pixel)];
-
-            dst_slice.copy_from_slice(src_slice);
-        }
-    }
-
-    new_buff
 }

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -395,7 +395,7 @@ impl piet::RenderContext for RenderContext {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image> {
-        let buf = piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format);
+        let buf = piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format)?;
         Ok(SvgImage(match format {
             ImageFormat::Grayscale => {
                 let image = ImageBuffer::from_raw(width as _, height as _, buf)

--- a/piet-svg/src/lib.rs
+++ b/piet-svg/src/lib.rs
@@ -724,9 +724,11 @@ fn convert_image_buffer(buff: &[u8], width: usize, height: usize, stride: usize,
         for x in 0..width {
             let src_offset = y * stride + x * bytes_per_pixel;
             let dst_offset = (y * width + x) * bytes_per_pixel;
-            for i in 0..bytes_per_pixel {
-                new_buff[dst_offset + i] = buff[src_offset + i];
-            }
+
+            let src_slice = &buff[src_offset..(src_offset + bytes_per_pixel)];
+            let dst_slice = &mut new_buff[dst_offset..(dst_offset + bytes_per_pixel)];
+
+            dst_slice.copy_from_slice(src_slice);
         }
     }
 

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -331,7 +331,9 @@ impl RenderContext for WebRenderContext<'_> {
                 if stride == width * format.bytes_per_pixel() {
                     buf
                 } else {
-                    new_buf = piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format);
+                    new_buf = piet::util::image_buffer_to_tightly_packed(
+                        buf, width, height, stride, format,
+                    );
                     new_buf.as_slice()
                 }
             }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -312,10 +312,11 @@ impl RenderContext for WebRenderContext<'_> {
         matrix_to_affine(self.ctx.get_transform().unwrap())
     }
 
-    fn make_image(
+    fn make_image_with_stride(
         &mut self,
         width: usize,
         height: usize,
+        stride: usize,
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
@@ -326,35 +327,58 @@ impl RenderContext for WebRenderContext<'_> {
         canvas.set_height(height as u32);
         let mut new_buf: Vec<u8>;
         let buf = match format {
-            ImageFormat::RgbaSeparate => buf,
+            ImageFormat::RgbaSeparate => {
+                if stride == width * format.bytes_per_pixel() {
+                    buf
+                } else {
+                    new_buf = vec![0; width * height * 4];
+                    for y in 0..height {
+                        let src = &buf[y * stride..(y + 1) * stride];
+                        let dst = &mut new_buf[y * width * 4..(y + 1) * width * 4];
+                        dst.copy_from_slice(src);
+                    }
+                    new_buf.as_slice()
+                }
+            }
             ImageFormat::RgbaPremul => {
                 new_buf = vec![0; width * height * 4];
-                for i in 0..width * height {
-                    let a = buf[i * 4 + 3];
-                    new_buf[i * 4 + 0] = unpremul(buf[i * 4 + 0], a);
-                    new_buf[i * 4 + 1] = unpremul(buf[i * 4 + 1], a);
-                    new_buf[i * 4 + 2] = unpremul(buf[i * 4 + 2], a);
-                    new_buf[i * 4 + 3] = a;
+                for y in 0..height {
+                    for x in 0..width {
+                        let src_offset = y * stride + x * 4;
+                        let dst_offset = y * width * 4 + x * 4;
+                        let a = buf[src_offset + 3];
+                        new_buf[dst_offset + 0] = unpremul(buf[src_offset + 0], a);
+                        new_buf[dst_offset + 1] = unpremul(buf[src_offset + 1], a);
+                        new_buf[dst_offset + 2] = unpremul(buf[src_offset + 2], a);
+                    }
                 }
                 new_buf.as_slice()
             }
             ImageFormat::Rgb => {
                 new_buf = vec![0; width * height * 4];
-                for i in 0..width * height {
-                    new_buf[i * 4 + 0] = buf[i * 3 + 0];
-                    new_buf[i * 4 + 1] = buf[i * 3 + 1];
-                    new_buf[i * 4 + 2] = buf[i * 3 + 2];
-                    new_buf[i * 4 + 3] = 255;
+                for y in 0..height {
+                    for x in 0..width {
+                        let src_offset = y * stride + x * 3;
+                        let dst_offset = y * width * 4 + x * 4;
+                        new_buf[dst_offset + 0] = buf[src_offset + 0];
+                        new_buf[dst_offset + 1] = buf[src_offset + 1];
+                        new_buf[dst_offset + 2] = buf[src_offset + 2];
+                        new_buf[dst_offset + 3] = 255;
+                    }
                 }
                 new_buf.as_slice()
             }
             ImageFormat::Grayscale => {
                 new_buf = vec![0; width * height * 4];
-                for i in 0..width * height {
-                    new_buf[i * 4 + 0] = buf[i];
-                    new_buf[i * 4 + 1] = buf[i];
-                    new_buf[i * 4 + 2] = buf[i];
-                    new_buf[i * 4 + 3] = 255;
+                for y in 0..height {
+                    for x in 0..width {
+                        let src_offset = y * stride + x;
+                        let dst_offset = y * width * 4 + x * 4;
+                        new_buf[dst_offset + 0] = buf[src_offset];
+                        new_buf[dst_offset + 1] = buf[src_offset];
+                        new_buf[dst_offset + 2] = buf[src_offset];
+                        new_buf[dst_offset + 3] = 255;
+                    }
                 }
                 new_buf.as_slice()
             }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -320,6 +320,15 @@ impl RenderContext for WebRenderContext<'_> {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Self::Image, Error> {
+        if buf.len()
+            < piet::util::expected_image_buffer_size(
+                format.bytes_per_pixel() * width,
+                height,
+                stride,
+            )
+        {
+            return Err(Error::InvalidInput);
+        }
         let document = self.window.document().unwrap();
         let element = document.create_element("canvas").unwrap();
         let canvas = element.dyn_into::<HtmlCanvasElement>().unwrap();

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -333,7 +333,7 @@ impl RenderContext for WebRenderContext<'_> {
                 } else {
                     new_buf = piet::util::image_buffer_to_tightly_packed(
                         buf, width, height, stride, format,
-                    );
+                    )?;
                     new_buf.as_slice()
                 }
             }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -331,12 +331,7 @@ impl RenderContext for WebRenderContext<'_> {
                 if stride == width * format.bytes_per_pixel() {
                     buf
                 } else {
-                    new_buf = vec![0; width * height * 4];
-                    for y in 0..height {
-                        let src = &buf[y * stride..(y + 1) * stride];
-                        let dst = &mut new_buf[y * width * 4..(y + 1) * width * 4];
-                        dst.copy_from_slice(src);
-                    }
+                    new_buf = piet::util::image_buffer_to_tightly_packed(buf, width, height, stride, format);
                     new_buf.as_slice()
                 }
             }
@@ -345,7 +340,7 @@ impl RenderContext for WebRenderContext<'_> {
                 for y in 0..height {
                     for x in 0..width {
                         let src_offset = y * stride + x * 4;
-                        let dst_offset = y * width * 4 + x * 4;
+                        let dst_offset = (y * width + x) * 4;
                         let a = buf[src_offset + 3];
                         new_buf[dst_offset + 0] = unpremul(buf[src_offset + 0], a);
                         new_buf[dst_offset + 1] = unpremul(buf[src_offset + 1], a);
@@ -359,7 +354,7 @@ impl RenderContext for WebRenderContext<'_> {
                 for y in 0..height {
                     for x in 0..width {
                         let src_offset = y * stride + x * 3;
-                        let dst_offset = y * width * 4 + x * 4;
+                        let dst_offset = (y * width + x) * 4;
                         new_buf[dst_offset + 0] = buf[src_offset + 0];
                         new_buf[dst_offset + 1] = buf[src_offset + 1];
                         new_buf[dst_offset + 2] = buf[src_offset + 2];
@@ -373,7 +368,7 @@ impl RenderContext for WebRenderContext<'_> {
                 for y in 0..height {
                     for x in 0..width {
                         let src_offset = y * stride + x;
-                        let dst_offset = y * width * 4 + x * 4;
+                        let dst_offset = (y * width + x) * 4;
                         new_buf[dst_offset + 0] = buf[src_offset];
                         new_buf[dst_offset + 1] = buf[src_offset];
                         new_buf[dst_offset + 2] = buf[src_offset];

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -111,6 +111,17 @@ impl RenderContext for NullRenderContext {
         Ok(NullImage)
     }
 
+    fn make_image_with_stride(
+        &mut self,
+        width: usize,
+        height: usize,
+        stride: usize,
+        buf: &[u8],
+        format: ImageFormat,
+    ) -> Result<Self::Image, Error> {
+        Ok(NullImage)
+    }
+
     fn draw_image(
         &mut self,
         _image: &Self::Image,

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -113,11 +113,11 @@ impl RenderContext for NullRenderContext {
 
     fn make_image_with_stride(
         &mut self,
-        width: usize,
-        height: usize,
-        stride: usize,
-        buf: &[u8],
-        format: ImageFormat,
+        _width: usize,
+        _height: usize,
+        _stride: usize,
+        _buf: &[u8],
+        _format: ImageFormat,
     ) -> Result<Self::Image, Error> {
         Ok(NullImage)
     }

--- a/piet/src/null_renderer.rs
+++ b/piet/src/null_renderer.rs
@@ -101,16 +101,6 @@ impl RenderContext for NullRenderContext {
         Ok(NullImage)
     }
 
-    fn make_image(
-        &mut self,
-        _width: usize,
-        _height: usize,
-        _buf: &[u8],
-        _format: ImageFormat,
-    ) -> Result<Self::Image, Error> {
-        Ok(NullImage)
-    }
-
     fn make_image_with_stride(
         &mut self,
         _width: usize,

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -251,8 +251,9 @@ where
     }
 
     /// Create a new [`Image`] from a pixel buffer with a specified row stride.
+    /// 
     /// This has the same semantics as [`make_image`], but allows the caller to
-    /// specify the stride of the image data and is useful for images that are
+    /// specify the stride of the image data. It is useful for images that are
     /// not tightly packed.
     /// 
     /// # Arguments

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -228,6 +228,14 @@ where
     ///
     /// If you are trying to create an image from the contents of this
     /// [`RenderContext`], see [`capture_image_area`].
+    /// 
+    /// # Arguments
+    /// 
+    /// * `width` - The width of the image in pixels.
+    /// * `height` - The height of the image in pixels.
+    /// * `buf` - The pixel data. The length of this buffer must be at least
+    ///   `width * height * format.bytes_per_pixel()`.
+    /// * `format` - The format of the pixel data.
     ///
     /// [`draw_image`]: RenderContext::draw_image
     /// [`draw_image_area`]: RenderContext::draw_image_area
@@ -242,6 +250,22 @@ where
         self.make_image_with_stride(width, height, width * format.bytes_per_pixel(), buf, format)
     }
 
+    /// Create a new [`Image`] from a pixel buffer with a specified row stride.
+    /// This has the same semantics as [`make_image`], but allows the caller to
+    /// specify the stride of the image data and is useful for images that are
+    /// not tightly packed.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `width` - The width of the image in pixels.
+    /// * `height` - The height of the image in pixels.
+    /// * `stride` - The number of bytes between the start of one row of pixels
+    ///   and the start of the next row of pixels.
+    /// * `buf` - The pixel data for the image. The length of this buffer must
+    ///   be at least `stride * height`.
+    /// * `format` - The format of the pixel data.
+    /// 
+    /// [`make_image`]: RenderContext::make_image
     fn make_image_with_stride(
         &mut self,
         width: usize,

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -228,9 +228,9 @@ where
     ///
     /// If you are trying to create an image from the contents of this
     /// [`RenderContext`], see [`capture_image_area`].
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `width` - The width of the image in pixels.
     /// * `height` - The height of the image in pixels.
     /// * `buf` - The pixel data. The length of this buffer must be at least
@@ -251,13 +251,13 @@ where
     }
 
     /// Create a new [`Image`] from a pixel buffer with a specified row stride.
-    /// 
+    ///
     /// This has the same semantics as [`make_image`], but allows the caller to
     /// specify the stride of the image data. It is useful for images that are
     /// not tightly packed.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `width` - The width of the image in pixels.
     /// * `height` - The height of the image in pixels.
     /// * `stride` - The number of bytes between the start of one row of pixels
@@ -265,7 +265,7 @@ where
     /// * `buf` - The pixel data for the image. The length of this buffer must
     ///   be at least `stride * height`.
     /// * `format` - The format of the pixel data.
-    /// 
+    ///
     /// [`make_image`]: RenderContext::make_image
     fn make_image_with_stride(
         &mut self,

--- a/piet/src/render_context.rs
+++ b/piet/src/render_context.rs
@@ -238,6 +238,17 @@ where
         height: usize,
         buf: &[u8],
         format: ImageFormat,
+    ) -> Result<Self::Image, Error> {
+        self.make_image_with_stride(width, height, width * format.bytes_per_pixel(), buf, format)
+    }
+
+    fn make_image_with_stride(
+        &mut self,
+        width: usize,
+        height: usize,
+        stride: usize,
+        buf: &[u8],
+        format: ImageFormat,
     ) -> Result<Self::Image, Error>;
 
     /// Draw an [`Image`] into the provided [`Rect`].

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -256,7 +256,13 @@ mod tests {
 }
 
 /// Converts a image buffer to tightly packed owned buffer.
-pub fn image_buffer_to_tightly_packed(buff: &[u8], width: usize, height: usize, stride: usize, format: crate::ImageFormat) -> Vec<u8> {
+pub fn image_buffer_to_tightly_packed(
+    buff: &[u8],
+    width: usize,
+    height: usize,
+    stride: usize,
+    format: crate::ImageFormat,
+) -> Vec<u8> {
     let bytes_per_pixel = format.bytes_per_pixel();
     let row_size = width * bytes_per_pixel;
 
@@ -264,7 +270,7 @@ pub fn image_buffer_to_tightly_packed(buff: &[u8], width: usize, height: usize, 
         // nothing to do, just return the buffer as is
         return buff.to_vec();
     }
-    
+
     let mut new_buff = vec![0u8; width * height * bytes_per_pixel];
 
     for y in 0..height {

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -3,7 +3,7 @@
 use std::ops::{Bound, Range, RangeBounds};
 
 use crate::kurbo::{Rect, Size};
-use crate::{Color, FontFamily, FontStyle, FontWeight, LineMetric, TextAttribute};
+use crate::{Color, Error, FontFamily, FontStyle, FontWeight, LineMetric, TextAttribute};
 
 use unic_bidi::bidi_class::{BidiClass, BidiClassCategory};
 
@@ -231,6 +231,54 @@ pub fn first_strong_rtl(text: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Converts a image buffer to tightly packed owned buffer.
+///
+/// # Notes
+///
+/// * strides less than `width * bytes_per_pixel` are **allowed**
+/// * if the buffer is too small, [`InvalidInput`] is returned
+///
+/// [`InvalidInput`]: Error::InvalidInput
+pub fn image_buffer_to_tightly_packed(
+    buff: &[u8],
+    width: usize,
+    height: usize,
+    stride: usize,
+    format: crate::ImageFormat,
+) -> Result<Vec<u8>, Error> {
+    if width == 0 || height == 0 {
+        // empty image
+        return Ok(vec![]);
+    }
+
+    let bytes_per_pixel = format.bytes_per_pixel();
+    let row_size = width * bytes_per_pixel;
+    let expected_size = stride * (height - 1) + row_size;
+
+    if buff.len() < expected_size {
+        return Err(Error::InvalidInput);
+    }
+
+    if stride == row_size {
+        // nothing to do, just return the buffer as is
+        return Ok(buff.to_vec());
+    }
+
+    let mut new_buff = vec![0u8; width * height * bytes_per_pixel];
+
+    for y in 0..height {
+        let src_row_start = y * stride;
+        let dst_row_start = y * width * bytes_per_pixel;
+
+        let src_row_slice = &buff[src_row_start..(src_row_start + row_size)];
+        let dst_row_slice = &mut new_buff[dst_row_start..(dst_row_start + row_size)];
+
+        dst_row_slice.copy_from_slice(src_row_slice);
+    }
+
+    Ok(new_buff)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -253,35 +301,75 @@ mod tests {
 
         assert_eq!(count_until_utf16("", 0), None);
     }
-}
 
-/// Converts a image buffer to tightly packed owned buffer.
-pub fn image_buffer_to_tightly_packed(
-    buff: &[u8],
-    width: usize,
-    height: usize,
-    stride: usize,
-    format: crate::ImageFormat,
-) -> Vec<u8> {
-    let bytes_per_pixel = format.bytes_per_pixel();
-    let row_size = width * bytes_per_pixel;
+    #[test]
+    fn test_image_buffer_to_tightly_packed() {
+        let w: u16 = 7;
+        let h: u16 = 11;
+        let format = crate::ImageFormat::RgbaSeparate;
+        let bpp = format.bytes_per_pixel();
 
-    if stride == row_size {
-        // nothing to do, just return the buffer as is
-        return buff.to_vec();
+        let make_buffer_with_stride = |stride: usize| -> Vec<u8> {
+            let mut buff = vec![0u8; stride * h as usize];
+
+            let split_u16 = |x: u16| -> (u8, u8) {
+                let most_significant = (x >> 8) as u8;
+                let least_significant = (x & 0xff) as u8;
+                (most_significant, least_significant)
+            };
+
+            for y in 0..h {
+                for x in 0..w {
+                    let i: usize = y as usize * stride + x as usize * bpp;
+                    let (r, g) = split_u16(x);
+                    let (b, a) = split_u16(y);
+                    buff[i] = r;
+                    buff[i + 1] = g;
+                    buff[i + 2] = b;
+                    buff[i + 3] = a;
+                }
+            }
+
+            buff
+        };
+
+        // a buffer with the correct stride should be returned as is
+        let tightly_packed_buffer = make_buffer_with_stride(w as usize * bpp);
+        let result = image_buffer_to_tightly_packed(
+            &tightly_packed_buffer,
+            w as usize,
+            h as usize,
+            w as usize * bpp,
+            format,
+        );
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result, tightly_packed_buffer);
+
+        // a buffer with a larger stride should be converted to tightly packed
+        let buff = make_buffer_with_stride(w as usize * bpp + 1);
+        let result = image_buffer_to_tightly_packed(
+            &buff,
+            w as usize,
+            h as usize,
+            w as usize * bpp + 1,
+            format,
+        );
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert_eq!(result, tightly_packed_buffer);
+
+        // a buffer that is too small should return an error
+        let small_buff = tightly_packed_buffer[..(tightly_packed_buffer.len() - 1)].to_vec();
+        let result = image_buffer_to_tightly_packed(
+            &small_buff,
+            w as usize,
+            h as usize,
+            w as usize * bpp,
+            format,
+        );
+        assert!(result.is_err());
+        let result = result.unwrap_err();
+        assert_eq!(result.to_string(), Error::InvalidInput.to_string());
     }
-
-    let mut new_buff = vec![0u8; width * height * bytes_per_pixel];
-
-    for y in 0..height {
-        let src_row_start = y * stride;
-        let dst_row_start = y * width * bytes_per_pixel;
-
-        let src_row_slice = &buff[src_row_start..(src_row_start + row_size)];
-        let dst_row_slice = &mut new_buff[dst_row_start..(dst_row_start + row_size)];
-
-        dst_row_slice.copy_from_slice(src_row_slice);
-    }
-
-    new_buff
 }

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -254,3 +254,28 @@ mod tests {
         assert_eq!(count_until_utf16("", 0), None);
     }
 }
+
+/// Converts a image buffer to tightly packed owned buffer.
+pub fn image_buffer_to_tightly_packed(buff: &[u8], width: usize, height: usize, stride: usize, format: crate::ImageFormat) -> Vec<u8> {
+    let bytes_per_pixel = format.bytes_per_pixel();
+    let row_size = width * bytes_per_pixel;
+
+    if stride == row_size {
+        // nothing to do, just return the buffer as is
+        return buff.to_vec();
+    }
+    
+    let mut new_buff = vec![0u8; width * height * bytes_per_pixel];
+
+    for y in 0..height {
+        let src_row_start = y * stride;
+        let dst_row_start = y * width * bytes_per_pixel;
+
+        let src_row_slice = &buff[src_row_start..(src_row_start + row_size)];
+        let dst_row_slice = &mut new_buff[dst_row_start..(dst_row_start + row_size)];
+
+        dst_row_slice.copy_from_slice(src_row_slice);
+    }
+
+    new_buff
+}

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -231,6 +231,15 @@ pub fn first_strong_rtl(text: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Returns the number of bytes needed to be read from the image buffer.
+pub fn expected_image_buffer_size(row_size: usize, height: usize, stride: usize) -> usize {
+    if height == 0 {
+        return 0;
+    }
+
+    stride * (height - 1) + row_size
+}
+
 /// Converts a image buffer to tightly packed owned buffer.
 ///
 /// # Notes
@@ -253,9 +262,8 @@ pub fn image_buffer_to_tightly_packed(
 
     let bytes_per_pixel = format.bytes_per_pixel();
     let row_size = width * bytes_per_pixel;
-    let expected_size = stride * (height - 1) + row_size;
 
-    if buff.len() < expected_size {
+    if buff.len() < expected_image_buffer_size(row_size, height, stride) {
         return Err(Error::InvalidInput);
     }
 

--- a/piet/src/util.rs
+++ b/piet/src/util.rs
@@ -240,7 +240,7 @@ pub fn expected_image_buffer_size(row_size: usize, height: usize, stride: usize)
     stride * (height - 1) + row_size
 }
 
-/// Converts a image buffer to tightly packed owned buffer.
+/// Converts an image buffer to a tightly packed owned buffer.
 ///
 /// # Notes
 ///
@@ -272,11 +272,11 @@ pub fn image_buffer_to_tightly_packed(
         return Ok(buff.to_vec());
     }
 
-    let mut new_buff = vec![0u8; width * height * bytes_per_pixel];
+    let mut new_buff = vec![0u8; height * row_size];
 
     for y in 0..height {
         let src_row_start = y * stride;
-        let dst_row_start = y * width * bytes_per_pixel;
+        let dst_row_start = y * row_size;
 
         let src_row_slice = &buff[src_row_start..(src_row_start + row_size)];
         let dst_row_slice = &mut new_buff[dst_row_start..(dst_row_start + row_size)];


### PR DESCRIPTION
The `make_image_with_stride` function will allow to create images from a buffer with a specific row stride. See #553 for more info.

Progress:
 - [x] add `make_image_with_stride` to `RenderContext`
 - [x] add documentation
 - [x] implement for `NullRenderContext`
 - [x] implement for `piet-cairo`
 - [x] implement for `piet-coregraphics`
 - [x] implement for `piet-direct2d`
 - [x] implement for `piet-svg`
 - [x] implement for `piet-web`
 - [x] check use of ~`std::ptr::copy_nonoverlapping`~ `copy_from_slice` when possible
 - [x] size checks
 - [x] **more tests**?

Resolves #553.