### PR TITLE
Fix all CI failures.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,12 @@ jobs:
 
       - name: test firefox
         run: wasm-pack test --headless --firefox piet-common
+        # macOS 14 CI runners don't have Firefox installed
+        if: contains(matrix.os, 'macos') == false
+
+      - name: test safari
+        run: wasm-pack test --headless --safari piet-common
+        if: contains(matrix.os, 'macos')
 
   docs:
     name: cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,6 @@ jobs:
         # macOS 14 CI runners don't have Firefox installed
         if: contains(matrix.os, 'macos') == false
 
-      - name: test safari
-        run: wasm-pack test --headless --safari piet-common
-        if: contains(matrix.os, 'macos')
-
   docs:
     name: cargo doc
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ env:
   # version like 1.70. Note that we only specify MAJOR.MINOR and not PATCH so that bugfixes still
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
-  RUST_STABLE_VER: "1.76" # In quotes because otherwise 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.82" # In quotes because otherwise 1.70 would be interpreted as 1.7
 
 name: CI
 

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -40,7 +40,7 @@ png = { version = "0.17.7", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.6.2", path = "../piet-cairo" }
-cairo-rs = { version = "0.19.0", default_features = false }
+cairo-rs = { version = "0.19.0", default-features = false }
 cairo-sys-rs = { version = "0.19.0" }
 
 [target.'cfg(any(target_os="macos", target_os="ios"))'.dependencies]

--- a/piet-common/src/direct2d_back.rs
+++ b/piet-common/src/direct2d_back.rs
@@ -72,10 +72,6 @@ pub struct BitmapTarget<'a> {
     context: D2DDeviceContext,
 }
 
-trait WrapError<T> {
-    fn wrap(self) -> Result<T, piet::Error>;
-}
-
 impl Device {
     /// Create a new device.
     ///

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -17,7 +17,7 @@ associative-cache = "1.0.1"
 
 wio = "0.2.2"
 winapi = { version = "0.3.9", features = ["d2d1", "d2d1_1", "d2d1effects", "d2dbasetypes", "dcommon", "d3d11", "dxgi", "winnls"] }
-dwrote = { version = "0.11.0", default_features = false }
+dwrote = { version = "0.11.0", default-features = false }
 
 [dev-dependencies]
 piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }

--- a/piet-direct2d/src/d2d.rs
+++ b/piet-direct2d/src/d2d.rs
@@ -648,10 +648,10 @@ impl DeviceContext {
         unsafe {
             let params = D2D1_LAYER_PARAMETERS {
                 contentBounds: D2D1_RECT_F {
-                    left: std::f32::NEG_INFINITY,
-                    top: std::f32::NEG_INFINITY,
-                    right: std::f32::INFINITY,
-                    bottom: std::f32::INFINITY,
+                    left: f32::NEG_INFINITY,
+                    top: f32::NEG_INFINITY,
+                    right: f32::INFINITY,
+                    bottom: f32::INFINITY,
                 },
                 geometricMask: mask.0.as_raw(),
                 maskAntialiasMode: D2D1_ANTIALIAS_MODE_PER_PRIMITIVE,

--- a/piet-direct2d/src/dwrite.rs
+++ b/piet-direct2d/src/dwrite.rs
@@ -165,7 +165,7 @@ impl DwriteFactory {
 impl FontCollection {
     pub(crate) fn font_family(&self, name: &str) -> Option<PietFontFamily> {
         let wname = name.to_wide_null();
-        let mut idx = u32::max_value();
+        let mut idx = u32::MAX;
         let mut exists = 0_i32;
 
         let family = unsafe {

--- a/piet-direct2d/src/text.rs
+++ b/piet-direct2d/src/text.rs
@@ -487,7 +487,7 @@ fn resolve_family_name(family: &FontFamily) -> &str {
 impl LoadedFontsInner {
     fn add(&mut self, font_data: &[u8]) -> Result<FontFamily, Error> {
         let font_data: Arc<Vec<u8>> = Arc::new(font_data.to_owned());
-        let font_file = FontFile::new_from_data(font_data).ok_or(Error::FontLoadingFailed)?;
+        let font_file = FontFile::new_from_buffer(font_data).ok_or(Error::FontLoadingFailed)?;
         let collection_loader = CustomFontCollectionLoaderImpl::new(&[font_file.clone()]);
         let collection = FontCollection::from_loader(collection_loader);
         let mut families = collection.families_iter();

--- a/piet-web/src/lib.rs
+++ b/piet-web/src/lib.rs
@@ -530,8 +530,10 @@ impl WebRenderContext<'_> {
     fn set_brush(&mut self, brush: &Brush, is_fill: bool) {
         let value = self.brush_value(brush);
         if is_fill {
+            #[allow(deprecated)]
             self.ctx.set_fill_style(&value);
         } else {
+            #[allow(deprecated)]
             self.ctx.set_stroke_style(&value);
         }
     }

--- a/piet-web/src/text.rs
+++ b/piet-web/src/text.rs
@@ -316,7 +316,7 @@ impl WebTextLayout {
         // various functions like `text_width` are stateful, and require
         // the context to be configured correcttly.
         self.ctx.set_font(&self.font.get_font_string());
-        let new_width = new_width.into().unwrap_or(std::f64::INFINITY);
+        let new_width = new_width.into().unwrap_or(f64::INFINITY);
         let mut line_metrics =
             lines::calculate_line_metrics(&self.text, &self.ctx, new_width, self.font.size);
 
@@ -630,7 +630,7 @@ pub(crate) mod test {
 
         //let mut text_layout = D2DText::new();
         //let font = text_layout.new_font_by_name("sans-serif", 12.0).build().unwrap();
-        //let layout = text_layout.new_text_layout(&font, input, std::f64::INFINITY).build().unwrap();
+        //let layout = text_layout.new_text_layout(&font, input, f64::INFINITY).build().unwrap();
 
         //assert_eq!(input.graphemes(true).count(), 1);
         //assert_eq!(layout.hit_test_text_position(0, true).map(|p| p.point_x as f64), Some(layout.size().width));

--- a/piet/src/text.rs
+++ b/piet/src/text.rs
@@ -302,7 +302,7 @@ pub enum TextAlignment {
 /// - The beginning of a line has text position `0`.
 /// - The end of a line is a valid text position. e.g. `text.len()` is a valid text position.
 /// - If the text position is not at a code point or grapheme boundary, undesirable behavior may
-/// occur.
+///   occur.
 pub trait TextLayout: Clone {
     /// The total size of this `TextLayout`.
     ///


### PR DESCRIPTION
* Update Rust stable to 1.82.
* Satisfy Clippy 1.82.
* Update snapshots to reflect the CI macOS 14.7.0 behavior. ([piet-snapshots#35](https://github.com/linebender/piet-snapshots/pull/35))
* Disable Firefox testing on macOS as the new macOS 14 runners don't have Firefox installed.