### PR TITLE
Prepare to release v0.8.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "piet"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "image",
  "kurbo",
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "piet-cairo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cairo-rs",
  "criterion",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "piet-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cairo-rs",
  "cairo-sys-rs",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "piet-coregraphics"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "associative-cache",
  "core-foundation 0.10.1",
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "piet-direct2d"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "associative-cache",
  "dwrote",
@@ -1131,7 +1131,7 @@ dependencies = [
 
 [[package]]
 name = "piet-svg"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.13.1",
  "evcxr_runtime",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "piet-web"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "js-sys",
  "piet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = [
 #
 # NOTE: When bumping this, remember to also bump the aforementioned other packages'
 #       version in the dependencies section at the bottom of this file.
-version = "0.7.0"
+version = "0.8.0"
 
 edition = "2024"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files.
@@ -36,9 +36,9 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/linebender/piet"
 
 [workspace.dependencies]
-piet = { version = "=0.7.0", path = "piet" }
-piet-common = { version = "=0.7.0", path = "piet-common" }
-piet-cairo = { version = "=0.7.0", path = "piet-cairo" }
-piet-coregraphics = { version = "=0.7.0", path = "piet-coregraphics" }
-piet-direct2d = { version = "=0.7.0", path = "piet-direct2d" }
-piet-web = { version = "=0.7.0", path = "piet-web" }
+piet = { version = "=0.8.0", path = "piet" }
+piet-common = { version = "=0.8.0", path = "piet-common" }
+piet-cairo = { version = "=0.8.0", path = "piet-cairo" }
+piet-coregraphics = { version = "=0.8.0", path = "piet-coregraphics" }
+piet-direct2d = { version = "=0.8.0", path = "piet-direct2d" }
+piet-web = { version = "=0.8.0", path = "piet-web" }


### PR DESCRIPTION
Not much has changed since 0.7.0 besides dependency changes, but probably still worth a release.

What do you think @flxzt ?