### PR TITLE
Resolve cyclical `piet-common` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ repository = "https://github.com/linebender/piet"
 
 [workspace.dependencies]
 piet = { version = "=0.8.0", path = "piet" }
-piet-common = { version = "=0.8.0", path = "piet-common" }
 piet-cairo = { version = "=0.8.0", path = "piet-cairo" }
 piet-coregraphics = { version = "=0.8.0", path = "piet-coregraphics" }
 piet-direct2d = { version = "=0.8.0", path = "piet-direct2d" }

--- a/piet-cairo/Cargo.toml
+++ b/piet-cairo/Cargo.toml
@@ -27,7 +27,7 @@ xi-unicode = "0.3.0"
 
 [dev-dependencies]
 piet = { workspace = true, features = ["samples"] }
-piet-common = { workspace = true, features = ["png"] }
+piet-common = { path = "../piet-common", features = ["png"] }
 criterion = "0.5.1"
 
 [[bench]]

--- a/piet-coregraphics/Cargo.toml
+++ b/piet-coregraphics/Cargo.toml
@@ -28,4 +28,4 @@ associative-cache = "2.0.0"
 
 [dev-dependencies]
 piet = { workspace = true, features = ["samples"] }
-piet-common = { workspace = true, features = ["png"] }
+piet-common = { path = "../piet-common", features = ["png"] }

--- a/piet-direct2d/Cargo.toml
+++ b/piet-direct2d/Cargo.toml
@@ -27,4 +27,4 @@ dwrote = { version = "0.11.4", default-features = false }
 
 [dev-dependencies]
 piet = { workspace = true, features = ["samples"] }
-piet-common = { workspace = true, features = ["png"] }
+piet-common = { path = "../piet-common", features = ["png"] }


### PR DESCRIPTION
We use `piet-common` only as a dev-dependency, so we can get away with not specifying a version. This helps resolve a cyclical dependency issue when publishing, where e.g. `piet-cairo` depends on `piet-common` which depends on `piet-cairo`.