### PR TITLE
Enable nightly doc testing again.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,14 +178,8 @@ jobs:
         if: contains(matrix.os, 'ubuntu')
 
       - name: install nightly toolchain
-        # NOTE: Currently pinned to 2024-02-01 with '@master'. Move to just '@nightly' when possible.
-        #       Right now that breaks the build due to pathfinder_simd 0.5.2 not compiling with nightly.
-        #       The issue seems to have been fixed in https://github.com/servo/pathfinder/pull/548
-        #       However there is no new published crate version containing that fix, yet.
-        #       See more at https://github.com/linebender/piet/issues/566
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
           targets: wasm32-unknown-unknown
 
       - name: restore cache


### PR DESCRIPTION
[`pathfinder_simd`](https://crates.io/crates/pathfinder_simd) v0.5.2 is no longer the latest and Cargo resolves it for `piet-svg` as v0.5.4 which once again works with the nightly Rust toolchain.

Fixes #566.