### PR TITLE
Update SemVer compatible dependencies.

### DIFF
--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["rendering::graphics-api"]
 piet = { version = "=0.6.2", path = "../piet" }
 
 cairo-rs = { version = "0.20.1", default-features = false } # We don't need glib
-pango = { version = "0.20.1", features = ["v1_44"] }
-pangocairo = "0.20.1"
-unicode-segmentation = "1.10.0"
+pango = { version = "0.20.4", features = ["v1_44"] }
+pangocairo = "0.20.4"
+unicode-segmentation = "1.12.0"
 xi-unicode = "0.3.0"
 
 [dev-dependencies]

--- a/piet-common/Cargo.toml
+++ b/piet-common/Cargo.toml
@@ -33,7 +33,7 @@ serde = ["piet/serde"]
 piet = { version = "=0.6.2", path = "../piet" }
 piet-web = { version = "=0.6.2", path = "../piet-web", optional = true }
 cfg-if = "1.0.0"
-png = { version = "0.17.7", optional = true }
+png = { version = "0.17.14", optional = true }
 
 [target.'cfg(any(target_os="linux", target_os="openbsd", target_os="freebsd", target_os="netbsd"))'.dependencies]
 piet-cairo = { version = "=0.6.2", path = "../piet-cairo" }
@@ -49,14 +49,14 @@ piet-direct2d = { version = "=0.6.2", path = "../piet-direct2d" }
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
 piet-web = { version = "=0.6.2", path = "../piet-web" }
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.95"
 
 [target.'cfg(target_arch="wasm32")'.dev-dependencies]
-getrandom = { version = "0.2.8", features = ["js"] }
-wasm-bindgen-test = "0.3.33"
+getrandom = { version = "0.2.15", features = ["js"] }
+wasm-bindgen-test = "0.3.45"
 
 [target.'cfg(target_arch="wasm32")'.dependencies.web-sys]
-version = "0.3.60"
+version = "0.3.72"
 features = [
     "console",
     "Window",

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -17,7 +17,7 @@ foreign-types = "0.5.0"
 core-graphics = "0.24.0"
 core-text = "21.0.0"
 core-foundation = "0.10.0"
-core-foundation-sys = "0.8.3"
+core-foundation-sys = "0.8.7"
 associative-cache = "1.0.1"
 
 [dev-dependencies]

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -17,7 +17,7 @@ associative-cache = "1.0.1"
 
 wio = "0.2.2"
 winapi = { version = "0.3.9", features = ["d2d1", "d2d1_1", "d2d1effects", "d2dbasetypes", "dcommon", "d3d11", "dxgi", "winnls"] }
-dwrote = { version = "0.11.0", default-features = false }
+dwrote = { version = "0.11.2", default-features = false }
 
 [dev-dependencies]
 piet = { version = "=0.6.2", path = "../piet", features = ["samples"] }

--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -16,22 +16,22 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 piet = { version = "=0.6.2", path = "../piet" }
 
-unicode-segmentation = "1.10.0"
+unicode-segmentation = "1.12.0"
 xi-unicode = "0.3.0"
-wasm-bindgen = "0.2.83"
-js-sys = "0.3.60"
+wasm-bindgen = "0.2.95"
+js-sys = "0.3.72"
 
 [dependencies.web-sys]
-version = "0.3.60"
+version = "0.3.72"
 features = ["Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap",
             "ImageData", "TextMetrics"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.33"
+wasm-bindgen-test = "0.3.45"
 
 [dev-dependencies.web-sys]
-version = "0.3.60"
+version = "0.3.72"
 features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData",
             "TextMetrics"]

--- a/piet-web/examples/basic/Cargo.toml
+++ b/piet-web/examples/basic/Cargo.toml
@@ -14,9 +14,9 @@ default = ["console_error_panic_hook"]
 piet = { path = "../../../piet", features = ["samples"] }
 piet-web = { path = "../.." }
 
-wasm-bindgen = "0.2.83"
+wasm-bindgen = "0.2.95"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 
 [dependencies.web-sys]
-version = "0.3.60"
+version = "0.3.72"
 features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlElement", "HtmlCanvasElement"]

--- a/piet/Cargo.toml
+++ b/piet/Cargo.toml
@@ -15,8 +15,8 @@ include = ["src/**/*", "Cargo.toml", "snapshots/resources/*"]
 image = { version = "0.25.4", optional = true, default-features = false }
 kurbo = "0.11.1"
 pico-args = { version = "0.4.2", optional = true }
-png = { version = "0.17.7", optional = true }
-os_info = { version = "3.6.0", optional = true, default-features = false }
+png = { version = "0.17.14", optional = true }
+os_info = { version = "3.8.2", optional = true, default-features = false }
 unic-bidi = "0.9.0"
 
 [features]


### PR DESCRIPTION
This is the result of `cargo upgrade --ignore-rust-version`.