### PR TITLE
Enable the console feature for web-sys.

### DIFF
--- a/piet-web/Cargo.toml
+++ b/piet-web/Cargo.toml
@@ -23,15 +23,9 @@ js-sys = "0.3.72"
 
 [dependencies.web-sys]
 version = "0.3.72"
-features = ["Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
+features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
             "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap",
             "ImageData", "TextMetrics"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.45"
-
-[dev-dependencies.web-sys]
-version = "0.3.72"
-features = ["console", "Window", "CanvasGradient", "CanvasRenderingContext2d", "CanvasWindingRule",
-            "Document", "DomMatrix", "Element", "HtmlCanvasElement", "ImageBitmap", "ImageData",
-            "TextMetrics"]


### PR DESCRIPTION
The `console` feature was only enabled with dev dependencies.

That combined with the Piet CI being of an older Linebender variation that tests with dev dependencies enabled means that the CI didn't catch that `piet-web` can't actually be compiled.

