### PR TITLE
Satisfy clippy 1.68.

### DIFF
--- a/piet/src/font.rs
+++ b/piet/src/font.rs
@@ -44,9 +44,10 @@ pub enum FontFamilyInner {
 pub struct FontWeight(u16);
 
 /// A font style, which may be italic or regular.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FontStyle {
     /// Prefer the regular style for the current font family, if available.
+    #[default]
     Regular,
     /// Prefer the italic style for the current font family, if available.
     ///
@@ -160,11 +161,5 @@ impl Default for FontFamily {
 impl Default for FontWeight {
     fn default() -> Self {
         FontWeight::REGULAR
-    }
-}
-
-impl Default for FontStyle {
-    fn default() -> Self {
-        FontStyle::Regular
     }
 }

--- a/piet/src/shapes.rs
+++ b/piet/src/shapes.rs
@@ -108,9 +108,10 @@ impl LineJoin {
 }
 
 /// Options for the cap of stroked lines.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
 pub enum LineCap {
     /// The stroke is squared off at the endpoint of the path.
+    #[default]
     Butt,
     /// The stroke ends in a semicircular arc with a diameter equal to the line width.
     Round,
@@ -225,12 +226,6 @@ impl Default for LineJoin {
         LineJoin::Miter {
             limit: LineJoin::DEFAULT_MITER_LIMIT,
         }
-    }
-}
-
-impl Default for LineCap {
-    fn default() -> Self {
-        LineCap::Butt
     }
 }
 

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -263,10 +263,11 @@ pub trait TextLayoutBuilder: Sized {
 }
 
 /// The alignment of text in a [`TextLayout`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextAlignment {
     /// Text is aligned to the left edge in left-to-right scripts, and the
     /// right edge in right-to-left scripts.
+    #[default]
     Start,
     /// Text is aligned to the right edge in left-to-right scripts, and the
     /// left edge in right-to-left scripts.
@@ -566,12 +567,6 @@ impl From<FontWeight> for TextAttribute {
 impl From<FontStyle> for TextAttribute {
     fn from(src: FontStyle) -> TextAttribute {
         TextAttribute::Style(src)
-    }
-}
-
-impl Default for TextAlignment {
-    fn default() -> Self {
-        TextAlignment::Start
     }
 }
 


### PR DESCRIPTION
Clippy lints addressed:
* [`derivable_impls`](https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls)