### PR TITLE
Bump versions of kurbo,cairo, pango deps

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["rendering::graphics-api"]
 [dependencies]
 piet = { version = "=0.6.2", path = "../piet" }
 
-cairo-rs = { version = "0.19.0", default-features = false } # We don't need glib
-pango = { version = "0.19.0", features = ["v1_44"] }
-pangocairo = "0.19.0"
+cairo-rs = { version = "0.20.1", default-features = false } # We don't need glib
+pango = { version = "0.20.1", features = ["v1_44"] }
+pangocairo = "0.20.1"
 unicode-segmentation = "1.10.0"
 xi-unicode = "0.3.0"
 

--- a/piet-cairo/src/lib.rs
+++ b/piet-cairo/src/lib.rs
@@ -503,7 +503,7 @@ impl<'a> CairoRenderContext<'a> {
         };
         // Cairo returns an error if we try to paint an empty image, causing us to panic. We check if
         // either the source or destination is empty, and early-return if so.
-        if src_rect.is_empty() || dst_rect.is_empty() {
+        if src_rect.is_zero_area() || dst_rect.is_zero_area() {
             return;
         }
 

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -40,8 +40,8 @@ png = { version = "0.17.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.6.2", path = "../piet-cairo" }
-cairo-rs = { version = "0.19.0", default-features = false }
-cairo-sys-rs = { version = "0.19.0" }
+cairo-rs = { version = "0.20.1", default-features = false }
+cairo-sys-rs = { version = "0.20.0" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]
 piet-coregraphics = { version = "=0.6.2", path = "../piet-coregraphics" }

--- a/piet-direct2d/src/lib.rs
+++ b/piet-direct2d/src/lib.rs
@@ -674,7 +674,7 @@ fn draw_image<'a>(
     dst_rect: Rect,
     interp: InterpolationMode,
 ) {
-    if dst_rect.is_empty() || image.empty_image {
+    if dst_rect.is_zero_area() || image.empty_image {
         // source or destination are empty
         return;
     }

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -13,7 +13,7 @@ include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 
 [dependencies]
 image = { version = "0.24.5", optional = true, default-features = false }
-kurbo = "0.10.4"
+kurbo = "0.11.1"
 pico-args = { version = "0.4.2", optional = true }
 png = { version = "0.17.7", optional = true }
 os_info = { version = "3.6.0", optional = true, default-features = false }


### PR DESCRIPTION
Simply bumping the versions seems to be enough, there are no API updates that would require any changes in piet this time (see changelog [here](https://github.com/gtk-rs/gtk-rs-core/releases/tag/0.20.0))