### PR TITLE
Update kurbo and svg dependencies, fix a clippy warning.

### DIFF
--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -603,7 +603,6 @@ impl<'a> D2DRenderContext<'a> {
                 return;
             }
         };
-        let width = width;
         self.rt.draw_geometry(&geom, &brush, width, style);
     }
 

--- a/piet-svg/Cargo.toml
+++ b/piet-svg/Cargo.toml
@@ -20,7 +20,7 @@ font-kit = "0.10.1"
 image = { version = "0.24.5", default-features = false, features = ["png"] }
 piet = { version = "=0.6.2", path = "../piet" }
 rustybuzz = "0.4.0"
-svg = "0.10.0"
+svg = "0.13.1"
 
 [dev-dependencies]
 piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
 image = { version = "0.24.5", optional = true, default-features = false }
-kurbo = "0.9"
+kurbo = "0.10.4"
 pico-args = { version = "0.4.2", optional = true }
 png = { version = "0.17.7", optional = true }
 os_info = { version = "3.6.0", optional = true, default-features = false }


### PR DESCRIPTION
This updates to the latest kurbo, I could have a version which is compatible with both piet and vello... 

* Svg had a future incompatibility warning, upgrade to fix that.
* Clippy noticed that `font_kit::sources::MultiSource` is `!Send !Sync`, So replace `Arc<Mutex<MultiSource>` with `Rc<RefCell<_>>`.

Not sure if this last bit is a wanted change, or if it'd be preferred to just silence the warning, or ignore it entirely?
