### PR TITLE
Fix `README.md` header logo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image of piet logo](./misc/piet-logo.png)
+![image of piet logo](https://github.com/linebender/piet/raw/HEAD/misc/piet-logo.png)
 
 <div align="center">
 


### PR DESCRIPTION
Something with crates.io publishing has changed where the header image now gets an incorrect path. See e.g. [v0.6.0](https://crates.io/crates/piet/0.6.0) vs [v0.8.0](https://crates.io/crates/piet/0.8.0).

Without figuring out what's going on with Cargo, this PR just changes the logo path to absolute, which should solve the issue.