### PR TITLE
Bump pango, cairo to v0.18

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "=0.6.2", path = "../piet" }
 
-cairo-rs = { version = "0.17.0", default-features = false } # We don't need glib
-pango = { version = "0.17.0", features = ["v1_44"] }
-pangocairo = "0.17.0"
+cairo-rs = { version = "0.18.0", default-features = false } # We don't need glib
+pango = { version = "0.18.0", features = ["v1_44"] }
+pangocairo = "0.18.0"
 unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
 

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -40,8 +40,8 @@ png = { version = "0.17.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.6.2", path = "../piet-cairo" }
-cairo-rs = { version = "0.17.0", default_features = false }
-cairo-sys-rs = { version = "0.17.0" }
+cairo-rs = { version = "0.18.0", default_features = false }
+cairo-sys-rs = { version = "0.18.0" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 piet-coregraphics = { version = "=0.6.2", path = "../piet-coregraphics" }

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -544,7 +544,7 @@ impl WebRenderContext<'_> {
     fn set_stroke(&mut self, width: f64, style: Option<&StrokeStyle>) {
         let default_style = StrokeStyle::default();
         let style = style.unwrap_or(&default_style);
-        let mut canvas_state = self.canvas_states.last_mut().unwrap();
+        let canvas_state = self.canvas_states.last_mut().unwrap();
 
         if width != canvas_state.line_width {
             self.ctx.set_line_width(width);


### PR DESCRIPTION
A new pango and cairo release is out, the changelog can be found [here](https://github.com/gtk-rs/gtk-rs-core/releases/tag/0.18.0). There are no changes in the API that are used by piet as far as I can tell.

Can there be a new piet release at some point? The last one is using cairo v0.16 .