### PR TITLE
Update readme badges and `main` branch references.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,6 @@ or @raphlinus (or another administrator) to set it up for you.
 `piet-snapshots`. Rebasing would cause the revision to be rewritten, which would
 mean that the commit referenced by the submodule would no longer exist.
 
-[`samples`]: https://github.com/linebender/piet/tree/master/piet/src/samples
+[`samples`]: https://github.com/linebender/piet/tree/main/piet/src/samples
 [`piet-snapshots`]: https://github.com/linebender/piet-snapshots
 [persisting workflow data using artifacts]: https://docs.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 ![image of piet logo](./misc/piet-logo.png)
 
-# Piet: a 2D graphics abstraction
-[![Crates.io](https://img.shields.io/crates/v/piet)](https://crates.io/crates/piet)
-[![Documentation](https://docs.rs/piet/badge.svg)](https://docs.rs/piet)
-[![Build Status](https://travis-ci.com/linebender/piet.svg?branch=master)](https://travis-ci.com/linebender/piet)
+<div align="center">
+
+# Piet
+
+**A 2D graphics abstraction**
+
+[![Latest published version.](https://img.shields.io/crates/v/piet.svg)](https://crates.io/crates/piet)
+[![Documentation build status.](https://img.shields.io/docsrs/piet.svg)](https://docs.rs/piet)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+
+[![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23piet-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/259397-piet)
+[![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/piet/ci.yml?logo=github&label=CI)](https://github.com/linebender/piet/actions)
+[![Dependency staleness status.](https://deps.rs/crate/piet/latest/status.svg)](https://deps.rs/crate/piet)
+
+</div>
 
 Cross-platform 2D graphics.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![Linebender Zulip chat.](https://img.shields.io/badge/Linebender-%23piet-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/259397-piet)
 [![GitHub Actions CI status.](https://img.shields.io/github/actions/workflow/status/linebender/piet/ci.yml?logo=github&label=CI)](https://github.com/linebender/piet/actions)
-[![Dependency staleness status.](https://deps.rs/crate/piet/latest/status.svg)](https://deps.rs/crate/piet)
+[![Dependency staleness status.](https://deps.rs/repo/github/linebender/piet/status.svg)](https://deps.rs/repo/github/linebender/piet)
 
 </div>
 


### PR DESCRIPTION
Now that the `master` branch is called `main` a few docs needed updating. A badge needed updating too, so I updated the whole set to a newer standard.