### PR TITLE
Make samples_main take an Fn trait

### DIFF
--- a/piet/src/samples/mod.rs
+++ b/piet/src/samples/mod.rs
@@ -93,7 +93,7 @@ struct Args {
 ///   testing environment, such as the versions of various dependencies; this
 ///   will be appended to the GENERATED_BY file.
 pub fn samples_main(
-    f: fn(usize, f64, &Path) -> Result<(), BoxErr>,
+    f: impl Fn(usize, f64, &Path) -> Result<(), BoxErr>,
     prefix: &str,
     env_info: Option<&str>,
 ) -> ! {


### PR DESCRIPTION
I'm currently using a [hacky workaround](https://github.com/notgull/piet-hardware/blob/9bb5e1cdf58bdc8ad47fd7ea3906fbc72da9a034/crates/piet-wgpu/examples/test_picture_wgpu.rs#L46-L69) in `piet-hardware` to test samples, and it doesn't look like there is a reason why it's an `fn` pointer instead of an `Fn` trait?